### PR TITLE
Update kwargs handling for provider models

### DIFF
--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -90,10 +90,9 @@ class OpenAILanguageModel(inference.BaseLanguageModel):
     self.format_type = format_type
     self.temperature = temperature
     self.max_workers = max_workers
-    self._extra_kwargs = kwargs or {}
 
     if not self.api_key:
-      raise exceptions.InferenceConfigError('API key not provided for OpenAI.')
+      raise exceptions.InferenceConfigError('API key not provided.')
 
     # Initialize the OpenAI client
     self._client = openai.OpenAI(
@@ -105,13 +104,13 @@ class OpenAILanguageModel(inference.BaseLanguageModel):
     super().__init__(
         constraint=schema.Constraint(constraint_type=schema.ConstraintType.NONE)
     )
+    self._extra_kwargs = kwargs or {}
 
   def _process_single_prompt(
       self, prompt: str, config: dict
   ) -> inference.ScoredOutput:
     """Process a single prompt and return a ScoredOutput."""
     try:
-      # Prepare the system message for structured output
       system_message = ''
       if self.format_type == data.FormatType.JSON:
         system_message = (
@@ -122,17 +121,37 @@ class OpenAILanguageModel(inference.BaseLanguageModel):
             'You are a helpful assistant that responds in YAML format.'
         )
 
-      response = self._client.chat.completions.create(
-          model=self.model_id,
-          messages=[
-              {'role': 'system', 'content': system_message},
-              {'role': 'user', 'content': prompt},
-          ],
-          temperature=config.get('temperature', self.temperature),
-          max_tokens=config.get('max_output_tokens'),
-          top_p=config.get('top_p'),
-          n=1,
-      )
+      messages = [{'role': 'user', 'content': prompt}]
+      if system_message:
+        messages.insert(0, {'role': 'system', 'content': system_message})
+
+      api_params = {
+          'model': self.model_id,
+          'messages': messages,
+          'temperature': config.get('temperature', self.temperature),
+          'n': 1,
+      }
+
+      if self.format_type == data.FormatType.JSON:
+        # Enables structured JSON output for compatible models
+        api_params['response_format'] = {'type': 'json_object'}
+
+      if (v := config.get('max_output_tokens')) is not None:
+        api_params['max_tokens'] = v
+      if (v := config.get('top_p')) is not None:
+        api_params['top_p'] = v
+      for key in [
+          'frequency_penalty',
+          'presence_penalty',
+          'seed',
+          'stop',
+          'logprobs',
+          'top_logprobs',
+      ]:
+        if (v := config.get(key)) is not None:
+          api_params[key] = v
+
+      response = self._client.chat.completions.create(**api_params)
 
       # Extract the response text using the v1.x response format
       output_text = response.choices[0].message.content
@@ -156,13 +175,27 @@ class OpenAILanguageModel(inference.BaseLanguageModel):
     Yields:
       Lists of ScoredOutputs.
     """
+    merged_kwargs = self.merge_kwargs(kwargs)
+
     config = {
-        'temperature': kwargs.get('temperature', self.temperature),
+        'temperature': merged_kwargs.get('temperature', self.temperature),
     }
-    if 'max_output_tokens' in kwargs:
-      config['max_output_tokens'] = kwargs['max_output_tokens']
-    if 'top_p' in kwargs:
-      config['top_p'] = kwargs['top_p']
+    if 'max_output_tokens' in merged_kwargs:
+      config['max_output_tokens'] = merged_kwargs['max_output_tokens']
+    if 'top_p' in merged_kwargs:
+      config['top_p'] = merged_kwargs['top_p']
+
+    # Forward OpenAI-specific parameters
+    for key in [
+        'frequency_penalty',
+        'presence_penalty',
+        'seed',
+        'stop',
+        'logprobs',
+        'top_logprobs',
+    ]:
+      if key in merged_kwargs:
+        config[key] = merged_kwargs[key]
 
     # Use parallel processing for batches larger than 1
     if len(batch_prompts) > 1 and self.max_workers > 1:

--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -49,6 +49,13 @@ class OpenAILanguageModel(inference.BaseLanguageModel):
       default_factory=dict, repr=False, compare=False
   )
 
+  @property
+  def requires_fence_output(self) -> bool:
+    """OpenAI JSON mode returns raw JSON without fences."""
+    if self.format_type == data.FormatType.JSON:
+      return False
+    return super().requires_fence_output
+
   def __init__(
       self,
       model_id: str = 'gpt-4o-mini',

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -18,7 +18,64 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 from langextract import data
+from langextract import exceptions
 from langextract import inference
+from langextract.providers import gemini
+from langextract.providers import ollama
+from langextract.providers import openai as openai_provider
+
+
+class TestBaseLanguageModel(absltest.TestCase):
+
+  def test_merge_kwargs_with_none(self):
+    """Test merge_kwargs handles None runtime_kwargs."""
+
+    class TestModel(inference.BaseLanguageModel):
+
+      def infer(self, batch_prompts, **kwargs):
+        return iter([])
+
+    model = TestModel()
+    model._extra_kwargs = {"a": 1, "b": 2}
+
+    result = model.merge_kwargs(None)
+    self.assertEqual(
+        {"a": 1, "b": 2},
+        result,
+        "merge_kwargs(None) should return stored kwargs unchanged",
+    )
+
+    result = model.merge_kwargs({})
+    self.assertEqual(
+        {"a": 1, "b": 2},
+        result,
+        "merge_kwargs({}) should return stored kwargs unchanged",
+    )
+
+    result = model.merge_kwargs({"b": 3, "c": 4})
+    self.assertEqual(
+        {"a": 1, "b": 3, "c": 4},
+        result,
+        "Runtime kwargs should override stored kwargs and add new keys",
+    )
+
+  def test_merge_kwargs_without_extra_kwargs(self):
+    """Test merge_kwargs when _extra_kwargs doesn't exist."""
+
+    class TestModel(inference.BaseLanguageModel):
+
+      def infer(self, batch_prompts, **kwargs):
+        return iter([])
+
+    model = TestModel()
+    # Intentionally not setting _extra_kwargs to test fallback behavior
+
+    result = model.merge_kwargs({"a": 1})
+    self.assertEqual(
+        {"a": 1},
+        result,
+        "merge_kwargs should work even without _extra_kwargs attribute",
+    )
 
 
 class TestOllamaLanguageModel(absltest.TestCase):
@@ -26,7 +83,7 @@ class TestOllamaLanguageModel(absltest.TestCase):
   @mock.patch("langextract.providers.ollama.OllamaLanguageModel._ollama_query")
   def test_ollama_infer(self, mock_ollama_query):
 
-    # Actuall full gemma2 response using Ollama.
+    # Real gemma2 response structure from Ollama API for validation
     gemma_response = {
         "model": "gemma2:latest",
         "created_at": "2025-01-23T22:37:08.579440841Z",
@@ -73,7 +130,7 @@ class TestOllamaLanguageModel(absltest.TestCase):
         "eval_duration": 1848000000,
     }
     mock_ollama_query.return_value = gemma_response
-    model = inference.OllamaLanguageModel(
+    model = ollama.OllamaLanguageModel(
         model_id="gemma2:latest",
         model_url="http://localhost:11434",
         structured_output_format="json",
@@ -94,6 +151,233 @@ class TestOllamaLanguageModel(absltest.TestCase):
     ]]
     self.assertEqual(results, expected_results)
 
+  @mock.patch("requests.post")
+  def test_ollama_extra_kwargs_passed_to_api(self, mock_post):
+    """Verify extra kwargs like timeout and keep_alive are passed to the API."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "response": '{"test": "value"}',
+        "done": True,
+    }
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(
+        model_id="test-model",
+        timeout=300,
+        keep_alive=600,
+        num_threads=8,
+    )
+
+    prompts = ["Test prompt"]
+    list(model.infer(prompts))
+
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    json_payload = call_args.kwargs["json"]
+
+    self.assertEqual(json_payload["options"]["keep_alive"], 600)
+    self.assertEqual(json_payload["options"]["num_thread"], 8)
+    # timeout is passed to requests.post, not in the JSON payload
+    self.assertEqual(call_args.kwargs["timeout"], 300)
+
+  @mock.patch("requests.post")
+  def test_ollama_stop_and_top_p_passthrough(self, mock_post):
+    """Verify stop and top_p parameters are passed to Ollama API."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "response": '{"test": "value"}',
+        "done": True,
+    }
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(
+        model_id="test-model",
+        top_p=0.9,
+        stop=["\\n\\n", "END"],
+    )
+
+    prompts = ["Test prompt"]
+    list(model.infer(prompts))
+
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    json_payload = call_args.kwargs["json"]
+
+    # Ollama expects 'stop' at top level, not in options
+    self.assertEqual(json_payload["stop"], ["\\n\\n", "END"])
+    self.assertEqual(json_payload["options"]["top_p"], 0.9)
+
+  @mock.patch("requests.post")
+  def test_ollama_defaults_when_unspecified(self, mock_post):
+    """Verify Ollama uses correct defaults when parameters are not specified."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "response": '{"test": "value"}',
+        "done": True,
+    }
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(model_id="test-model")
+
+    prompts = ["Test prompt"]
+    list(model.infer(prompts))
+
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    json_payload = call_args.kwargs["json"]
+
+    self.assertEqual(json_payload["options"]["temperature"], 0.8)
+    self.assertEqual(json_payload["options"]["keep_alive"], 300)
+    self.assertEqual(json_payload["options"]["num_ctx"], 2048)
+    self.assertEqual(call_args.kwargs["timeout"], 30)
+
+  @mock.patch("requests.post")
+  def test_ollama_runtime_kwargs_override_stored(self, mock_post):
+    """Verify runtime kwargs override stored kwargs."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "response": '{"test": "value"}',
+        "done": True,
+    }
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(
+        model_id="test-model",
+        temperature=0.5,
+        keep_alive=300,
+    )
+
+    prompts = ["Test prompt"]
+    list(model.infer(prompts, temperature=0.8, keep_alive=600))
+
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    json_payload = call_args.kwargs["json"]
+
+    self.assertEqual(json_payload["options"]["temperature"], 0.8)
+    self.assertEqual(json_payload["options"]["keep_alive"], 600)
+
+  @mock.patch("requests.post")
+  def test_ollama_temperature_zero(self, mock_post):
+    """Test that temperature=0.0 is properly passed to Ollama."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "response": '{"test": "value"}',
+        "done": True,
+    }
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(
+        model_id="test-model",
+        temperature=0.0,
+    )
+
+    list(model.infer(["test prompt"]))
+
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    json_payload = call_args.kwargs["json"]
+
+    self.assertEqual(json_payload["options"]["temperature"], 0.0)
+
+
+class TestGeminiLanguageModel(absltest.TestCase):
+
+  @mock.patch("google.genai.Client")
+  def test_gemini_allowlist_filtering(self, mock_client_class):
+    """Test that only allow-listed keys are passed through."""
+    mock_client = mock.Mock()
+    mock_client_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.text = '{"result": "test"}'
+    mock_client.models.generate_content.return_value = mock_response
+
+    model = gemini.GeminiLanguageModel(
+        model_id="gemini-2.5-flash",
+        api_key="test-key",
+        # Allow-listed parameters
+        tools=["tool1", "tool2"],
+        stop_sequences=["\n\n"],
+        system_instruction="Be helpful",
+        # Unknown parameters to test filtering
+        unknown_param="should_be_ignored",
+        another_unknown="also_ignored",
+    )
+
+    expected_extra_kwargs = {
+        "tools": ["tool1", "tool2"],
+        "stop_sequences": ["\n\n"],
+        "system_instruction": "Be helpful",
+    }
+    self.assertEqual(
+        expected_extra_kwargs,
+        model._extra_kwargs,
+        "Only allow-listed kwargs should be stored in _extra_kwargs",
+    )
+
+    prompts = ["Test prompt"]
+    list(model.infer(prompts))
+
+    mock_client.models.generate_content.assert_called_once()
+    call_args = mock_client.models.generate_content.call_args
+    config = call_args.kwargs["config"]
+
+    for key in ["tools", "stop_sequences", "system_instruction"]:
+      self.assertIn(key, config, f"Expected {key} to be in API config")
+      self.assertEqual(
+          expected_extra_kwargs[key],
+          config[key],
+          f"Config value for {key} should match what was provided",
+      )
+
+  @mock.patch("google.genai.Client")
+  def test_gemini_runtime_kwargs_filtered(self, mock_client_class):
+    """Test that runtime kwargs are also filtered by allow-list."""
+    mock_client = mock.Mock()
+    mock_client_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.text = '{"result": "test"}'
+    mock_client.models.generate_content.return_value = mock_response
+
+    model = gemini.GeminiLanguageModel(
+        model_id="gemini-2.5-flash",
+        api_key="test-key",
+    )
+
+    prompts = ["Test prompt"]
+    list(
+        model.infer(
+            prompts,
+            candidate_count=2,
+            safety_settings={"HARM_CATEGORY_DANGEROUS": "BLOCK_NONE"},
+            unknown_runtime_param="ignored",
+        )
+    )
+
+    call_args = mock_client.models.generate_content.call_args
+    config = call_args.kwargs["config"]
+
+    self.assertEqual(
+        2,
+        config.get("candidate_count"),
+        "candidate_count should be passed through to API",
+    )
+    self.assertEqual(
+        {"HARM_CATEGORY_DANGEROUS": "BLOCK_NONE"},
+        config.get("safety_settings"),
+        "safety_settings should be passed through to API",
+    )
+    self.assertNotIn(
+        "unknown_runtime_param", config, "Unknown kwargs should be filtered out"
+    )
+
 
 class TestOpenAILanguageModelInference(parameterized.TestCase):
 
@@ -105,52 +389,35 @@ class TestOpenAILanguageModelInference(parameterized.TestCase):
   def test_openai_infer_with_parameters(
       self, api_key, base_url, model_id, temperature, mock_openai_class
   ):
-    # Mock the OpenAI client and chat completion response
     mock_client = mock.Mock()
     mock_openai_class.return_value = mock_client
 
-    # Mock response structure for v1.x API
     mock_response = mock.Mock()
     mock_response.choices = [
         mock.Mock(message=mock.Mock(content='{"name": "John", "age": 30}'))
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
-    # Create model instance
-    model = inference.OpenAILanguageModel(
+    model = openai_provider.OpenAILanguageModel(
         model_id=model_id,
         api_key=api_key,
         base_url=base_url,
         temperature=temperature,
     )
 
-    # Test inference
     batch_prompts = ["Extract name and age from: John is 30 years old"]
     results = list(model.infer(batch_prompts))
 
-    # Verify API was called correctly
-    # Note: The new implementation adds a system message for JSON format
-    mock_client.chat.completions.create.assert_called_once_with(
-        model="gpt-4o-mini",
-        messages=[
-            {
-                "role": "system",
-                "content": (
-                    "You are a helpful assistant that responds in JSON format."
-                ),
-            },
-            {
-                "role": "user",
-                "content": "Extract name and age from: John is 30 years old",
-            },
-        ],
-        temperature=temperature,
-        max_tokens=None,
-        top_p=None,
-        n=1,
-    )
+    # JSON format adds a system message; only explicitly set params are passed
+    mock_client.chat.completions.create.assert_called_once()
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(call_args.kwargs["model"], "gpt-4o-mini")
+    self.assertEqual(call_args.kwargs["temperature"], temperature)
+    self.assertEqual(call_args.kwargs["n"], 1)
+    self.assertEqual(len(call_args.kwargs["messages"]), 2)
+    self.assertEqual(call_args.kwargs["messages"][0]["role"], "system")
+    self.assertEqual(call_args.kwargs["messages"][1]["role"], "user")
 
-    # Check results
     expected_results = [[
         inference.ScoredOutput(score=1.0, output='{"name": "John", "age": 30}')
     ]]
@@ -160,43 +427,39 @@ class TestOpenAILanguageModelInference(parameterized.TestCase):
 class TestOpenAILanguageModel(absltest.TestCase):
 
   def test_openai_parse_output_json(self):
-    model = inference.OpenAILanguageModel(
+    model = openai_provider.OpenAILanguageModel(
         api_key="test-key", format_type=data.FormatType.JSON
     )
 
-    # Test valid JSON parsing
     output = '{"key": "value", "number": 42}'
     parsed = model.parse_output(output)
     self.assertEqual(parsed, {"key": "value", "number": 42})
 
-    # Test invalid JSON
     with self.assertRaises(ValueError) as context:
       model.parse_output("invalid json")
     self.assertIn("Failed to parse output as JSON", str(context.exception))
 
   def test_openai_parse_output_yaml(self):
-    model = inference.OpenAILanguageModel(
+    model = openai_provider.OpenAILanguageModel(
         api_key="test-key", format_type=data.FormatType.YAML
     )
 
-    # Test valid YAML parsing
     output = "key: value\nnumber: 42"
     parsed = model.parse_output(output)
     self.assertEqual(parsed, {"key": "value", "number": 42})
 
-    # Test invalid YAML
     with self.assertRaises(ValueError) as context:
       model.parse_output("invalid: yaml: bad")
     self.assertIn("Failed to parse output as YAML", str(context.exception))
 
   def test_openai_no_api_key_raises_error(self):
-    with self.assertRaises(ValueError) as context:
-      inference.OpenAILanguageModel(api_key=None)
+    with self.assertRaises(exceptions.InferenceConfigError) as context:
+      openai_provider.OpenAILanguageModel(api_key=None)
     self.assertEqual(str(context.exception), "API key not provided.")
 
   @mock.patch("openai.OpenAI")
-  def test_openai_temperature_zero(self, mock_openai_class):
-    # Test that temperature=0.0 is properly passed through
+  def test_openai_extra_kwargs_passed(self, mock_openai_class):
+    """Test that extra kwargs are passed to OpenAI API."""
     mock_client = mock.Mock()
     mock_openai_class.return_value = mock_client
 
@@ -206,21 +469,161 @@ class TestOpenAILanguageModel(absltest.TestCase):
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
-    model = inference.OpenAILanguageModel(
-        api_key="test-key", temperature=0.0  # Testing zero temperature
+    model = openai_provider.OpenAILanguageModel(
+        api_key="test-key",
+        frequency_penalty=0.5,
+        presence_penalty=0.7,
+        seed=42,
     )
 
     list(model.infer(["test prompt"]))
 
-    # Verify temperature=0.0 was passed to the API
-    mock_client.chat.completions.create.assert_called_with(
-        model="gpt-4o-mini",
-        messages=mock.ANY,
-        temperature=0.0,
-        max_tokens=None,
-        top_p=None,
-        n=1,
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(call_args.kwargs["frequency_penalty"], 0.5)
+    self.assertEqual(call_args.kwargs["presence_penalty"], 0.7)
+    self.assertEqual(call_args.kwargs["seed"], 42)
+
+  @mock.patch("openai.OpenAI")
+  def test_openai_runtime_kwargs_override(self, mock_openai_class):
+    """Test that runtime kwargs override stored kwargs."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai_provider.OpenAILanguageModel(
+        api_key="test-key",
+        temperature=0.5,
+        seed=123,
     )
+
+    list(model.infer(["test prompt"], temperature=0.8, seed=456))
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(call_args.kwargs["temperature"], 0.8)
+    self.assertEqual(call_args.kwargs["seed"], 456)
+
+  @mock.patch("openai.OpenAI")
+  def test_openai_json_response_format(self, mock_openai_class):
+    """Test that JSON format adds response_format parameter."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai_provider.OpenAILanguageModel(
+        api_key="test-key", format_type=data.FormatType.JSON
+    )
+
+    list(model.infer(["test prompt"]))
+
+    mock_client.chat.completions.create.assert_called_once()
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(
+        call_args.kwargs["response_format"], {"type": "json_object"}
+    )
+
+  @mock.patch("openai.OpenAI")
+  def test_openai_temperature_zero(self, mock_openai_class):
+    """Verify temperature=0.0 is properly passed to the API."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai_provider.OpenAILanguageModel(
+        api_key="test-key", temperature=0.0
+    )
+
+    list(model.infer(["test prompt"]))
+
+    mock_client.chat.completions.create.assert_called_once()
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(call_args.kwargs["temperature"], 0.0)
+    self.assertEqual(call_args.kwargs["model"], "gpt-4o-mini")
+    self.assertEqual(call_args.kwargs["n"], 1)
+
+  @mock.patch("openai.OpenAI")
+  def test_openai_none_values_filtered(self, mock_openai_class):
+    """Test that None values are not passed to the API."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai_provider.OpenAILanguageModel(
+        api_key="test-key",
+        top_p=0.9,
+    )
+
+    list(model.infer(["test prompt"], top_p=None, seed=None))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertNotIn("top_p", call_args.kwargs)
+    self.assertNotIn("seed", call_args.kwargs)
+
+  @mock.patch("openai.OpenAI")
+  def test_openai_no_system_message_when_not_json_yaml(self, mock_openai_class):
+    """Test that no system message is sent when format_type is not JSON/YAML."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content="test output"))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai_provider.OpenAILanguageModel(
+        api_key="test-key",
+        format_type=None,
+    )
+
+    list(model.infer(["test prompt"]))
+
+    call_args = mock_client.chat.completions.create.call_args
+    messages = call_args.kwargs["messages"]
+
+    self.assertEqual(len(messages), 1)
+    self.assertEqual(messages[0]["role"], "user")
+    self.assertEqual(messages[0]["content"], "test prompt")
+
+  @mock.patch("google.genai.Client")
+  def test_gemini_none_values_filtered(self, mock_client_class):
+    """Test that None values are not passed to Gemini API."""
+    mock_client = mock.Mock()
+    mock_client_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.text = '{"result": "test"}'
+    mock_client.models.generate_content.return_value = mock_response
+
+    model = gemini.GeminiLanguageModel(
+        model_id="gemini-2.5-flash",
+        api_key="test-key",
+    )
+
+    list(model.infer(["test prompt"], candidate_count=None))
+
+    call_args = mock_client.models.generate_content.call_args
+    config = call_args.kwargs["config"]
+
+    self.assertNotIn("candidate_count", config)
 
 
 if __name__ == "__main__":

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -501,7 +501,6 @@ class TestLiveAPIOpenAI(unittest.TestCase):
         examples=examples,
         model_id=DEFAULT_OPENAI_MODEL,
         api_key=OPENAI_API_KEY,
-        fence_output=True,
         use_schema_constraints=False,
         language_model_params=OPENAI_MODEL_PARAMS,
     )
@@ -559,7 +558,6 @@ class TestLiveAPIOpenAI(unittest.TestCase):
         provider="OpenAILanguageModel",  # Explicit provider selection
         provider_kwargs={
             "api_key": OPENAI_API_KEY,
-            "fence_output": True,
             "temperature": 0.0,
         },
     )
@@ -610,7 +608,6 @@ class TestLiveAPIOpenAI(unittest.TestCase):
         examples=examples,
         model_id=DEFAULT_OPENAI_MODEL,
         api_key=OPENAI_API_KEY,
-        fence_output=True,
         use_schema_constraints=False,
         language_model_params=OPENAI_MODEL_PARAMS,
     )


### PR DESCRIPTION
# Description

Updates kwargs handling across all provider models to properly merge stored and runtime parameters. Runtime kwargs take precedence over initialization kwargs, allowing dynamic configuration overrides.

Fixes #136

Bug fix

# How Has This Been Tested?

All tests pass including live API and Ollama integration tests:

```
$ pytest tests/inference_test.py -v
$ tox -e format
$ tox -e lint-src,lint-tests
$ tox -e live-api
$ tox -e ollama-integration
```

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.