### PR TITLE
fix: Change OllamaLanguageModel parameter from 'model' to 'model_id'

### DIFF
--- a/langextract/inference.py
+++ b/langextract/inference.py
@@ -113,13 +113,13 @@ class OllamaLanguageModel(BaseLanguageModel):
 
   def __init__(
       self,
-      model: str,
+      model_id: str,
       model_url: str = _OLLAMA_DEFAULT_MODEL_URL,
       structured_output_format: str = 'json',
       constraint: schema.Constraint = schema.Constraint(),
       **kwargs,
   ) -> None:
-    self._model = model
+    self._model = model_id
     self._model_url = model_url
     self._structured_output_format = structured_output_format
     self._constraint = constraint

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -73,7 +73,7 @@ class TestOllamaLanguageModel(absltest.TestCase):
     }
     mock_ollama_query.return_value = gemma_response
     model = inference.OllamaLanguageModel(
-        model="gemma2:latest",
+        model_id="gemma2:latest",
         model_url="http://localhost:11434",
         structured_output_format="json",
     )


### PR DESCRIPTION
# Description

Fix parameter mismatch in OllamaLanguageModel constructor that caused TypeError when using Ollama with langextract. The `extract()` function passes `model_id` but `OllamaLanguageModel.__init__()` expected `model`, preventing Ollama integration from working.

Fixes #27

Bug fix

# How Has This Been Tested?

```bash
$ python -m pytest tests/inference_test.py::TestOllamaLanguageModel -v
```

The existing unit test was updated to use the new parameter name and continues to pass, verifying the fix works correctly.

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes
- [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.
