### PR TITLE
Fixed Readme bug #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ lx.io.save_annotated_documents([result], output_name="extraction_results.jsonl",
 # Generate the visualization from the file
 html_content = lx.visualize("extraction_results.jsonl")
 with open("visualization.html", "w") as f:
-    f.write(html_content)
+    f.write(str(html_content))
 ```
 
 This creates an animated and interactive HTML file:


### PR DESCRIPTION
docs: Updated bug in README example code which was causing TypeError: write() argument must be str, not HTML