### PR TITLE
docs: add output_dir="." to all save_annotated_documents examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The extractions can be saved to a `.jsonl` file, a popular format for working wi
 
 ```python
 # Save the results to a JSONL file
-lx.io.save_annotated_documents([result], output_name="extraction_results.jsonl")
+lx.io.save_annotated_documents([result], output_name="extraction_results.jsonl", output_dir=".")
 
 # Generate the visualization from the file
 html_content = lx.visualize("extraction_results.jsonl")

--- a/docs/examples/longer_text_example.md
+++ b/docs/examples/longer_text_example.md
@@ -76,7 +76,7 @@ result = lx.extract(
 print(f"Extracted {len(result.extractions)} entities from {len(result.text):,} characters")
 
 # Save and visualize the results
-lx.io.save_annotated_documents([result], output_name="romeo_juliet_extractions.jsonl")
+lx.io.save_annotated_documents([result], output_name="romeo_juliet_extractions.jsonl", output_dir=".")
 
 # Generate the interactive visualization
 html_content = lx.visualize("romeo_juliet_extractions.jsonl")

--- a/docs/examples/medication_examples.md
+++ b/docs/examples/medication_examples.md
@@ -62,7 +62,7 @@ for entity in result.extractions:
     print(f"• {entity.extraction_class.capitalize()}: {entity.extraction_text}{position_info}")
 
 # Save and visualize the results
-lx.io.save_annotated_documents([result], output_name="medical_ner_extraction.jsonl")
+lx.io.save_annotated_documents([result], output_name="medical_ner_extraction.jsonl", output_dir=".")
 
 # Generate the interactive visualization
 html_content = lx.visualize("medical_ner_extraction.jsonl")


### PR DESCRIPTION
## Summary

This PR ensures consistent file saving behavior across all documentation examples by adding `output_dir="."` to all `save_annotated_documents` calls.

## Problem

Without explicitly setting `output_dir`, files are saved to `test_output/` by default, which can confuse users who expect files to be saved in their current directory.

## Solution

Added `output_dir="."` parameter to all `save_annotated_documents` calls in:
- README.md
- docs/examples/longer_text_example.md  
- docs/examples/medication_examples.md (first occurrence)

This follows the same pattern that was applied to one instance in medication_examples.md previously.

## Testing

All examples have been verified to include the parameter. Users will now find their output files in their current working directory as expected.