### PR TITLE
Fix save_annotated_documents to handle string paths

### DIFF
--- a/langextract/io.py
+++ b/langextract/io.py
@@ -81,7 +81,7 @@ class Dataset(abc.ABC):
 
 def save_annotated_documents(
     annotated_documents: Iterator[data.AnnotatedDocument],
-    output_dir: pathlib.Path | None = None,
+    output_dir: pathlib.Path | str | None = None,
     output_name: str = 'data.jsonl',
     show_progress: bool = True,
 ) -> None:
@@ -90,7 +90,7 @@ def save_annotated_documents(
   Args:
     annotated_documents: Iterator over AnnotatedDocument objects to save.
     output_dir: The directory to which the JSONL file should be written.
-      Defaults to 'test_output/' if None.
+      Can be a Path object or a string. Defaults to 'test_output/' if None.
     output_name: File name for the JSONL file.
     show_progress: Whether to show a progress bar during saving.
 
@@ -100,6 +100,8 @@ def save_annotated_documents(
   """
   if output_dir is None:
     output_dir = pathlib.Path('test_output')
+  else:
+    output_dir = pathlib.Path(output_dir)
 
   output_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
# Description

This PR fixes a bug where `save_annotated_documents` fails when passing a string path (e.g., `output_dir="."`) as shown in the README example. The function was expecting a `pathlib.Path` object but the type hint and README example suggest strings should be supported.

The fix updates the function to:
- Accept both `pathlib.Path` and `str` types for the `output_dir` parameter
- Convert string paths to `Path` objects before calling `.mkdir()`
- Maintain backward compatibility with existing code using `Path` objects

This ensures users following the README Quick Start example won't encounter:
```
AttributeError: 'str' object has no attribute 'mkdir'
```


Choose one: **Bug fix**

# How Has This Been Tested?

Tested the fix with multiple scenarios to ensure both string and Path objects work correctly.

# Checklist:


-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.