### PR TITLE
fix ollama example, add language_model_type param

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,8 @@ result = lx.extract(
     model_id="gemma2:2b",  # Automatically selects Ollama provider
     model_url="http://localhost:11434",
     fence_output=False,
-    use_schema_constraints=False
+    use_schema_constraints=False,
+    language_model_type=lx.inference.OllamaLanguageModel
 )
 ```
 


### PR DESCRIPTION
if using ollama server, should pass language_model_type  param or it will raise an error