### PR TITLE
Add API key support for OllamaLanguageModel

### DIFF
--- a/langextract/providers/ollama.py
+++ b/langextract/providers/ollama.py
@@ -48,6 +48,7 @@ Direct provider instantiation (when model ID conflicts with other providers):
     model = OllamaLanguageModel(
         model_id="gemma2:2b",
         model_url="http://localhost:11434",  # optional, uses default if not specified
+        api_key="your-api-key",  # optional, for authenticated proxies like Open WebUI
     )
 
     # Use with extract by passing the model instance
@@ -157,6 +158,7 @@ class OllamaLanguageModel(inference.BaseLanguageModel):
       structured_output_format: str | None = None,  # Deprecated
       constraint: schema.Constraint = schema.Constraint(),
       timeout: int | None = None,
+      api_key: str | None = None,
       **kwargs,
   ) -> None:
     """Initialize the Ollama language model.
@@ -169,9 +171,11 @@ class OllamaLanguageModel(inference.BaseLanguageModel):
       structured_output_format: DEPRECATED - use format_type instead.
       constraint: Schema constraints.
       timeout: Request timeout in seconds. Defaults to 120.
+      api_key: Optional API key for authentication (sent as Bearer token).
       **kwargs: Additional parameters.
     """
     self._requests = requests
+    self._api_key = api_key
 
     # Handle deprecated structured_output_format parameter
     if structured_output_format is not None:
@@ -356,13 +360,19 @@ class OllamaLanguageModel(inference.BaseLanguageModel):
 
     request_timeout = timeout if timeout is not None else _DEFAULT_TIMEOUT
 
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+    }
+    
+    # Add Authorization header if API key is provided
+    if self._api_key:
+      headers['Authorization'] = f'Bearer {self._api_key}'
+
     try:
       response = self._requests.post(
           api_url,
-          headers={
-              'Content-Type': 'application/json',
-              'Accept': 'application/json',
-          },
+          headers=headers,
           json=payload,
           timeout=request_timeout,
       )

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -80,6 +80,55 @@ class TestBaseLanguageModel(absltest.TestCase):
 
 class TestOllamaLanguageModel(absltest.TestCase):
 
+  @mock.patch("requests.post")
+  def test_ollama_authorization_header(self, mock_post):
+    """Verify Authorization header is sent when api_key is provided."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+      "response": '{"test": "value"}',
+      "done": True,
+    }
+    mock_post.return_value = mock_response
+
+    api_key = "test-token-123"
+    model = ollama.OllamaLanguageModel(
+      model_id="test-model",
+      api_key=api_key,
+    )
+
+    prompts = ["Test prompt"]
+    list(model.infer(prompts))
+
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    headers = call_args.kwargs["headers"]
+    self.assertEqual(headers["Authorization"], f"Bearer {api_key}")
+
+  @mock.patch("requests.post")
+  def test_ollama_no_authorization_header_when_no_api_key(self, mock_post):
+    """Verify Authorization header is not sent when api_key is not provided."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+      "response": '{"test": "value"}',
+      "done": True,
+    }
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(
+      model_id="test-model",
+      # No api_key provided
+    )
+
+    prompts = ["Test prompt"]
+    list(model.infer(prompts))
+
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    headers = call_args.kwargs["headers"]
+    self.assertNotIn("Authorization", headers)
+
   @mock.patch("langextract.providers.ollama.OllamaLanguageModel._ollama_query")
   def test_ollama_infer(self, mock_ollama_query):
 


### PR DESCRIPTION
This PR addresses issue #156 by adding `api_key` support to the Ollama provider and passes it via an authorization bearer header. This allows proxies such as Open WebUI to continue working in such environments.