### PR TITLE
feat: Add Ollama integration with Docker examples and CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 
@@ -79,3 +79,54 @@ jobs:
             exit 0
           fi
           tox -e live-api
+
+  ollama-integration-test:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect file changes
+        id: changes
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            langextract/inference.py
+            examples/ollama/**
+            tests/test_ollama_integration.py
+            .github/workflows/ci.yaml
+
+      - name: Skip if no Ollama changes
+        if: steps.changes.outputs.any_changed == 'false'
+        run: |
+          echo "No Ollama-related changes detected – skipping job."
+          exit 0
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Launch Ollama container
+        run: |
+          docker run -d --name ollama \
+            -p 127.0.0.1:11434:11434 \
+            -v ollama:/root/.ollama \
+            ollama/ollama:0.5.4
+          for i in {1..20}; do
+            curl -fs http://localhost:11434/api/version && break
+            sleep 3
+          done
+
+      - name: Pull gemma2 model
+        run: docker exec ollama ollama pull gemma2:2b || true
+
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+
+      - name: Run Ollama integration tests
+        run: tox -e ollama-integration

--- a/.github/workflows/validate_pr_template.yaml
+++ b/.github/workflows/validate_pr_template.yaml
@@ -11,31 +11,31 @@ jobs:
   check:
     if: github.event.pull_request.draft == false   # drafts can save early
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Fail if template untouched
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           printf '%s\n' "$PR_BODY" | tr -d '\r' > body.txt
-          
+
           # Required sections from the template
           required=( "# Description" "Fixes #" "# How Has This Been Tested?" "# Checklist" )
           err=0
-          
+
           # Check for required sections
           for h in "${required[@]}"; do
             grep -Fq "$h" body.txt || { echo "::error::$h missing"; err=1; }
           done
-          
+
           # Check for placeholder text that should be replaced
           grep -Eiq 'Replace this with|Choose one:' body.txt && {
-            echo "::error::Template placeholders still present"; err=1; 
+            echo "::error::Template placeholders still present"; err=1;
           }
-          
+
           # Also check for the unmodified issue number placeholder
           grep -Fq 'Fixes #[issue number]' body.txt && {
             echo "::error::Issue number placeholder not updated"; err=1;
           }
-          
+
           exit $err

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 - [Quick Start](#quick-start)
 - [Installation](#installation)
 - [API Key Setup for Cloud Models](#api-key-setup-for-cloud-models)
+- [Using OpenAI Models](#using-openai-models)
+- [Using Local LLMs with Ollama](#using-local-llms-with-ollama)
 - [More Examples](#more-examples)
   - [*Romeo and Juliet* Full Text Extraction](#romeo-and-juliet-full-text-extraction)
   - [Medication Extraction](#medication-extraction)
@@ -256,13 +258,13 @@ result = lx.extract(
 LangExtract also supports OpenAI models. Example OpenAI configuration:
 
 ```python
-from langextract.inference import OpenAILanguageModel
+import langextract as lx
 
 result = lx.extract(
     text_or_documents=input_text,
     prompt_description=prompt,
     examples=examples,
-    language_model_type=OpenAILanguageModel,
+    language_model_type=lx.inference.OpenAILanguageModel,
     model_id="gpt-4o",
     api_key=os.environ.get('OPENAI_API_KEY'),
     fence_output=True,
@@ -271,6 +273,29 @@ result = lx.extract(
 ```
 
 Note: OpenAI models require `fence_output=True` and `use_schema_constraints=False` because LangExtract doesn't implement schema constraints for OpenAI yet.
+
+## Using Local LLMs with Ollama
+
+LangExtract supports local inference using Ollama, allowing you to run models without API keys:
+
+```python
+import langextract as lx
+
+result = lx.extract(
+    text_or_documents=input_text,
+    prompt_description=prompt,
+    examples=examples,
+    language_model_type=lx.inference.OllamaLanguageModel,
+    model_id="gemma2:2b",  # or any Ollama model
+    model_url="http://localhost:11434",
+    fence_output=False,
+    use_schema_constraints=False
+)
+```
+
+**Quick setup:** Install Ollama from [ollama.com](https://ollama.com/), run `ollama pull gemma2:2b`, then `ollama serve`.
+
+For detailed installation, Docker setup, and examples, see [`examples/ollama/`](examples/ollama/).
 
 ## More Examples
 
@@ -324,6 +349,17 @@ Or reproduce the full CI matrix locally with tox:
 ```bash
 tox  # runs pylint + pytest on Python 3.10 and 3.11
 ```
+
+### Ollama Integration Testing
+
+If you have Ollama installed locally, you can run integration tests:
+
+```bash
+# Test Ollama integration (requires Ollama running with gemma2:2b model)
+tox -e ollama-integration
+```
+
+This test will automatically detect if Ollama is available and run real inference tests.
 
 ## Development
 

--- a/examples/ollama/.dockerignore
+++ b/examples/ollama/.dockerignore
@@ -1,0 +1,35 @@
+# Ignore Python cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# Ignore version control
+.git/
+.gitignore
+
+# Ignore OS files
+.DS_Store
+Thumbs.db
+
+# Ignore virtual environments
+venv/
+env/
+.venv/
+
+# Ignore IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Ignore test artifacts
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Ignore build artifacts
+build/
+dist/
+*.egg-info/

--- a/examples/ollama/Dockerfile
+++ b/examples/ollama/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.11-slim-bookworm
+
+WORKDIR /app
+
+RUN pip install langextract
+
+COPY quickstart.py .
+
+CMD ["python", "quickstart.py"]

--- a/examples/ollama/README.md
+++ b/examples/ollama/README.md
@@ -1,0 +1,32 @@
+# Ollama Examples
+
+This directory contains examples for using LangExtract with Ollama for local LLM inference.
+
+For setup instructions and documentation, see the [main README's Ollama section](../../README.md#using-local-llms-with-ollama).
+
+## Quick Reference
+
+**Local setup:**
+```bash
+ollama pull gemma2:2b
+python quickstart.py
+```
+
+**Docker setup:**
+```bash
+docker-compose up
+```
+
+## Files
+
+- `quickstart.py` - Basic extraction example with configurable model
+- `docker-compose.yml` - Production-ready Docker setup with health checks
+- `Dockerfile` - Container definition for LangExtract
+
+## Model License
+
+Ollama models come with their own licenses. For example:
+- Gemma models: [Gemma Terms of Use](https://ai.google.dev/gemma/terms)
+- Llama models: [Meta Llama License](https://llama.meta.com/llama-downloads/)
+
+Please review the license for any model you use.

--- a/examples/ollama/docker-compose.yml
+++ b/examples/ollama/docker-compose.yml
@@ -1,0 +1,42 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  ollama:
+    image: ollama/ollama:0.5.4
+    ports:
+      - "127.0.0.1:11434:11434"  # Bind only to localhost for security
+    volumes:
+      - ollama-data:/root/.ollama  # Cross-platform support
+    command: serve
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/version"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+
+  langextract:
+    build: .
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      - OLLAMA_HOST=http://ollama:11434
+    volumes:
+      - .:/app
+    command: python quickstart.py
+
+volumes:
+  ollama-data:

--- a/examples/ollama/quickstart.py
+++ b/examples/ollama/quickstart.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quick-start example for using Ollama with langextract."""
+
+import argparse
+import os
+
+import langextract as lx
+
+
+def run_extraction(model_id="gemma2:2b", temperature=0.3):
+  """Run a simple extraction example using Ollama."""
+  input_text = "Isaac Asimov was a prolific science fiction writer."
+
+  prompt = "Extract the author's full name and their primary literary genre."
+
+  examples = [
+      lx.data.ExampleData(
+          text=(
+              "J.R.R. Tolkien was an English writer, best known for"
+              " high-fantasy."
+          ),
+          extractions=[
+              lx.data.Extraction(
+                  extraction_class="author_details",
+                  # extraction_text includes full context with ellipsis for clarity
+                  extraction_text="J.R.R. Tolkien was an English writer...",
+                  attributes={
+                      "name": "J.R.R. Tolkien",
+                      "genre": "high-fantasy",
+                  },
+              )
+          ],
+      )
+  ]
+
+  result = lx.extract(
+      text_or_documents=input_text,
+      prompt_description=prompt,
+      examples=examples,
+      language_model_type=lx.inference.OllamaLanguageModel,
+      model_id=model_id,
+      model_url=os.getenv("OLLAMA_HOST", "http://localhost:11434"),
+      temperature=temperature,
+      fence_output=False,
+      use_schema_constraints=False,
+  )
+
+  return result
+
+
+def main():
+  """Main function to run the quick-start example."""
+  parser = argparse.ArgumentParser(description="Run Ollama extraction example")
+  parser.add_argument(
+      "--model-id",
+      default=os.getenv("MODEL_ID", "gemma2:2b"),
+      help="Ollama model ID (default: gemma2:2b or MODEL_ID env var)",
+  )
+  parser.add_argument(
+      "--temperature",
+      type=float,
+      default=float(os.getenv("TEMPERATURE", "0.3")),
+      help="Model temperature (default: 0.3 or TEMPERATURE env var)",
+  )
+  args = parser.parse_args()
+
+  print(f"🚀 Running Ollama quick-start example with {args.model_id}...")
+  print("-" * 50)
+
+  try:
+    result = run_extraction(
+        model_id=args.model_id, temperature=args.temperature
+    )
+
+    for extraction in result.extractions:
+      print(f"Class: {extraction.extraction_class}")
+      print(f"Text: {extraction.extraction_text}")
+      print(f"Attributes: {extraction.attributes}")
+
+    print("\n✅ SUCCESS! Ollama is working with langextract")
+    return True
+
+  except ConnectionError as e:
+    print(f"\nConnectionError: {e}")
+    print("Make sure Ollama is running: 'ollama serve'")
+    return False
+  except Exception as e:
+    print(f"\nError: {type(e).__name__}: {e}")
+    return False
+
+
+if __name__ == "__main__":
+  success = main()
+  exit(0 if success else 1)

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for Ollama functionality."""
+import socket
+
+import pytest
+import requests
+
+import langextract as lx
+
+
+def _ollama_available():
+  """Check if Ollama is running on localhost:11434."""
+  with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    result = sock.connect_ex(("localhost", 11434))
+    return result == 0
+
+
+@pytest.mark.skipif(not _ollama_available(), reason="Ollama not running")
+def test_ollama_extraction():
+  """Test extraction using Ollama when available."""
+  input_text = "Isaac Asimov was a prolific science fiction writer."
+  prompt = "Extract the author's full name and their primary literary genre."
+
+  examples = [
+      lx.data.ExampleData(
+          text=(
+              "J.R.R. Tolkien was an English writer, best known for"
+              " high-fantasy."
+          ),
+          extractions=[
+              lx.data.Extraction(
+                  extraction_class="author_details",
+                  extraction_text="J.R.R. Tolkien was an English writer...",
+                  attributes={
+                      "name": "J.R.R. Tolkien",
+                      "genre": "high-fantasy",
+                  },
+              )
+          ],
+      )
+  ]
+
+  model_id = "gemma2:2b"
+
+  try:
+    result = lx.extract(
+        text_or_documents=input_text,
+        prompt_description=prompt,
+        examples=examples,
+        language_model_type=lx.inference.OllamaLanguageModel,
+        model_id=model_id,
+        model_url="http://localhost:11434",
+        temperature=0.3,
+        fence_output=False,
+        use_schema_constraints=False,
+    )
+
+    assert len(result.extractions) > 0
+    extraction = result.extractions[0]
+    assert extraction.extraction_class == "author_details"
+    if extraction.attributes:
+      assert "asimov" in extraction.attributes.get("name", "").lower()
+
+  except ValueError as e:
+    if "Can't find Ollama" in str(e):
+      pytest.skip(f"Ollama model {model_id} not available")
+    raise

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [tox]
-envlist = py310, py311, format, lint-src, lint-tests
+envlist = py310, py311, py312, format, lint-src, lint-tests
 skip_missing_interpreters = True
 
 [testenv]
@@ -54,3 +54,9 @@ passenv =
 deps = {[testenv]deps}
 commands =
     pytest tests/test_live_api.py -v -m live_api --maxfail=1
+
+[testenv:ollama-integration]
+basepython = python3.11
+deps = {[testenv]deps}
+commands =
+    pytest tests/test_ollama_integration.py -v --tb=short


### PR DESCRIPTION
# Description

Add Ollama integration support with Docker examples and documentation for LangExtract. This PR introduces a complete example setup for using Ollama with LangExtract, including containerized deployment options and automated testing.

Fixes #7
Fixes #22
Fixes #56

Type: Feature

# Changes

## Added
- `examples/ollama/` directory with:
  - Docker configuration (`Dockerfile`, `.dockerignore`, `docker-compose.yml`)
  - Quickstart Python example (`quickstart.py`)
  - Documentation (`README.md`)
- `tests/test_ollama_integration.py` - Integration test for Ollama functionality

## Modified
- `.github/workflows/ci.yaml` - Updated CI pipeline to include Ollama tests
- `.github/workflows/validate_pr_template.yaml` - PR template validation updates
- `README.md` - Added Ollama integration documentation
- `tox.ini` - Added Ollama test configuration

# How Has This Been Tested?

Tested using the new integration test suite and manual verification of Docker examples:

```
$ python -m pytest tests/test_ollama_integration.py
$ docker-compose -f examples/ollama/docker-compose.yml up --build
```

# Checklist:

- [x] I have read and acknowledged Google's Open Source Code of conduct
- [x] I have read the Contributing page and signed the appropriate CLA
- [x] I have discussed my proposed solution with code owners in the linked issue(s)
- [x] I have made necessary documentation changes
- [x] I have added tests to cover the new Ollama integration
- [x] I have followed Google's Python Style Guide and ran `pylint` over the affected code