### PR TITLE
feat: Add support for Anthropic API, and make OllamaLanguageModel more configurable 

### DIFF
--- a/langextract/inference.py
+++ b/langextract/inference.py
@@ -421,6 +421,7 @@ class OpenAILanguageModel(BaseLanguageModel):
       self,
       model_id: str = 'gpt-4o-mini',
       api_key: str | None = None,
+      base_url: str | None = None,
       organization: str | None = None,
       format_type: data.FormatType = data.FormatType.JSON,
       temperature: float = 0.0,
@@ -432,6 +433,7 @@ class OpenAILanguageModel(BaseLanguageModel):
     Args:
       model_id: The OpenAI model ID to use (e.g., 'gpt-4o-mini', 'gpt-4o').
       api_key: API key for OpenAI service.
+      base_url: Optional base URL for OpenAI API (e.g., "https://api.openai.com/v1" for OpenAI, "https://api.anthropic.com/v1/" for Claude).
       organization: Optional OpenAI organization ID.
       format_type: Output format (JSON or YAML).
       temperature: Sampling temperature.
@@ -452,7 +454,9 @@ class OpenAILanguageModel(BaseLanguageModel):
 
     # Initialize the OpenAI client
     self._client = openai.OpenAI(
-        api_key=self.api_key, organization=self.organization
+        api_key=self.api_key,
+        organization=self.organization,
+        base_url=base_url
     )
 
     super().__init__(

--- a/langextract/inference.py
+++ b/langextract/inference.py
@@ -460,9 +460,7 @@ class OpenAILanguageModel(BaseLanguageModel):
 
     # Initialize the OpenAI client
     self._client = openai.OpenAI(
-        api_key=self.api_key,
-        organization=self.organization,
-        base_url=base_url
+        api_key=self.api_key, organization=self.organization, base_url=base_url
     )
 
     super().__init__(

--- a/langextract/inference.py
+++ b/langextract/inference.py
@@ -117,12 +117,16 @@ class OllamaLanguageModel(BaseLanguageModel):
       model_url: str = _OLLAMA_DEFAULT_MODEL_URL,
       structured_output_format: str = 'json',
       constraint: schema.Constraint = schema.Constraint(),
+      num_ctx: int = 2048,
+      keep_alive: int = 5 * 60,  # seconds
       **kwargs,
   ) -> None:
     self._model = model_id
     self._model_url = model_url
     self._structured_output_format = structured_output_format
     self._constraint = constraint
+    self._num_ctx = num_ctx
+    self._keep_alive = keep_alive
     self._extra_kwargs = kwargs or {}
     super().__init__(constraint=constraint)
 
@@ -136,6 +140,8 @@ class OllamaLanguageModel(BaseLanguageModel):
           model=self._model,
           structured_output_format=self._structured_output_format,
           model_url=self._model_url,
+          num_ctx=self._num_ctx,
+          keep_alive=self._keep_alive,
       )
       # No score for Ollama. Default to 1.0
       yield [ScoredOutput(score=1.0, output=response['response'])]

--- a/langextract/inference.py
+++ b/langextract/inference.py
@@ -453,6 +453,7 @@ class OpenAILanguageModel(BaseLanguageModel):
     self.format_type = format_type
     self.temperature = temperature
     self.max_workers = max_workers
+    self.base_url = base_url
     self._extra_kwargs = kwargs or {}
 
     if not self.api_key:
@@ -460,7 +461,9 @@ class OpenAILanguageModel(BaseLanguageModel):
 
     # Initialize the OpenAI client
     self._client = openai.OpenAI(
-        api_key=self.api_key, organization=self.organization, base_url=base_url
+        api_key=self.api_key,
+        organization=self.organization,
+        base_url=self.base_url,
     )
 
     super().__init__(

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -85,6 +85,8 @@ class TestOllamaLanguageModel(absltest.TestCase):
         model="gemma2:latest",
         structured_output_format="json",
         model_url="http://localhost:11434",
+        num_ctx=2048,
+        keep_alive=5 * 60,  # Ollama default keep alive time
     )
     expected_results = [[
         inference.ScoredOutput(


### PR DESCRIPTION
- Add `base_url` to `OpenAILanguageModel` so that we could call API call to anthropic API server for using Claude model
- When using Ollama, setting `num_ctx` and `keep_alive` are important in some cases, so it would be better to let users to use their own values when calling Ollama model