### PR TITLE
Add debug logging when debug=True in lx.extract()

### DIFF
--- a/langextract/__init__.py
+++ b/langextract/__init__.py
@@ -174,7 +174,8 @@ def extract(
     )
 
   if debug:
-    from langextract import debug_utils  # pylint: disable=import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
+    from langextract import debug_utils
 
     debug_utils.configure_debug_logging()
 

--- a/langextract/__init__.py
+++ b/langextract/__init__.py
@@ -55,11 +55,7 @@ LanguageModelT = TypeVar("LanguageModelT", bound=inference.BaseLanguageModel)
 # Set up visualization helper at the top level (lx.visualize).
 visualize = visualization.visualize
 
-# Load environment variables from .env file
-# NOTE: This behavior will be changed to opt-in in v2.0.0
-# Libraries typically should not auto-load .env files, but this is kept
-# for backward compatibility. Users can set environment variables directly
-# or use python-dotenv explicitly in their own code.
+# Auto-load .env for backward compatibility (will be opt-in in v2.0.0)
 dotenv.load_dotenv()
 
 
@@ -143,7 +139,9 @@ def extract(
         Suffix for keys containing extraction attributes. Default is
         "_attributes".
       language_model_params: Additional parameters for the language model.
-      debug: Whether to populate debug fields.
+      debug: Whether to enable debug logging. When True, enables detailed logging
+        of function calls, arguments, return values, and timing for the langextract
+        namespace. Note: Debug logging remains enabled for the process once activated.
       model_url: Endpoint URL for self-hosted or on-prem models. Only forwarded
         when the selected `language_model_type` accepts this argument.
       extraction_passes: Number of sequential extraction attempts to improve
@@ -174,6 +172,11 @@ def extract(
         "Examples are required for reliable extraction. Please provide at least"
         " one ExampleData object with sample extractions."
     )
+
+  if debug:
+    from langextract import debug_utils  # pylint: disable=import-outside-toplevel
+
+    debug_utils.configure_debug_logging()
 
   if max_workers is not None and batch_length < max_workers:
     warnings.warn(

--- a/langextract/debug_utils.py
+++ b/langextract/debug_utils.py
@@ -1,0 +1,184 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Debug utilities for LangExtract."""
+
+import functools
+import inspect
+import logging
+import reprlib
+import time
+from typing import Any, Callable, Mapping
+
+_LOG = logging.getLogger("langextract.debug")
+
+# Add NullHandler to prevent "No handler found" warnings
+_langextract_logger = logging.getLogger("langextract")
+if not _langextract_logger.handlers:
+  _langextract_logger.addHandler(logging.NullHandler())
+
+# Sensitive keys to redact
+_REDACT_KEYS = {
+    "api_key",
+    "apikey",
+    "token",
+    "secret",
+    "password",
+    "authorization",
+    "bearer",
+    "jwt",
+}
+_MAX_STR = 500
+_MAX_SEQ = 20
+
+
+def _safe_repr(obj: Any) -> str:
+  """Truncate object repr for safe logging."""
+  r = reprlib.Repr()
+  r.maxstring = _MAX_STR
+  r.maxlist = r.maxtuple = r.maxset = r.maxdict = _MAX_SEQ
+  return r.repr(obj)
+
+
+def _redact_value(name: str, value: Any) -> str:
+  """Redact sensitive values based on parameter name."""
+  if isinstance(name, str) and name.lower() in _REDACT_KEYS:
+    return "<REDACTED>"
+  # If a nested mapping, redact its sensitive keys too
+  if isinstance(value, Mapping):
+    redacted = {}
+    for k, v in value.items():
+      if isinstance(k, str) and k.lower() in _REDACT_KEYS:
+        redacted[k] = "<REDACTED>"
+      else:
+        redacted[k] = _safe_repr(v)
+    return _safe_repr(redacted)
+  return _safe_repr(value)
+
+
+def _redact_mapping(mapping: Mapping[str, Any]) -> dict[str, str]:
+  """Replace sensitive values with <REDACTED>."""
+  out = {}
+  for k, v in mapping.items():
+    out[k] = _redact_value(k, v)
+  return out
+
+
+def _format_bound_args(
+    fn: Callable, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> str:
+  """Format function arguments using signature inspection."""
+  try:
+    sig = inspect.signature(fn)
+    bound = sig.bind_partial(*args, **kwargs)
+    bound.apply_defaults()
+  except Exception:
+    # Fallback (no names) if binding fails
+    parts = [_safe_repr(a) for a in args]
+    if kwargs:
+      red = _redact_mapping(kwargs)
+      parts += [f"{k}={v}" for k, v in sorted(red.items())]
+    return ", ".join(parts)
+
+  parts: list[str] = []
+  for name, value in bound.arguments.items():
+    if name in ("self", "cls"):
+      parts.append(f"{name}=<{type(value).__name__}>")
+    else:
+      parts.append(f"{name}={_redact_value(name, value)}")
+  return ", ".join(parts)
+
+
+def debug_log_calls(fn: Callable) -> Callable:
+  """Log function calls with redacted sensitive data and timing.
+
+  Automatically redacts api_key, token, etc. and truncates large outputs.
+  """
+
+  @functools.wraps(fn)
+  def wrapper(*args, **kwargs):
+    logger = _LOG
+    if not logger.isEnabledFor(logging.DEBUG):
+      return fn(*args, **kwargs)
+
+    fn_qual = getattr(fn, "__qualname__", fn.__name__)
+    mod = getattr(fn, "__module__", "")
+
+    # Format arguments using signature inspection
+    arg_str = _format_bound_args(fn, args, kwargs)
+
+    logger.debug("[%s] CALL: %s(%s)", mod, fn_qual, arg_str, stacklevel=2)
+
+    start = time.perf_counter()
+    try:
+      result = fn(*args, **kwargs)
+    except Exception:
+      dur_ms = (time.perf_counter() - start) * 1000
+      logger.exception(
+          "[%s] EXCEPTION: %s (%.1f ms)", mod, fn_qual, dur_ms, stacklevel=2
+      )
+      raise
+
+    dur_ms = (time.perf_counter() - start) * 1000
+    result_repr = _safe_repr(result)
+    logger.debug(
+        "[%s] RETURN: %s -> %s (%.1f ms)",
+        mod,
+        fn_qual,
+        result_repr,
+        dur_ms,
+        stacklevel=2,
+    )
+    return result
+
+  return wrapper
+
+
+def configure_debug_logging() -> None:
+  """Enable debug logging for the 'langextract' namespace only."""
+  from absl import logging as absl_logging  # pylint: disable=import-outside-toplevel
+
+  logger = logging.getLogger("langextract")
+
+  # Skip if we already added our handler
+  our_handler_exists = any(
+      isinstance(h, logging.StreamHandler)
+      and getattr(h, "langextract_debug", False)
+      for h in logger.handlers
+  )
+  if our_handler_exists:
+    return
+
+  # Respect host handlers - only set level if they exist
+  non_null_handlers = [
+      h for h in logger.handlers if not isinstance(h, logging.NullHandler)
+  ]
+
+  if non_null_handlers:
+    logger.setLevel(logging.DEBUG)
+  else:
+    logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
+    fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    handler.setFormatter(logging.Formatter(fmt))
+    handler.langextract_debug = True
+    logger.addHandler(handler)
+    logger.propagate = False
+
+  # Best-effort absl configuration
+  try:
+    absl_logging.set_verbosity(absl_logging.DEBUG)
+  except Exception:  # pylint: disable=broad-exception-caught
+    pass

--- a/langextract/inference.py
+++ b/langextract/inference.py
@@ -27,6 +27,7 @@ from typing_extensions import deprecated
 import yaml
 
 from langextract import data
+from langextract import debug_utils
 from langextract import exceptions
 from langextract import schema
 
@@ -63,23 +64,28 @@ class BaseLanguageModel(abc.ABC):
     _constraint: A `Constraint` object specifying constraints for model output.
   """
 
-  def __init__(self, constraint: schema.Constraint = schema.Constraint()):
+  @debug_utils.debug_log_calls
+  def __init__(
+      self, constraint: schema.Constraint | None = None, **kwargs: Any
+  ):
     """Initializes the BaseLanguageModel with an optional constraint.
 
     Args:
       constraint: Applies constraints when decoding the output. Defaults to no
         constraint.
+      **kwargs: Additional keyword arguments passed to the model.
     """
-    self._constraint = constraint
+    self._constraint = constraint or schema.Constraint()
     self._schema: schema.BaseSchema | None = None
     self._fence_output_override: bool | None = None
-    self._extra_kwargs: dict[str, Any] = {}
+    self._extra_kwargs: dict[str, Any] = kwargs.copy()
 
   @classmethod
   def get_schema_class(cls) -> type[schema.BaseSchema] | None:
     """Return the schema class this provider supports."""
     return None
 
+  @debug_utils.debug_log_calls
   def apply_schema(self, schema_instance: schema.BaseSchema | None) -> None:
     """Apply a schema instance to this provider.
 

--- a/langextract/tokenizer.py
+++ b/langextract/tokenizer.py
@@ -28,8 +28,7 @@ import dataclasses
 import enum
 import re
 
-from absl import logging
-
+from langextract import debug_utils
 from langextract import exceptions
 
 
@@ -150,6 +149,7 @@ _WORD_PATTERN = re.compile(rf"(?:{_LETTERS_PATTERN}|{_DIGITS_PATTERN})\Z")
 _KNOWN_ABBREVIATIONS = frozenset({"Mr.", "Mrs.", "Ms.", "Dr.", "Prof.", "St."})
 
 
+@debug_utils.debug_log_calls
 def tokenize(text: str) -> TokenizedText:
   """Splits text into tokens (words, digits, or punctuation).
 
@@ -163,7 +163,6 @@ def tokenize(text: str) -> TokenizedText:
   Returns:
     A TokenizedText object containing all extracted tokens.
   """
-  logging.debug("Entering tokenize() with text:\n%r", text)
   tokenized = TokenizedText(text=text)
   previous_end = 0
   for token_index, match in enumerate(_TOKEN_PATTERN.finditer(text)):
@@ -192,7 +191,6 @@ def tokenize(text: str) -> TokenizedText:
       token.token_type = TokenType.PUNCTUATION
     tokenized.tokens.append(token)
     previous_end = end_pos
-  logging.debug("Completed tokenize(). Total tokens: %d", len(tokenized.tokens))
   return tokenized
 
 


### PR DESCRIPTION
# Description

Enables debug logging when `debug=True` is passed to `extract()`. Logs function calls, arguments, returns, and timing with automatic redaction of sensitive keys (`api_key`, `token`, etc.).

Key improvements:
- Library-safe: No global side effects, respects host logging
- Secure: Auto-redacts sensitive parameters and nested dicts
- Correct: Uses `inspect.signature` for proper function/method detection
- Performant: Early exit guards when debugging disabled

**For better issue support**: Debug logs from non-sensitive test data can be shared in GitHub issues to help diagnose problems.

Fixes #127

Related to #4, #132, #63, #139 - Helps debug parsing errors and encoding issues

Feature

# How Has This Been Tested?

```
$ pytest tests -v
$ tox -e format
$ tox -e lint-src,lint-tests
```

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.