### PR TITLE
Fix: Resolve libmagic ImportError (#6)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Production Dockerfile for LangExtract with libmagic support
+FROM python:3.10-slim
+
+# Install system dependencies including libmagic
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libmagic1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Install LangExtract from PyPI
+RUN pip install --no-cache-dir langextract
+
+# Set default command
+CMD ["python"]

--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ pip install -e ".[dev]"
 pip install -e ".[test]"
 ```
 
+### Docker
+
+```bash
+docker build -t langextract .
+docker run --rm -e LANGEXTRACT_API_KEY="your-api-key" langextract python your_script.py
+```
 
 ## API Key Setup for Cloud Models
 
@@ -296,6 +302,12 @@ Or reproduce the full CI matrix locally with tox:
 ```bash
 tox  # runs pylint + pytest on Python 3.10 and 3.11
 ```
+
+## Troubleshooting
+
+**libmagic error**: If you see "failed to find libmagic", install with `pip install langextract[full]` or install system dependencies:
+- Ubuntu/Debian: `sudo apt-get install libmagic1`
+- macOS: `brew install libmagic`
 
 ## Disclaimer
 

--- a/langextract/__init__.py
+++ b/langextract/__init__.py
@@ -16,6 +16,13 @@
 
 from __future__ import annotations
 
+# Ensure libmagic is available before langfun imports python-magic.
+# pylibmagic provides pre-built binaries that python-magic needs.
+try:
+    import pylibmagic  # noqa: F401 (side-effect import)
+except ImportError:
+    pass
+
 from collections.abc import Iterable, Sequence
 import os
 from typing import Any, Type, TypeVar, cast

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langextract"
-version = "1.0.0"
+version = "1.0.1"
 description = "LangExtract: A library for extracting structured data from language models"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -41,6 +41,7 @@ dependencies = [
     "pydantic>=1.8.0",
     "python-dotenv>=0.19.0",
     "python-magic>=0.4.27",
+    "pylibmagic>=0.5.0",
     "requests>=2.25.0",
     "tqdm>=4.64.0",
     "typing-extensions>=4.0.0"
@@ -63,6 +64,10 @@ dev = [
 test = [
     "pytest>=7.4.0",
     "tomli>=2.0.0"
+]
+full = [
+    "python-magic>=0.4.27",
+    "pylibmagic>=0.5.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Fixes the "failed to find libmagic" error by bundling pre-built libmagic libraries via `pylibmagic>=0.5.0`.

### Changes
- Add `pylibmagic>=0.5.0` dependency for bundled libraries
- Add `[full]` install option and pre-import handling
- Update README with troubleshooting and Docker sections
- Bump version to 1.0.1

Fixes #6