### PR TITLE
fix: expose ResolverParsingError in __init__.py for top-level access

### DIFF
--- a/langextract/__init__.py
+++ b/langextract/__init__.py
@@ -38,6 +38,7 @@ from langextract import prompting
 from langextract import resolver
 from langextract import schema
 from langextract import visualization
+from langextract.resolver import ResolverParsingError
 
 
 LanguageModelT = TypeVar("LanguageModelT", bound=inference.BaseLanguageModel)


### PR DESCRIPTION
Expose `ResolverParsingError` in `__init__.py` to allow top-level access via `langextract.ResolverParsingError`.