### PR TITLE
Add GPT-5 model support and improve temperature handling

### DIFF
--- a/langextract/__init__.py
+++ b/langextract/__init__.py
@@ -68,7 +68,7 @@ def extract(
     language_model_type: Type[LanguageModelT] = inference.GeminiLanguageModel,
     format_type: data.FormatType = data.FormatType.JSON,
     max_char_buffer: int = 1000,
-    temperature: float = 0.5,
+    temperature: float | None = None,
     fence_output: bool | None = None,
     use_schema_constraints: bool = True,
     batch_length: int = 10,
@@ -102,16 +102,19 @@ def extract(
         multiple times. Note that max_workers improves processing speed without
         additional token costs. Refer to your API provider's pricing details and
         monitor usage with small test runs to estimate costs.
-      model_id: The model ID to use for extraction.
+      model_id: The model ID to use for extraction (e.g., 'gemini-2.5-flash').
+        If your model ID is not recognized or you need to use a custom provider,
+        use the 'config' parameter with factory.ModelConfig to specify the
+        provider explicitly.
       language_model_type: [DEPRECATED] The type of language model to use for
         inference. Warning triggers when value differs from the legacy default
         (GeminiLanguageModel). This parameter will be removed in v2.0.0. Use
         the model, config, or model_id parameters instead.
       format_type: The format type for the output (JSON or YAML).
       max_char_buffer: Max number of characters for inference.
-      temperature: The sampling temperature for generation. Higher values (e.g.,
-        0.5) can improve performance with schema constraints on some models by
-        reducing repetitive outputs. Defaults to 0.5.
+      temperature: The sampling temperature for generation. When None (default),
+        uses the model's default temperature. Set to 0.0 for deterministic output
+        or higher values for more variation.
       fence_output: Whether to expect/generate fenced output (```json or
         ```yaml). When True, the model is prompted to generate fenced output and
         the resolver expects it. When False, raw JSON/YAML is expected. When None,

--- a/langextract/providers/registry.py
+++ b/langextract/providers/registry.py
@@ -29,6 +29,7 @@ import typing
 
 from absl import logging
 
+from langextract import exceptions
 from langextract import inference
 
 
@@ -130,9 +131,12 @@ def resolve(model_id: str) -> type[inference.BaseLanguageModel]:
     if any(pattern.search(model_id) for pattern in entry.patterns):
       return entry.loader()
 
-  raise ValueError(
-      f"No provider registered for model_id={model_id!r}. Available patterns:"
-      f" {[str(p.pattern) for e in _ENTRIES for p in e.patterns]}"
+  available_patterns = [str(p.pattern) for e in _ENTRIES for p in e.patterns]
+  raise exceptions.InferenceConfigError(
+      f"No provider registered for model_id={model_id!r}. "
+      f"Available patterns: {available_patterns}\n"
+      "Tip: You can explicitly specify a provider using 'config' parameter "
+      "with factory.ModelConfig and a provider class."
   )
 
 
@@ -181,7 +185,7 @@ def resolve_provider(provider_name: str) -> type[inference.BaseLanguageModel]:
   except re.error:
     pass
 
-  raise ValueError(
+  raise exceptions.InferenceConfigError(
       f"No provider found matching: {provider_name!r}. "
       "Available providers can be listed with list_providers()"
   )

--- a/tests/factory_test.py
+++ b/tests/factory_test.py
@@ -162,10 +162,10 @@ class FactoryTest(absltest.TestCase):
     self.assertIn("API key required", str(cm.exception))
 
   def test_raises_error_when_no_provider_matches_model_id(self):
-    """Factory should raise ValueError for unregistered model IDs."""
+    """Factory should raise InferenceConfigError for unregistered model IDs."""
     config = factory.ModelConfig(model_id="unknown-model")
 
-    with self.assertRaises(ValueError) as cm:
+    with self.assertRaises(exceptions.InferenceConfigError) as cm:
       factory.create_model(config)
 
     self.assertIn("No provider registered", str(cm.exception))

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -555,6 +555,29 @@ class TestOpenAILanguageModel(absltest.TestCase):
     self.assertEqual(call_args.kwargs["n"], 1)
 
   @mock.patch("openai.OpenAI")
+  def test_openai_temperature_none_not_sent(self, mock_openai_class):
+    """Test that temperature=None is not sent to the API."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    # Test with temperature=None in model init
+    model = openai_provider.OpenAILanguageModel(
+        api_key="test-key",
+        temperature=None,
+    )
+
+    list(model.infer(["test prompt"]))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertNotIn("temperature", call_args.kwargs)
+
+  @mock.patch("openai.OpenAI")
   def test_openai_none_values_filtered(self, mock_openai_class):
     """Test that None values are not passed to the API."""
     mock_client = mock.Mock()

--- a/tests/provider_plugin_test.py
+++ b/tests/provider_plugin_test.py
@@ -185,7 +185,9 @@ class PluginSmokeTest(absltest.TestCase):
           list,
           "Registry should remain functional with bad provider",
       )
-      with self.assertRaisesRegex(ValueError, "No provider registered"):
+      with self.assertRaisesRegex(
+          lx.exceptions.InferenceConfigError, "No provider registered"
+      ):
         lx.providers.registry.resolve("bad")
 
   def test_plugin_priority_override_core_provider(self):
@@ -649,7 +651,8 @@ class PluginE2ETest(absltest.TestCase):
         lx.providers.load_plugins_once()
 
         with self.assertRaisesRegex(
-            ValueError, "No provider registered for model_id='test-pip-model"
+            lx.exceptions.InferenceConfigError,
+            "No provider registered for model_id='test-pip-model",
         ):
           lx.providers.registry.resolve("test-pip-model-789")
 

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 from absl.testing import absltest
 
+from langextract import exceptions
 from langextract import inference
 from langextract.providers import registry
 
@@ -94,7 +95,8 @@ class RegistryTest(absltest.TestCase):
   def test_no_provider_registered(self):
     """Test error when no provider matches."""
     with self.assertRaisesRegex(
-        ValueError, "No provider registered for model_id='unknown-model'"
+        exceptions.InferenceConfigError,
+        "No provider registered for model_id='unknown-model'",
     ):
       registry.resolve("unknown-model")
 
@@ -121,7 +123,7 @@ class RegistryTest(absltest.TestCase):
     registry.clear()
 
     # Should fail after clear
-    with self.assertRaises(ValueError):
+    with self.assertRaises(exceptions.InferenceConfigError):
       registry.resolve("temp-model")
 
   def test_list_entries(self):
@@ -166,7 +168,7 @@ class RegistryTest(absltest.TestCase):
     self.assertEqual(registry.resolve("custom-123"), CustomProvider)
 
     # Should not match without digits
-    with self.assertRaises(ValueError):
+    with self.assertRaises(exceptions.InferenceConfigError):
       registry.resolve("custom-abc")
 
   def test_resolve_provider_by_name(self):
@@ -186,7 +188,7 @@ class RegistryTest(absltest.TestCase):
 
   def test_resolve_provider_not_found(self):
     """Test resolve_provider raises for unknown provider."""
-    with self.assertRaises(ValueError) as cm:
+    with self.assertRaises(exceptions.InferenceConfigError) as cm:
       registry.resolve_provider("UnknownProvider")
     self.assertIn("No provider found matching", str(cm.exception))
 


### PR DESCRIPTION
# Description

Adds GPT-5 model support (gpt-5, gpt-5-mini, gpt-5-nano) and improves temperature handling for better model compatibility.

- Register GPT-5 patterns in OpenAI provider
- Default temperature to None (uses model defaults, required for GPT-5-nano)
- Use InferenceConfigError for clearer error messages
- Document using ModelConfig for custom providers

Fixes #141

Feature

# How Has This Been Tested?



Verified with GPT-5-nano API.

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.