### PR TITLE
Fix unicode escaping in example generation

### DIFF
--- a/langextract/prompting.py
+++ b/langextract/prompting.py
@@ -127,7 +127,7 @@ class QAPromptGenerator:
       else:
         answer = formatted_content.strip()
     elif self.format_type == data.FormatType.JSON:
-      formatted_content = json.dumps(data_dict, indent=2)
+      formatted_content = json.dumps(data_dict, indent=2, ensure_ascii=False)
       if self.fence_output:
         answer = f"```json\n{formatted_content.strip()}\n```"
       else:


### PR DESCRIPTION
## Description

Fixes Unicode characters being escaped in example generation due to the default behavior of `json.dumps()`.

In the `format_example_as_text` function in `prompting.py`, `json.dumps(data_dict, indent=2)` is used without setting `ensure_ascii=False`. This causes non-ASCII characters (e.g., Chinese, Arabic, Cyrillic) to be escaped into `\uXXXX` sequences, which harms readability and usability in multilingual contexts.

This change adds `ensure_ascii=False` to preserve Unicode characters in their original form, improving clarity and supporting better internationalization for language model prompts.

Fixes #93

## Example Comparison

### Before (with escaping)
```json
{
  "text": "\u4f60\u597d\uff0c\u4eca\u5929\u6c14\u6e29\u5982\u4f55\uff1f"
}
```

### After (direct Unicode)
```json
{
  "text": "你好，今天气温如何？"
}
```
✅ Characters are displayed naturally. Same improvement applies to Japanese, Korean, Arabic, Russian, etc.

## How Has This Been Tested?

- Manually tested with multilingual inputs including Chinese, Japanese, Korean, Arabic, and Russian.
- Confirmed that Unicode characters are no longer escaped in the output.
- Ran all required checks locally:
  ```bash
  ./autoformat.sh
  pylint --rcfile=.pylintrc langextract tests
  pytest tests
  ```
  All formatting, linting, and tests passed.

## Checklist

- [x] I have signed the [Google Contributor License Agreement (CLA)](https://cla.developers.google.com/)
- [x] I have read and followed the [HAI-DEF Community Guidelines](https://developers.google.com/health-ai-developer-foundations/community-guidelines)
- [x] My code follows the project's style guide (formatted with `./autoformat.sh`)
- [x] All tests pass (`pylint` and `pytest`)
- [x] This PR contains a single, focused change (fixes one specific issue)
- [x] I have referenced the related issue (`Closes #93`)
- [x] No infrastructure, build, or documentation files were modified

## Additional Notes

- This is a small, non-breaking change that improves user experience for multilingual developers.
- The change is backward-compatible: ASCII-only use cases remain unaffected.
- Enhances prompt clarity for LLMs by preserving natural text representation.
- No sensitive data or privacy concerns involved.
- Contribution is free of malicious code and made in good faith.