### PR TITLE
Add manual trigger capability to validation workflows

### DIFF
--- a/.github/workflows/check-infrastructure-changes.yml
+++ b/.github/workflows/check-infrastructure-changes.yml
@@ -3,6 +3,7 @@ name: Protect Infrastructure Files
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -10,11 +11,12 @@ permissions:
 
 jobs:
   protect-infrastructure:
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:
       - name: Check for infrastructure file changes
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -3,6 +3,7 @@ name: Require linked issue with community support
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -11,11 +12,12 @@ permissions:
 
 jobs:
   enforce:
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:
       - name: Verify linked issue
+        if: github.event_name == 'pull_request'
         uses: nearform-actions/github-action-check-linked-issues@v1.2.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -32,6 +34,7 @@ jobs:
             Use GitHub automation to close the issue when this PR is merged.
 
       - name: Check community support
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +64,9 @@ jobs:
                   issue(number: $number) {
                     reactionGroups {
                       content
-                      users { totalCount }
+                      users {
+                        totalCount
+                      }
                     }
                   }
                 }

--- a/.github/workflows/check-pr-size.yml
+++ b/.github/workflows/check-pr-size.yml
@@ -3,6 +3,7 @@ name: Check PR size
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate PR size
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/validate_pr_template.yaml
+++ b/.github/workflows/validate_pr_template.yaml
@@ -3,17 +3,19 @@ name: Validate PR template
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   check:
-    if: github.event.pull_request.draft == false   # drafts can save early
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false   # drafts can save early
     runs-on: ubuntu-latest
 
     steps:
       - name: Fail if template untouched
+        if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |


### PR DESCRIPTION
## Description

Adds workflow_dispatch trigger to validation workflows to enable manual triggering via GitHub UI or CLI.

## Changes

- Added `workflow_dispatch:` trigger to:
  - check-linked-issue.yml
  - check-pr-size.yml  
  - validate_pr_template.yaml
- Added conditional logic to ensure PR-specific steps only run on PR events
- Prevents errors when manually triggering workflows that expect PR context

## Benefits

- Allows maintainers to manually trigger workflows for testing
- Useful for debugging workflow issues
- Can manually re-run checks on PRs when needed

## Testing

After merging, workflows can be manually triggered via:
- GitHub UI: Actions tab → Select workflow → Run workflow
- CLI: `gh workflow run <workflow-file.yml> --ref <branch>`

Fixes #0 (Infrastructure improvement - maintainer-initiated)