### PR TITLE
Expose timeout parameter for Ollama provider

### DIFF
--- a/examples/ollama/README.md
+++ b/examples/ollama/README.md
@@ -23,6 +23,37 @@ docker-compose up
 - `docker-compose.yml` - Production-ready Docker setup with health checks
 - `Dockerfile` - Container definition for LangExtract
 
+## Configuration Options
+
+### Timeout Settings
+
+For slower models or large prompts, you may need to increase the timeout (default: 120 seconds):
+
+```python
+import langextract as lx
+
+result = lx.extract(
+    text_or_documents=input_text,
+    prompt_description=prompt,
+    examples=examples,
+    model_id="llama3.1:70b",  # Larger model may need more time
+    timeout=300,  # 5 minutes
+    model_url="http://localhost:11434",
+)
+```
+
+Or using ModelConfig:
+
+```python
+config = lx.factory.ModelConfig(
+    model_id="llama3.1:70b",
+    provider_kwargs={
+        "model_url": "http://localhost:11434",
+        "timeout": 300,  # 5 minutes
+    }
+)
+```
+
 ## Model License
 
 Ollama models come with their own licenses. For example:

--- a/examples/ollama/quickstart.py
+++ b/examples/ollama/quickstart.py
@@ -50,8 +50,6 @@ def run_extraction(model_id="gemma2:2b", temperature=0.3):
       )
   ]
 
-  # Option 1: Use ModelConfig for explicit configuration
-  # This gives you full control over provider-specific settings
   model_config = lx.factory.ModelConfig(
       model_id=model_id,
       provider_kwargs={
@@ -69,8 +67,7 @@ def run_extraction(model_id="gemma2:2b", temperature=0.3):
       use_schema_constraints=True,
   )
 
-  # Option 2 (simpler): Just pass model_id directly
-  # LangExtract's registry automatically identifies Ollama models like "gemma2:2b"
+  # Option 2: Pass model_id directly (simpler)
   # result = lx.extract(
   #     text_or_documents=input_text,
   #     prompt_description=prompt,


### PR DESCRIPTION
# Description

Increases default timeout for Ollama from 30s to 120s to support slower models. Adds explicit timeout parameter that can be configured via constructor or passed through lx.extract().

This change resolves timeout issues when using Ollama with large models or long contexts.

Fixes #152
Addresses #85 (timeout errors with long context)
Related to #136 (kwargs not being passed through properly)

Bug fix

# How Has This Been Tested?

```
$ python -m pytest tests/inference_test.py::TestOllamaLanguageModel -xvs
$ ./autoformat.sh
```

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.