### PR TITLE
Add LangExtractError base exception for centralized error handling

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base exceptions for LangExtract.
+
+This module defines the base exception class that all LangExtract exceptions
+inherit from. Individual modules define their own specific exceptions.
+"""
+
+__all__ = ["LangExtractError"]
+
+
+class LangExtractError(Exception):
+  """Base exception for all LangExtract errors.
+
+  All exceptions raised by LangExtract should inherit from this class.
+  This allows users to catch all LangExtract-specific errors with a single
+  except clause.
+  """

--- a/langextract/__init__.py
+++ b/langextract/__init__.py
@@ -32,12 +32,27 @@ import dotenv
 
 from langextract import annotation
 from langextract import data
+from langextract import exceptions
 from langextract import inference
 from langextract import io
 from langextract import prompting
 from langextract import resolver
 from langextract import schema
 from langextract import visualization
+
+__all__ = [
+    "extract",
+    "visualize",
+    "annotation",
+    "data",
+    "exceptions",
+    "inference",
+    "io",
+    "prompting",
+    "resolver",
+    "schema",
+    "visualization",
+]
 
 LanguageModelT = TypeVar("LanguageModelT", bound=inference.BaseLanguageModel)
 

--- a/langextract/annotation.py
+++ b/langextract/annotation.py
@@ -31,6 +31,7 @@ from absl import logging
 
 from langextract import chunking
 from langextract import data
+from langextract import exceptions
 from langextract import inference
 from langextract import progress
 from langextract import prompting
@@ -39,7 +40,7 @@ from langextract import resolver as resolver_lib
 ATTRIBUTE_SUFFIX = "_attributes"
 
 
-class DocumentRepeatError(Exception):
+class DocumentRepeatError(exceptions.LangExtractError):
   """Exception raised when identical document ids are present."""
 
 

--- a/langextract/chunking.py
+++ b/langextract/chunking.py
@@ -28,10 +28,11 @@ from absl import logging
 import more_itertools
 
 from langextract import data
+from langextract import exceptions
 from langextract import tokenizer
 
 
-class TokenUtilError(Exception):
+class TokenUtilError(exceptions.LangExtractError):
   """Error raised when token_util returns unexpected values."""
 
 

--- a/langextract/exceptions.py
+++ b/langextract/exceptions.py
@@ -1,0 +1,26 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base exceptions for LangExtract."""
+
+__all__ = ["LangExtractError"]
+
+
+class LangExtractError(Exception):
+  """Base exception for all LangExtract errors.
+
+  All exceptions raised by LangExtract should inherit from this class.
+  This allows users to catch all LangExtract-specific errors with a single
+  except clause.
+  """

--- a/langextract/inference.py
+++ b/langextract/inference.py
@@ -30,6 +30,7 @@ from typing_extensions import override
 import yaml
 
 from langextract import data
+from langextract import exceptions
 from langextract import schema
 
 _OLLAMA_DEFAULT_MODEL_URL = 'http://localhost:11434'
@@ -49,7 +50,7 @@ class ScoredOutput:
     return f'Score: {self.score:.2f}\nOutput:\n{formatted_lines}'
 
 
-class InferenceOutputError(Exception):
+class InferenceOutputError(exceptions.LangExtractError):
   """Exception raised when no scored outputs are available from the language model."""
 
   def __init__(self, message: str):

--- a/langextract/io.py
+++ b/langextract/io.py
@@ -26,12 +26,13 @@ import requests
 
 from langextract import data
 from langextract import data_lib
+from langextract import exceptions
 from langextract import progress
 
 DEFAULT_TIMEOUT_SECONDS = 30
 
 
-class InvalidDatasetError(Exception):
+class InvalidDatasetError(exceptions.LangExtractError):
   """Error raised when Dataset is empty or invalid."""
 
 

--- a/langextract/prompting.py
+++ b/langextract/prompting.py
@@ -23,10 +23,11 @@ import pydantic
 import yaml
 
 from langextract import data
+from langextract import exceptions
 from langextract import schema
 
 
-class PromptBuilderError(Exception):
+class PromptBuilderError(exceptions.LangExtractError):
   """Failure to build prompt."""
 
 

--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -31,6 +31,7 @@ from absl import logging
 import yaml
 
 from langextract import data
+from langextract import exceptions
 from langextract import schema
 from langextract import tokenizer
 
@@ -151,7 +152,7 @@ class AbstractResolver(abc.ABC):
 ExtractionValueType = str | int | float | dict | list | None
 
 
-class ResolverParsingError(Exception):
+class ResolverParsingError(exceptions.LangExtractError):
   """Error raised when content cannot be parsed as the given format."""
 
 

--- a/langextract/tokenizer.py
+++ b/langextract/tokenizer.py
@@ -30,8 +30,10 @@ import re
 
 from absl import logging
 
+from langextract import exceptions
 
-class BaseTokenizerError(Exception):
+
+class BaseTokenizerError(exceptions.LangExtractError):
   """Base class for all tokenizer-related errors."""
 
 


### PR DESCRIPTION
# Description

Introduces a common base exception class (`LangExtractError`) that all library-specific exceptions inherit from. This enables users to catch all LangExtract errors with a single except clause, improving error handling ergonomics.

Previously, users had no way to catch all library-specific exceptions with a single handler. This change provides a consistent exception hierarchy that follows Python best practices for library design.

Fixes #21

Choose one: Code health

# How Has This Been Tested?

Executed the existing test suite with formatting and linting checks:

```
$ ./autoformat.sh
$ tox -e py311
$ mypy langextract tests --ignore-missing-imports
```

All 156 tests pass with no new mypy errors introduced.

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.