### PR TITLE
Adding model and config parameters to extract()

### DIFF
--- a/langextract/__init__.py
+++ b/langextract/__init__.py
@@ -83,6 +83,8 @@ def extract(
     debug: bool = True,
     model_url: str | None = None,
     extraction_passes: int = 1,
+    config: factory.ModelConfig | None = None,
+    model: inference.BaseLanguageModel | None = None,
 ) -> data.AnnotatedDocument | Iterable[data.AnnotatedDocument]:
   """Extracts structured information from text.
 
@@ -106,6 +108,7 @@ def extract(
         monitor usage with small test runs to estimate costs.
       model_id: The model ID to use for extraction.
       language_model_type: The type of language model to use for inference.
+        DEPRECATED in favor of `model_id`, `config` and `model`.
       format_type: The format type for the output (JSON or YAML).
       max_char_buffer: Max number of characters for inference.
       temperature: The sampling temperature for generation. Higher values (e.g.,
@@ -146,6 +149,10 @@ def extract(
         for overlaps). WARNING: Each additional pass reprocesses tokens,
         potentially increasing API costs. For example, extraction_passes=3
         reprocesses tokens 3x.
+      config: Model configuration to use for extraction (favored over
+        `model_id` and `language_model_type`.)
+      model: Model to use for extraction (favored over `config`, `model_id` and
+        `language_model_type`.)
 
   Returns:
       An AnnotatedDocument with the extracted information when input is a
@@ -187,51 +194,53 @@ def extract(
   )
   prompt_template.examples.extend(examples)
 
-  # Generate schema constraints if enabled
-  model_schema = None
-  schema_constraint = None
-
-  # TODO: Unify schema generation.
-  if (
-      use_schema_constraints
-      and language_model_type == inference.GeminiLanguageModel
-  ):
-    model_schema = schema.GeminiSchema.from_examples(prompt_template.examples)
-
   # Handle backward compatibility for language_model_type parameter
   if language_model_type != inference.GeminiLanguageModel:
     warnings.warn(
         "The 'language_model_type' parameter is deprecated and will be removed"
         " in a future version. The provider is now automatically selected based"
-        " on the model_id.",
+        " on the 'model_id' or by the 'config' and/or 'model' parameters.",
         DeprecationWarning,
         stacklevel=2,
     )
 
-  # Use factory to create the language model
-  base_lm_kwargs: dict[str, Any] = {
-      "api_key": api_key,
-      "gemini_schema": model_schema,
-      "format_type": format_type,
-      "temperature": temperature,
-      "model_url": model_url,
-      "base_url": model_url,  # Support both parameter names for Ollama
-      "constraint": schema_constraint,
-      "max_workers": max_workers,
-  }
+  if not model and not config:
+    # Generate schema constraints if enabled
+    model_schema = None
 
-  # Merge user-provided params which have precedence over defaults.
-  base_lm_kwargs.update(language_model_params or {})
+    # TODO: Unify schema generation.
+    if (
+        use_schema_constraints
+        and language_model_type == inference.GeminiLanguageModel
+    ):
+      model_schema = schema.GeminiSchema.from_examples(prompt_template.examples)
 
-  # Filter out None values
-  filtered_kwargs = {k: v for k, v in base_lm_kwargs.items() if v is not None}
+    # Use factory to create the language model
+    base_lm_kwargs: dict[str, Any] = {
+        "api_key": api_key,
+        "gemini_schema": model_schema,
+        "format_type": format_type,
+        "temperature": temperature,
+        "model_url": model_url,
+        "base_url": model_url,  # Support both parameter names for Ollama
+        "max_workers": max_workers,
+    }
 
-  # Create model using factory
-  # Providers are loaded lazily by the registry on first resolve
-  config = factory.ModelConfig(
-      model_id=model_id, provider_kwargs=filtered_kwargs
-  )
-  language_model = factory.create_model(config)
+    # Merge user-provided params which have precedence over defaults.
+    base_lm_kwargs.update(language_model_params or {})
+
+    # Filter out None values
+    filtered_kwargs = {k: v for k, v in base_lm_kwargs.items() if v is not None}
+
+    # Create model using factory
+    # Providers are loaded lazily by the registry on first resolve
+    config = factory.ModelConfig(
+        model_id=model_id, provider_kwargs=filtered_kwargs
+    )
+
+  if not model:
+    assert config, "Could not determine model configuration"
+    model = factory.create_model(config)
 
   resolver_defaults = {
       "fence_output": fence_output,
@@ -244,7 +253,7 @@ def extract(
   res = resolver.Resolver(**resolver_defaults)
 
   annotator = annotation.Annotator(
-      language_model=language_model,
+      language_model=model,
       prompt_template=prompt_template,
       format_type=format_type,
       fence_output=fence_output,

--- a/langextract/__init__.py
+++ b/langextract/__init__.py
@@ -204,6 +204,16 @@ def extract(
         stacklevel=2,
     )
 
+  if use_schema_constraints and (model or config):
+    warnings.warn(
+        "The 'use_schema_constraints' parameter is ignored when 'model' or"
+        " 'config' is provided. To use schema constraints, include them"
+        " directly in your config's provider_kwargs (e.g., 'gemini_schema' for"
+        " Gemini models).",
+        UserWarning,
+        stacklevel=2,
+    )
+
   if not model and not config:
     # Generate schema constraints if enabled
     model_schema = None
@@ -239,7 +249,10 @@ def extract(
     )
 
   if not model:
-    assert config, "Could not determine model configuration"
+    if not config:
+      raise RuntimeError(
+          "Internal error: Failed to determine model configuration"
+      )
     model = factory.create_model(config)
 
   resolver_defaults = {

--- a/tests/extract_precedence_test.py
+++ b/tests/extract_precedence_test.py
@@ -1,0 +1,172 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for parameter precedence in extract()."""
+
+from unittest import mock
+
+from absl.testing import absltest
+
+from langextract import data
+from langextract import factory
+from langextract import inference
+import langextract as lx
+
+
+class ExtractParameterPrecedenceTest(absltest.TestCase):
+  """Tests ensuring correct precedence among extract() parameters."""
+
+  def setUp(self):
+    super().setUp()
+    self.examples = [
+        data.ExampleData(
+            text="example",
+            extractions=[
+                data.Extraction(
+                    extraction_class="entity",
+                    extraction_text="example",
+                )
+            ],
+        )
+    ]
+    self.description = "description"
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.factory.create_model")
+  def test_model_overrides_all_other_parameters(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    provided_model = mock.MagicMock()
+    mock_annotator = mock_annotator_cls.return_value
+    mock_annotator.annotate_text.return_value = "ok"
+
+    config = factory.ModelConfig(model_id="config-id")
+
+    result = lx.extract(
+        text_or_documents="text",
+        prompt_description=self.description,
+        examples=self.examples,
+        model=provided_model,
+        config=config,
+        model_id="ignored-model",
+        api_key="ignored-key",
+        language_model_type=inference.OpenAILanguageModel,
+        use_schema_constraints=False,
+    )
+
+    mock_create_model.assert_not_called()
+    _, kwargs = mock_annotator_cls.call_args
+    self.assertIs(kwargs["language_model"], provided_model)
+    self.assertEqual(result, "ok")
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.factory.create_model")
+  def test_config_overrides_model_id_and_language_model_type(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    config = factory.ModelConfig(
+        model_id="config-model", provider_kwargs={"api_key": "config-key"}
+    )
+    mock_model = mock.MagicMock()
+    mock_create_model.return_value = mock_model
+    mock_annotator = mock_annotator_cls.return_value
+    mock_annotator.annotate_text.return_value = "ok"
+
+    with mock.patch("langextract.factory.ModelConfig") as mock_model_config:
+      result = lx.extract(
+          text_or_documents="text",
+          prompt_description=self.description,
+          examples=self.examples,
+          config=config,
+          model_id="other-model",
+          api_key="other-key",
+          language_model_type=inference.OpenAILanguageModel,
+          use_schema_constraints=False,
+      )
+      mock_model_config.assert_not_called()
+
+    mock_create_model.assert_called_once_with(config)
+    _, kwargs = mock_annotator_cls.call_args
+    self.assertIs(kwargs["language_model"], mock_model)
+    self.assertEqual(config.provider_kwargs, {"api_key": "config-key"})
+    self.assertEqual(result, "ok")
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.factory.create_model")
+  def test_model_id_and_base_kwargs_override_language_model_type(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    mock_model = mock.MagicMock()
+    mock_create_model.return_value = mock_model
+    mock_annotator_cls.return_value.annotate_text.return_value = "ok"
+    mock_config = mock.MagicMock()
+
+    with mock.patch(
+        "langextract.factory.ModelConfig", return_value=mock_config
+    ) as mock_model_config:
+      with self.assertWarns(DeprecationWarning):
+        result = lx.extract(
+            text_or_documents="text",
+            prompt_description=self.description,
+            examples=self.examples,
+            model_id="model-123",
+            api_key="api-key",
+            temperature=0.9,
+            model_url="http://model",
+            language_model_type=inference.OpenAILanguageModel,
+            use_schema_constraints=False,
+        )
+
+    mock_model_config.assert_called_once()
+    _, kwargs = mock_model_config.call_args
+    self.assertEqual(kwargs["model_id"], "model-123")
+    provider_kwargs = kwargs["provider_kwargs"]
+    self.assertEqual(provider_kwargs["api_key"], "api-key")
+    self.assertEqual(provider_kwargs["temperature"], 0.9)
+    self.assertEqual(provider_kwargs["model_url"], "http://model")
+    self.assertEqual(provider_kwargs["base_url"], "http://model")
+    mock_create_model.assert_called_once_with(mock_config)
+    self.assertEqual(result, "ok")
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.factory.create_model")
+  def test_language_model_type_only_emits_warning_and_works(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    mock_model = mock.MagicMock()
+    mock_create_model.return_value = mock_model
+    mock_annotator_cls.return_value.annotate_text.return_value = "ok"
+    mock_config = mock.MagicMock()
+
+    with mock.patch(
+        "langextract.factory.ModelConfig", return_value=mock_config
+    ) as mock_model_config:
+      with self.assertWarns(DeprecationWarning):
+        result = lx.extract(
+            text_or_documents="text",
+            prompt_description=self.description,
+            examples=self.examples,
+            language_model_type=inference.OpenAILanguageModel,
+            use_schema_constraints=False,
+        )
+
+    mock_model_config.assert_called_once()
+    _, kwargs = mock_model_config.call_args
+    self.assertEqual(kwargs["model_id"], "gemini-2.5-flash")
+    mock_create_model.assert_called_once_with(mock_config)
+    self.assertEqual(result, "ok")
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -24,7 +24,6 @@ from langextract import inference
 from langextract import prompting
 from langextract import schema
 import langextract as lx
-from langextract.providers import gemini
 
 
 class InitTest(absltest.TestCase):


### PR DESCRIPTION
# Description

Adds `config` and `model` to `extract()` while maintaining full backward compatibility.

* Added two new settings to `extract()`:
  - `config`: An optional `ModelConfig`.
  - `model`: An optional `BaseModel` implementation.
* Parameter precedence in `extract()` for model selection is as follows (from
chosen first to last):
  - `model`
  - `config`
  - `model_id` (with `api_key`, `temperature` and `model_url`)
  - `language_model_type` (deprecated.)
* Dropped unused `constraints` from `extract()`

Fixes #106 

# How Has This Been Tested?

All tests succeed with:

```
$ poetry run pytest tests/
```

# Checklist:

-   [X] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
-   [X] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [X] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
-   [X] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
-   [X] I have added tests, or I have ensured existing tests cover the changes
-   [X] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.