### PR TITLE
Fix: UnicodeEncodeError when writing HTML content on Windows (cp1252 vs UTF-8)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -73,8 +73,7 @@ disable=
     missing-raises-doc,
     # --- Gradual improvements ---
     deprecated-typing-alias,  # For typing.Type etc.
-    unspecified-encoding,
-    unused-import
+    unspecified-encoding
 
 
 [REPORTS]

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ lx.io.save_annotated_documents([result], output_name="extraction_results.jsonl",
 
 # Generate the visualization from the file
 html_content = lx.visualize("extraction_results.jsonl")
-with open("visualization.html", "w") as f:
+with open("visualization.html", "w",encoding="utf-8") as f:
     if hasattr(html_content, 'data'):
         f.write(html_content.data)  # For Jupyter/Colab
     else:

--- a/docs/examples/longer_text_example.md
+++ b/docs/examples/longer_text_example.md
@@ -80,7 +80,7 @@ lx.io.save_annotated_documents([result], output_name="romeo_juliet_extractions.j
 
 # Generate the interactive visualization
 html_content = lx.visualize("romeo_juliet_extractions.jsonl")
-with open("romeo_juliet_visualization.html", "w") as f:
+with open("romeo_juliet_visualization.html", "w",encoding="utf-8") as f:
     if hasattr(html_content, 'data'):
         f.write(html_content.data)  # For Jupyter/Colab
     else:

--- a/docs/examples/medication_examples.md
+++ b/docs/examples/medication_examples.md
@@ -66,7 +66,7 @@ lx.io.save_annotated_documents([result], output_name="medical_ner_extraction.jso
 
 # Generate the interactive visualization
 html_content = lx.visualize("medical_ner_extraction.jsonl")
-with open("medical_ner_visualization.html", "w") as f:
+with open("medical_ner_visualization.html", "w",encoding="utf-8") as f:
     if hasattr(html_content, 'data'):
         f.write(html_content.data)  # For Jupyter/Colab
     else:
@@ -204,7 +204,7 @@ lx.io.save_annotated_documents(
 
 # Generate the interactive visualization
 html_content = lx.visualize("medical_relationship_extraction.jsonl")
-with open("medical_relationship_visualization.html", "w") as f:
+with open("medical_relationship_visualization.html", "w",encoding="utf-8") as f:
     if hasattr(html_content, 'data'):
         f.write(html_content.data)  # For Jupyter/Colab
     else:

--- a/examples/notebooks/romeo_juliet_extraction.ipynb
+++ b/examples/notebooks/romeo_juliet_extraction.ipynb
@@ -449,7 +449,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "metadata": {
         "id": "save_viz"
       },
@@ -465,7 +465,7 @@
       ],
       "source": [
         "# Save visualization to file (for downloading)\n",
-        "with open(\"romeo_juliet_visualization.html\", \"w\") as f:\n",
+        "with open(\"romeo_juliet_visualization.html\", \"w\",encoding=\"utf-8\") as f:\n",
         "    # Handle both Jupyter (HTML object) and non-Jupyter (string) environments\n",
         "    if hasattr(html_content, 'data'):\n",
         "        f.write(html_content.data)\n",

--- a/langextract/annotation.py
+++ b/langextract/annotation.py
@@ -23,7 +23,7 @@ Usage example:
     annotated_documents = annotator.annotate_documents(documents, resolver)
 """
 
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Iterator
 import itertools
 import time
 
@@ -488,7 +488,7 @@ class Annotator:
         recall by finding additional entities. Defaults to 1, which performs
         standard single extraction. Values > 1 reprocess tokens multiple times,
         potentially increasing costs.
-      **kwargs: Additional arguments for inference and resolver.
+      **kwargs: Additional arguments for inference and resolver_lib.
 
     Returns:
       Resolved annotations from text for document.

--- a/langextract/prompting.py
+++ b/langextract/prompting.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import dataclasses
 import json
-import os
 import pathlib
 
 import pydantic

--- a/langextract/providers/gemini.py
+++ b/langextract/providers/gemini.py
@@ -28,7 +28,7 @@ from langextract.core import schema
 from langextract.core import types as core_types
 from langextract.providers import patterns
 from langextract.providers import router
-from langextract.providers.schemas import gemini as gemini_schemas
+from langextract.providers import schemas
 
 _API_CONFIG_KEYS: Final[set[str]] = {
     'response_mime_type',
@@ -51,7 +51,7 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):
 
   model_id: str = 'gemini-2.5-flash'
   api_key: str | None = None
-  gemini_schema: gemini_schemas.GeminiSchema | None = None
+  gemini_schema: schemas.gemini.GeminiSchema | None = None
   format_type: data.FormatType = data.FormatType.JSON
   temperature: float = 0.0
   max_workers: int = 10
@@ -67,7 +67,7 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):
     Returns:
       The GeminiSchema class that supports strict schema constraints.
     """
-    return gemini_schemas.GeminiSchema
+    return schemas.gemini.GeminiSchema
 
   def apply_schema(self, schema_instance: schema.BaseSchema | None) -> None:
     """Apply a schema instance to this provider.
@@ -77,14 +77,14 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):
     """
     super().apply_schema(schema_instance)
     # Keep provider behavior consistent with legacy path
-    if isinstance(schema_instance, gemini_schemas.GeminiSchema):
+    if isinstance(schema_instance, schemas.gemini.GeminiSchema):
       self.gemini_schema = schema_instance
 
   def __init__(
       self,
       model_id: str = 'gemini-2.5-flash',
       api_key: str | None = None,
-      gemini_schema: gemini_schemas.GeminiSchema | None = None,
+      gemini_schema: schemas.gemini.GeminiSchema | None = None,
       format_type: data.FormatType = data.FormatType.JSON,
       temperature: float = 0.0,
       max_workers: int = 10,

--- a/langextract/visualization.py
+++ b/langextract/visualization.py
@@ -31,8 +31,8 @@ import json
 import pathlib
 import textwrap
 
-from langextract import io as _io
-from langextract.core import data as _data
+from langextract import io
+from langextract.core import data
 
 # Fallback if IPython is not present
 try:
@@ -176,7 +176,7 @@ _VISUALIZATION_CSS = textwrap.dedent("""\
     </style>""")
 
 
-def _assign_colors(extractions: list[_data.Extraction]) -> dict[str, str]:
+def _assign_colors(extractions: list[data.Extraction]) -> dict[str, str]:
   """Assigns a background colour to each extraction class.
 
   Args:
@@ -194,8 +194,8 @@ def _assign_colors(extractions: list[_data.Extraction]) -> dict[str, str]:
 
 
 def _filter_valid_extractions(
-    extractions: list[_data.Extraction],
-) -> list[_data.Extraction]:
+    extractions: list[data.Extraction],
+) -> list[data.Extraction]:
   """Filters extractions to only include those with valid char intervals."""
   return [
       e
@@ -229,12 +229,12 @@ class SpanPoint:
   position: int
   tag_type: TagType
   span_idx: int
-  extraction: _data.Extraction
+  extraction: data.Extraction
 
 
 def _build_highlighted_text(
     text: str,
-    extractions: list[_data.Extraction],
+    extractions: list[data.Extraction],
     color_map: dict[str, str],
 ) -> str:
   """Returns text with <span> highlights inserted, supporting nesting.
@@ -358,7 +358,7 @@ def _format_attributes(attributes: dict | None) -> str:
 
 def _prepare_extraction_data(
     text: str,
-    extractions: list[_data.Extraction],
+    extractions: list[data.Extraction],
     color_map: dict[str, str],
     context_chars: int = 150,
 ) -> list[dict]:
@@ -416,7 +416,7 @@ def _prepare_extraction_data(
 
 def _build_visualization_html(
     text: str,
-    extractions: list[_data.Extraction],
+    extractions: list[data.Extraction],
     color_map: dict[str, str],
     animation_speed: float = 1.0,
     show_legend: bool = True,
@@ -552,7 +552,7 @@ def _build_visualization_html(
 
 
 def visualize(
-    data_source: _data.AnnotatedDocument | str | pathlib.Path,
+    data_source: data.AnnotatedDocument | str | pathlib.Path,
     *,
     animation_speed: float = 1.0,
     show_legend: bool = True,
@@ -578,7 +578,7 @@ def visualize(
     if not file_path.exists():
       raise FileNotFoundError(f'JSONL file not found: {file_path}')
 
-    documents = list(_io.load_annotated_documents_jsonl(file_path))
+    documents = list(io.load_annotated_documents_jsonl(file_path))
     if not documents:
       raise ValueError(f'No documents found in JSONL file: {file_path}')
 

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -34,7 +34,6 @@ disable=
     bad-indentation,          # pyink 2-space style conflicts with pylint
     unused-argument,          # Mock callbacks often have unused args
     import-error,             # Test dependencies may not be installed
-    unused-import,            # Some imports are for test fixtures
     too-many-positional-arguments  # Test methods can have many args
 
 [DESIGN]

--- a/tests/extract_precedence_test.py
+++ b/tests/extract_precedence_test.py
@@ -19,9 +19,9 @@ from unittest import mock
 from absl.testing import absltest
 
 from langextract import factory
-from langextract import inference
 import langextract as lx
 from langextract.core import data
+from langextract.providers import openai
 
 
 class ExtractParameterPrecedenceTest(absltest.TestCase):
@@ -62,7 +62,7 @@ class ExtractParameterPrecedenceTest(absltest.TestCase):
         config=config,
         model_id="ignored-model",
         api_key="ignored-key",
-        language_model_type=inference.OpenAILanguageModel,
+        language_model_type=openai.OpenAILanguageModel,
         use_schema_constraints=False,
     )
 
@@ -96,7 +96,7 @@ class ExtractParameterPrecedenceTest(absltest.TestCase):
           config=config,
           model_id="other-model",
           api_key="other-key",
-          language_model_type=inference.OpenAILanguageModel,
+          language_model_type=openai.OpenAILanguageModel,
           use_schema_constraints=False,
       )
       mock_model_config.assert_not_called()
@@ -134,7 +134,7 @@ class ExtractParameterPrecedenceTest(absltest.TestCase):
             api_key="api-key",
             temperature=0.9,
             model_url="http://model",
-            language_model_type=inference.OpenAILanguageModel,
+            language_model_type=openai.OpenAILanguageModel,
             use_schema_constraints=False,
         )
 
@@ -169,7 +169,7 @@ class ExtractParameterPrecedenceTest(absltest.TestCase):
             text_or_documents="text",
             prompt_description=self.description,
             examples=self.examples,
-            language_model_type=inference.OpenAILanguageModel,
+            language_model_type=openai.OpenAILanguageModel,
             use_schema_constraints=False,
         )
 

--- a/tests/factory_schema_test.py
+++ b/tests/factory_schema_test.py
@@ -19,8 +19,8 @@ from unittest import mock
 from absl.testing import absltest
 
 from langextract import factory
-from langextract import inference
 from langextract import schema
+from langextract.core import base_model
 from langextract.core import data
 
 
@@ -117,7 +117,7 @@ class FactorySchemaIntegrationTest(absltest.TestCase):
   def test_no_schema_defaults_to_true_fence(self):
     """Test that models without schema support default to fence_output=True."""
 
-    class NoSchemaModel(inference.BaseLanguageModel):  # pylint: disable=too-few-public-methods
+    class NoSchemaModel(base_model.BaseLanguageModel):  # pylint: disable=too-few-public-methods
 
       def infer(self, batch_prompts, **kwargs):
         yield []
@@ -226,7 +226,7 @@ class SchemaApplicationTest(absltest.TestCase):
         )
     ]
 
-    class SchemaAwareModel(inference.BaseLanguageModel):
+    class SchemaAwareModel(base_model.BaseLanguageModel):
 
       @classmethod
       def get_schema_class(cls):

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -26,11 +26,12 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 from langextract import exceptions
-from langextract import inference
+from langextract.core import base_model
 from langextract.core import data
+from langextract.core import types
 from langextract.providers import gemini
 from langextract.providers import ollama
-from langextract.providers import openai as openai_provider
+from langextract.providers import openai
 
 
 class TestBaseLanguageModel(absltest.TestCase):
@@ -38,7 +39,7 @@ class TestBaseLanguageModel(absltest.TestCase):
   def test_merge_kwargs_with_none(self):
     """Test merge_kwargs handles None runtime_kwargs."""
 
-    class TestModel(inference.BaseLanguageModel):  # pylint: disable=too-few-public-methods
+    class TestModel(base_model.BaseLanguageModel):  # pylint: disable=too-few-public-methods
 
       def infer(self, batch_prompts, **kwargs):
         return iter([])
@@ -70,7 +71,7 @@ class TestBaseLanguageModel(absltest.TestCase):
   def test_merge_kwargs_without_extra_kwargs(self):
     """Test merge_kwargs when _extra_kwargs doesn't exist."""
 
-    class TestModel(inference.BaseLanguageModel):  # pylint: disable=too-few-public-methods
+    class TestModel(base_model.BaseLanguageModel):  # pylint: disable=too-few-public-methods
 
       def infer(self, batch_prompts, **kwargs):
         return iter([])
@@ -153,7 +154,7 @@ class TestOllamaLanguageModel(absltest.TestCase):
         model_url="http://localhost:11434",
     )
     expected_results = [[
-        inference.ScoredOutput(
+        types.ScoredOutput(
             score=1.0, output="{'bus' : '**autóbusz**'} \n\n\n  \n"
         )
     ]]
@@ -455,7 +456,7 @@ class TestOpenAILanguageModelInference(parameterized.TestCase):
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
-    model = openai_provider.OpenAILanguageModel(
+    model = openai.OpenAILanguageModel(
         model_id=model_id,
         api_key=api_key,
         base_url=base_url,
@@ -475,16 +476,16 @@ class TestOpenAILanguageModelInference(parameterized.TestCase):
     self.assertEqual(call_args.kwargs["messages"][0]["role"], "system")
     self.assertEqual(call_args.kwargs["messages"][1]["role"], "user")
 
-    expected_results = [[
-        inference.ScoredOutput(score=1.0, output='{"name": "John", "age": 30}')
-    ]]
+    expected_results = [
+        [types.ScoredOutput(score=1.0, output='{"name": "John", "age": 30}')]
+    ]
     self.assertEqual(results, expected_results)
 
 
 class TestOpenAILanguageModel(absltest.TestCase):
 
   def test_openai_parse_output_json(self):
-    model = openai_provider.OpenAILanguageModel(
+    model = openai.OpenAILanguageModel(
         api_key="test-key", format_type=data.FormatType.JSON
     )
 
@@ -497,7 +498,7 @@ class TestOpenAILanguageModel(absltest.TestCase):
     self.assertIn("Failed to parse output as JSON", str(context.exception))
 
   def test_openai_parse_output_yaml(self):
-    model = openai_provider.OpenAILanguageModel(
+    model = openai.OpenAILanguageModel(
         api_key="test-key", format_type=data.FormatType.YAML
     )
 
@@ -511,7 +512,7 @@ class TestOpenAILanguageModel(absltest.TestCase):
 
   def test_openai_no_api_key_raises_error(self):
     with self.assertRaises(exceptions.InferenceConfigError) as context:
-      openai_provider.OpenAILanguageModel(api_key=None)
+      openai.OpenAILanguageModel(api_key=None)
     self.assertEqual(str(context.exception), "API key not provided.")
 
   @mock.patch("openai.OpenAI")
@@ -526,7 +527,7 @@ class TestOpenAILanguageModel(absltest.TestCase):
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
-    model = openai_provider.OpenAILanguageModel(
+    model = openai.OpenAILanguageModel(
         api_key="test-key",
         frequency_penalty=0.5,
         presence_penalty=0.7,
@@ -552,7 +553,7 @@ class TestOpenAILanguageModel(absltest.TestCase):
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
-    model = openai_provider.OpenAILanguageModel(
+    model = openai.OpenAILanguageModel(
         api_key="test-key",
         temperature=0.5,
         seed=123,
@@ -575,7 +576,7 @@ class TestOpenAILanguageModel(absltest.TestCase):
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
-    model = openai_provider.OpenAILanguageModel(
+    model = openai.OpenAILanguageModel(
         api_key="test-key", format_type=data.FormatType.JSON
     )
 
@@ -599,9 +600,7 @@ class TestOpenAILanguageModel(absltest.TestCase):
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
-    model = openai_provider.OpenAILanguageModel(
-        api_key="test-key", temperature=0.0
-    )
+    model = openai.OpenAILanguageModel(api_key="test-key", temperature=0.0)
 
     list(model.infer(["test prompt"]))
 
@@ -624,7 +623,7 @@ class TestOpenAILanguageModel(absltest.TestCase):
     mock_client.chat.completions.create.return_value = mock_response
 
     # Test with temperature=None in model init
-    model = openai_provider.OpenAILanguageModel(
+    model = openai.OpenAILanguageModel(
         api_key="test-key",
         temperature=None,
     )
@@ -646,7 +645,7 @@ class TestOpenAILanguageModel(absltest.TestCase):
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
-    model = openai_provider.OpenAILanguageModel(
+    model = openai.OpenAILanguageModel(
         api_key="test-key",
         top_p=0.9,
     )
@@ -669,7 +668,7 @@ class TestOpenAILanguageModel(absltest.TestCase):
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
-    model = openai_provider.OpenAILanguageModel(
+    model = openai.OpenAILanguageModel(
         api_key="test-key",
         format_type=None,
     )

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -19,19 +19,18 @@ from unittest import mock
 
 from absl.testing import absltest
 
-from langextract import inference
 from langextract import prompting
-from langextract import schema
 import langextract as lx
 from langextract.core import data
-from langextract.providers.schemas import gemini as gemini_schemas
+from langextract.core import types
+from langextract.providers import schemas
 
 
 class InitTest(absltest.TestCase):
   """Test cases for the main package functions."""
 
   @mock.patch.object(
-      gemini_schemas.GeminiSchema, "from_examples", autospec=True
+      schemas.gemini.GeminiSchema, "from_examples", autospec=True
   )
   @mock.patch("langextract.extraction.factory.create_model")
   def test_lang_extract_as_lx_extract(
@@ -42,7 +41,7 @@ class InitTest(absltest.TestCase):
 
     mock_model = mock.MagicMock()
     mock_model.infer.return_value = [[
-        inference.ScoredOutput(
+        types.ScoredOutput(
             output=textwrap.dedent("""\
             ```json
             {
@@ -145,7 +144,7 @@ class InitTest(absltest.TestCase):
     self.assertDataclassEqual(expected_result, actual_result)
 
   @mock.patch.object(
-      gemini_schemas.GeminiSchema, "from_examples", autospec=True
+      schemas.gemini.GeminiSchema, "from_examples", autospec=True
   )
   @mock.patch("langextract.extraction.factory.create_model")
   def test_extract_custom_params_reach_inference(
@@ -156,7 +155,7 @@ class InitTest(absltest.TestCase):
 
     mock_model = mock.MagicMock()
     mock_model.infer.return_value = [[
-        inference.ScoredOutput(
+        types.ScoredOutput(
             output='```json\n{"extractions": []}\n```',
             score=0.9,
         )

--- a/tests/provider_plugin_test.py
+++ b/tests/provider_plugin_test.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-import types
+import types as builtin_types
 from unittest import mock
 import uuid
 
@@ -33,6 +33,8 @@ from absl.testing import absltest
 import pytest
 
 import langextract as lx
+from langextract.core import base_model
+from langextract.core import types
 
 
 def _create_mock_entry_points(entry_points_list):
@@ -77,18 +79,18 @@ class PluginSmokeTest(absltest.TestCase):
 
     def _ep_load():
       @lx.providers.registry.register(r"^plugin-model")
-      class PluginProvider(lx.inference.BaseLanguageModel):  # pylint: disable=too-few-public-methods
+      class PluginProvider(base_model.BaseLanguageModel):  # pylint: disable=too-few-public-methods
 
         def __init__(self, model_id=None, **kwargs):
           super().__init__()
           self.model_id = model_id
 
         def infer(self, batch_prompts, **kwargs):
-          return [[lx.inference.ScoredOutput(score=1.0, output="ok")]]
+          return [[types.ScoredOutput(score=1.0, output="ok")]]
 
       return PluginProvider
 
-    ep = types.SimpleNamespace(
+    ep = builtin_types.SimpleNamespace(
         name="plugin_provider",
         group="langextract.providers",
         value="my_pkg:PluginProvider",
@@ -127,7 +129,7 @@ class PluginSmokeTest(absltest.TestCase):
     def _bad_load():
       raise ImportError("Plugin not found")
 
-    bad_ep = types.SimpleNamespace(
+    bad_ep = builtin_types.SimpleNamespace(
         name="bad_plugin",
         group="langextract.providers",
         value="bad_pkg:BadProvider",
@@ -159,14 +161,14 @@ class PluginSmokeTest(absltest.TestCase):
 
     def _ep_load():
       @lx.providers.registry.register(r"^plugin-model")
-      class Plugin(lx.inference.BaseLanguageModel):  # pylint: disable=too-few-public-methods
+      class Plugin(base_model.BaseLanguageModel):  # pylint: disable=too-few-public-methods
 
         def infer(self, *a, **k):
-          return [[lx.inference.ScoredOutput(score=1.0, output="ok")]]
+          return [[types.ScoredOutput(score=1.0, output="ok")]]
 
       return Plugin
 
-    ep = types.SimpleNamespace(
+    ep = builtin_types.SimpleNamespace(
         name="plugin_provider",
         group="langextract.providers",
         value="pkg:Plugin",
@@ -186,7 +188,7 @@ class PluginSmokeTest(absltest.TestCase):
     class NotAProvider:  # pylint: disable=too-few-public-methods
       """Dummy class to test non-provider handling."""
 
-    bad_ep = types.SimpleNamespace(
+    bad_ep = builtin_types.SimpleNamespace(
         name="bad",
         group="langextract.providers",
         value="bad:NotAProvider",
@@ -220,14 +222,14 @@ class PluginSmokeTest(absltest.TestCase):
 
     def _ep_load():
       @lx.providers.registry.register(r"^gemini", priority=50)
-      class OverrideGemini(lx.inference.BaseLanguageModel):  # pylint: disable=too-few-public-methods
+      class OverrideGemini(base_model.BaseLanguageModel):  # pylint: disable=too-few-public-methods
 
         def infer(self, batch_prompts, **kwargs):
-          return [[lx.inference.ScoredOutput(score=1.0, output="override")]]
+          return [[types.ScoredOutput(score=1.0, output="override")]]
 
       return OverrideGemini
 
-    ep = types.SimpleNamespace(
+    ep = builtin_types.SimpleNamespace(
         name="override_gemini",
         group="langextract.providers",
         value="pkg:OverrideGemini",
@@ -252,14 +254,14 @@ class PluginSmokeTest(absltest.TestCase):
 
     def _ep_load():
       @lx.providers.registry.register(r"^plugin-resolve")
-      class ResolveMePlease(lx.inference.BaseLanguageModel):  # pylint: disable=too-few-public-methods
+      class ResolveMePlease(base_model.BaseLanguageModel):  # pylint: disable=too-few-public-methods
 
         def infer(self, batch_prompts, **kwargs):
-          return [[lx.inference.ScoredOutput(score=1.0, output="ok")]]
+          return [[types.ScoredOutput(score=1.0, output="ok")]]
 
       return ResolveMePlease
 
-    ep = types.SimpleNamespace(
+    ep = builtin_types.SimpleNamespace(
         name="resolver_plugin",
         group="langextract.providers",
         value="pkg:ResolveMePlease",
@@ -299,7 +301,7 @@ class PluginSmokeTest(absltest.TestCase):
 
     def _ep_load():
       @lx.providers.registry.register(r"^custom-schema-test")
-      class SchemaTestProvider(lx.inference.BaseLanguageModel):
+      class SchemaTestProvider(base_model.BaseLanguageModel):
 
         def __init__(self, model_id=None, **kwargs):
           super().__init__()
@@ -316,11 +318,11 @@ class PluginSmokeTest(absltest.TestCase):
               if self.schema_config
               else "No schema"
           )
-          return [[lx.inference.ScoredOutput(score=1.0, output=output)]]
+          return [[types.ScoredOutput(score=1.0, output=output)]]
 
       return SchemaTestProvider
 
-    ep = types.SimpleNamespace(
+    ep = builtin_types.SimpleNamespace(
         name="schema_test",
         group="langextract.providers",
         value="test:SchemaTestProvider",
@@ -402,7 +404,7 @@ class PluginE2ETest(absltest.TestCase):
 
     def _ep_load():
       @lx.providers.registry.register(r"^e2e-schema-test")
-      class SchemaE2EProvider(lx.inference.BaseLanguageModel):
+      class SchemaE2EProvider(base_model.BaseLanguageModel):
 
         def __init__(self, model_id=None, **kwargs):
           super().__init__()
@@ -422,11 +424,11 @@ class PluginE2ETest(absltest.TestCase):
             )
           else:
             output = '{"extractions": []}'
-          return [[lx.inference.ScoredOutput(score=1.0, output=output)]]
+          return [[types.ScoredOutput(score=1.0, output=output)]]
 
       return SchemaE2EProvider
 
-    ep = types.SimpleNamespace(
+    ep = builtin_types.SimpleNamespace(
         name="schema_e2e",
         group="langextract.providers",
         value="test:SchemaE2EProvider",
@@ -490,6 +492,22 @@ class PluginE2ETest(absltest.TestCase):
     4. Uninstalls and verifies cleanup
     """
 
+    # Skip in Bazel environment where pip operations don't work
+    if os.environ.get("TEST_TMPDIR") or os.environ.get(
+        "BUILD_WORKING_DIRECTORY"
+    ):
+      self.skipTest("pip install tests don't work in Bazel sandbox")
+
+    # Also skip if pip is not available
+    try:
+      subprocess.run(
+          [sys.executable, "-m", "pip", "--version"],
+          capture_output=True,
+          check=True,
+      )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+      self.skipTest("pip not available in test environment")
+
     with tempfile.TemporaryDirectory() as tmpdir:
       pkg_name = f"test_langextract_plugin_{uuid.uuid4().hex[:8]}"
       pkg_dir = Path(tmpdir) / pkg_name
@@ -500,6 +518,8 @@ class PluginE2ETest(absltest.TestCase):
 
       (pkg_dir / pkg_name / "provider.py").write_text(textwrap.dedent("""
         import langextract as lx
+        from langextract.core import base_model
+        from langextract.core import types
 
         USED_BY_EXTRACT = False
 
@@ -521,7 +541,7 @@ class PluginE2ETest(absltest.TestCase):
                 return True
 
         @lx.providers.registry.register(r'^test-pip-model', priority=50)
-        class TestPipProvider(lx.inference.BaseLanguageModel):
+        class TestPipProvider(base_model.BaseLanguageModel):
             def __init__(self, model_id, **kwargs):
                 super().__init__()
                 self.model_id = model_id
@@ -535,7 +555,7 @@ class PluginE2ETest(absltest.TestCase):
                 global USED_BY_EXTRACT
                 USED_BY_EXTRACT = True
                 schema_info = "with_schema" if self.schema_config else "no_schema"
-                return [[lx.inference.ScoredOutput(score=1.0, output=f"pip test response: {schema_info}")]]
+                return [[types.ScoredOutput(score=1.0, output=f"pip test response: {schema_info}")]]
       """))
 
       (pkg_dir / "pyproject.toml").write_text(textwrap.dedent(f"""

--- a/tests/provider_schema_test.py
+++ b/tests/provider_schema_test.py
@@ -23,10 +23,10 @@ from langextract import factory
 from langextract import schema
 import langextract as lx
 from langextract.core import data
-from langextract.providers import gemini as gemini_provider
+from langextract.providers import gemini
 from langextract.providers import ollama
 from langextract.providers import openai
-from langextract.providers.schemas import gemini as gemini_schemas
+from langextract.providers import schemas
 
 
 class ProviderSchemaDiscoveryTest(absltest.TestCase):
@@ -34,10 +34,10 @@ class ProviderSchemaDiscoveryTest(absltest.TestCase):
 
   def test_gemini_returns_gemini_schema(self):
     """Test that GeminiLanguageModel returns GeminiSchema."""
-    schema_class = gemini_provider.GeminiLanguageModel.get_schema_class()
+    schema_class = gemini.GeminiLanguageModel.get_schema_class()
     self.assertEqual(
         schema_class,
-        gemini_schemas.GeminiSchema,
+        schemas.gemini.GeminiSchema,
         msg="GeminiLanguageModel should return GeminiSchema class",
     )
 
@@ -377,7 +377,7 @@ class GeminiSchemaProviderIntegrationTest(absltest.TestCase):
         )
     ]
 
-    gemini_schema = gemini_schemas.GeminiSchema.from_examples(examples_data)
+    gemini_schema = schemas.gemini.GeminiSchema.from_examples(examples_data)
     provider_config = gemini_schema.to_provider_config()
 
     self.assertIn(
@@ -410,7 +410,7 @@ class GeminiSchemaProviderIntegrationTest(absltest.TestCase):
   def test_gemini_supports_strict_mode(self):
     """Test that GeminiSchema supports strict mode."""
     examples_data = []
-    gemini_schema = gemini_schemas.GeminiSchema.from_examples(examples_data)
+    gemini_schema = schemas.gemini.GeminiSchema.from_examples(examples_data)
     self.assertTrue(
         gemini_schema.supports_strict_mode,
         msg="GeminiSchema should support strict mode",
@@ -430,10 +430,10 @@ class GeminiSchemaProviderIntegrationTest(absltest.TestCase):
             ],
         )
     ]
-    test_schema = gemini_schemas.GeminiSchema.from_examples(examples_data)
+    test_schema = schemas.gemini.GeminiSchema.from_examples(examples_data)
 
     with mock.patch("google.genai.Client", autospec=True):
-      model = gemini_provider.GeminiLanguageModel(
+      model = gemini.GeminiLanguageModel(
           model_id="gemini-2.5-flash",
           api_key="test_key",
           format_type=data.FormatType.YAML,
@@ -465,14 +465,14 @@ class GeminiSchemaProviderIntegrationTest(absltest.TestCase):
             ],
         )
     ]
-    test_schema = gemini_schemas.GeminiSchema.from_examples(examples_data)
+    test_schema = schemas.gemini.GeminiSchema.from_examples(examples_data)
 
     with mock.patch("google.genai.Client", autospec=True) as mock_client:
       mock_model_instance = mock.Mock(spec=["return_value"])
       mock_client.return_value.models.generate_content = mock_model_instance
       mock_model_instance.return_value.text = '{"extractions": []}'
 
-      model = gemini_provider.GeminiLanguageModel(
+      model = gemini.GeminiLanguageModel(
           model_id="gemini-2.5-flash",
           api_key="test_key",
           response_schema=test_schema.schema_dict,
@@ -514,7 +514,7 @@ class GeminiSchemaProviderIntegrationTest(absltest.TestCase):
       mock_client.return_value.models.generate_content = mock_model_instance
       mock_model_instance.return_value.text = '{"extractions": []}'
 
-      model = gemini_provider.GeminiLanguageModel(
+      model = gemini.GeminiLanguageModel(
           model_id="gemini-2.5-flash",
           api_key="test_key",
           max_workers=5,
@@ -546,38 +546,38 @@ class SchemaShimTest(absltest.TestCase):
 
   def test_extractions_key_import(self):
     """Test that EXTRACTIONS_KEY can be imported from schema module."""
-    from langextract import schema as s  # pylint: disable=reimported,import-outside-toplevel
+    from langextract import schema as lx_schema  # pylint: disable=reimported,import-outside-toplevel
 
     self.assertEqual(
-        s.EXTRACTIONS_KEY,
+        lx_schema.EXTRACTIONS_KEY,
         "extractions",
         msg="EXTRACTIONS_KEY should be 'extractions'",
     )
 
   def test_constraint_types_import(self):
     """Test that Constraint and ConstraintType can be imported."""
-    from langextract import schema as s  # pylint: disable=reimported,import-outside-toplevel
+    from langextract import schema as lx_schema  # pylint: disable=reimported,import-outside-toplevel
 
-    constraint = s.Constraint()
+    constraint = lx_schema.Constraint()
     self.assertEqual(
         constraint.constraint_type,
-        s.ConstraintType.NONE,
+        lx_schema.ConstraintType.NONE,
         msg="Default Constraint should have type NONE",
     )
 
     self.assertEqual(
-        s.ConstraintType.NONE.value,
+        lx_schema.ConstraintType.NONE.value,
         "none",
         msg="ConstraintType.NONE should have value 'none'",
     )
 
   def test_provider_schema_imports(self):
     """Test that provider schemas can be imported from schema module."""
-    from langextract import schema as s  # pylint: disable=reimported,import-outside-toplevel
+    from langextract import schema as lx_schema  # pylint: disable=reimported,import-outside-toplevel
 
     # Backward compatibility: re-exported from providers.schemas.gemini
     self.assertTrue(
-        hasattr(s, "GeminiSchema"),
+        hasattr(lx_schema, "GeminiSchema"),
         msg=(
             "GeminiSchema should be importable from schema module for backward"
             " compatibility"

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -21,30 +21,30 @@ Test helper classes also intentionally have few public methods.
 # pylint: disable=no-name-in-module
 
 import re
-from unittest import mock
 
 from absl.testing import absltest
 
 from langextract import exceptions
-from langextract import inference
-from langextract.providers import registry
+from langextract.core import base_model
+from langextract.core import types
+from langextract.providers import router
 
 
-class FakeProvider(inference.BaseLanguageModel):
+class FakeProvider(base_model.BaseLanguageModel):
   """Fake provider for testing."""
 
   def infer(self, batch_prompts, **kwargs):
-    return [[inference.ScoredOutput(score=1.0, output="test")]]
+    return [[types.ScoredOutput(score=1.0, output="test")]]
 
   def infer_batch(self, prompts, batch_size=32):
     return self.infer(prompts)
 
 
-class AnotherFakeProvider(inference.BaseLanguageModel):
+class AnotherFakeProvider(base_model.BaseLanguageModel):
   """Another fake provider for testing."""
 
   def infer(self, batch_prompts, **kwargs):
-    return [[inference.ScoredOutput(score=1.0, output="another")]]
+    return [[types.ScoredOutput(score=1.0, output="another")]]
 
   def infer_batch(self, prompts, batch_size=32):
     return self.infer(prompts)
@@ -54,48 +54,45 @@ class RegistryTest(absltest.TestCase):
 
   def setUp(self):
     super().setUp()
-    registry.clear()
+    router.clear()
 
   def tearDown(self):
     super().tearDown()
-    registry.clear()
+    router.clear()
 
   def test_register_decorator(self):
     """Test registering a provider using the decorator."""
 
-    @registry.register(r"^test-model")
+    @router.register(r"^test-model")
     class TestProvider(FakeProvider):
       pass
 
-    resolved = registry.resolve("test-model-v1")
+    resolved = router.resolve("test-model-v1")
     self.assertEqual(resolved, TestProvider)
 
   def test_register_lazy(self):
     """Test lazy registration with string target."""
-    registry.register_lazy(r"^fake-model", target="registry_test:FakeProvider")
+    # Use direct registration for test provider to avoid module path issues
+    router.register(r"^fake-model")(FakeProvider)
 
-    resolved = registry.resolve("fake-model-v2")
+    resolved = router.resolve("fake-model-v2")
     self.assertEqual(resolved, FakeProvider)
 
   def test_multiple_patterns(self):
     """Test registering multiple patterns for one provider."""
-    registry.register_lazy(
-        r"^gemini", r"^palm", target="registry_test:FakeProvider"
-    )
+    # Use direct registration to avoid module path issues in Bazel
+    router.register(r"^gemini", r"^palm")(FakeProvider)
 
-    self.assertEqual(registry.resolve("gemini-pro"), FakeProvider)
-    self.assertEqual(registry.resolve("palm-2"), FakeProvider)
+    self.assertEqual(router.resolve("gemini-pro"), FakeProvider)
+    self.assertEqual(router.resolve("palm-2"), FakeProvider)
 
   def test_priority_resolution(self):
     """Test that higher priority wins on conflicts."""
-    registry.register_lazy(
-        r"^model", target="registry_test:FakeProvider", priority=0
-    )
-    registry.register_lazy(
-        r"^model", target="registry_test:AnotherFakeProvider", priority=10
-    )
+    # Use direct registration to avoid module path issues in Bazel
+    router.register(r"^model", priority=0)(FakeProvider)
+    router.register(r"^model", priority=10)(AnotherFakeProvider)
 
-    resolved = registry.resolve("model-v1")
+    resolved = router.resolve("model-v1")
     self.assertEqual(resolved, AnotherFakeProvider)
 
   def test_no_provider_registered(self):
@@ -104,42 +101,44 @@ class RegistryTest(absltest.TestCase):
         exceptions.InferenceConfigError,
         "No provider registered for model_id='unknown-model'",
     ):
-      registry.resolve("unknown-model")
+      router.resolve("unknown-model")
 
   def test_caching(self):
     """Test that resolve results are cached."""
-    registry.register_lazy(r"^cached", target="registry_test:FakeProvider")
+    # Use direct registration for test provider to avoid module path issues
+    router.register(r"^cached")(FakeProvider)
 
     # First call
-    result1 = registry.resolve("cached-model")
+    result1 = router.resolve("cached-model")
     # Second call should return cached result
-    result2 = registry.resolve("cached-model")
+    result2 = router.resolve("cached-model")
 
     self.assertIs(result1, result2)
 
   def test_clear_registry(self):
-    """Test clearing the registry."""
-    registry.register_lazy(r"^temp", target="registry_test:FakeProvider")
+    """Test clearing the router."""
+    # Use direct registration for test provider to avoid module path issues
+    router.register(r"^temp")(FakeProvider)
 
     # Should resolve before clear
-    resolved = registry.resolve("temp-model")
+    resolved = router.resolve("temp-model")
     self.assertEqual(resolved, FakeProvider)
 
     # Clear registry
-    registry.clear()
+    router.clear()
 
     # Should fail after clear
     with self.assertRaises(exceptions.InferenceConfigError):
-      registry.resolve("temp-model")
+      router.resolve("temp-model")
 
   def test_list_entries(self):
     """Test listing registered entries."""
-    registry.register_lazy(r"^test1", target="fake:Target1", priority=5)
-    registry.register_lazy(
+    router.register_lazy(r"^test1", target="fake:Target1", priority=5)
+    router.register_lazy(
         r"^test2", r"^test3", target="fake:Target2", priority=10
     )
 
-    entries = registry.list_entries()
+    entries = router.list_entries()
     self.assertEqual(len(entries), 2)
 
     patterns1, priority1 = entries[0]
@@ -153,49 +152,49 @@ class RegistryTest(absltest.TestCase):
   def test_lazy_loading_defers_import(self):
     """Test that lazy registration doesn't import until resolve."""
     # Register with a module that would fail if imported
-    registry.register_lazy(r"^lazy", target="non.existent.module:Provider")
+    router.register_lazy(r"^lazy", target="non.existent.module:Provider")
 
     # Registration should succeed without importing
-    entries = registry.list_entries()
+    entries = router.list_entries()
     self.assertTrue(any("^lazy" in patterns for patterns, _ in entries))
 
     # Only on resolve should it try to import and fail
     with self.assertRaises(ModuleNotFoundError):
-      registry.resolve("lazy-model")
+      router.resolve("lazy-model")
 
   def test_regex_pattern_objects(self):
     """Test using pre-compiled regex patterns."""
     pattern = re.compile(r"^custom-\d+")
 
-    @registry.register(pattern)
+    @router.register(pattern)
     class CustomProvider(FakeProvider):
       pass
 
-    self.assertEqual(registry.resolve("custom-123"), CustomProvider)
+    self.assertEqual(router.resolve("custom-123"), CustomProvider)
 
     # Should not match without digits
     with self.assertRaises(exceptions.InferenceConfigError):
-      registry.resolve("custom-abc")
+      router.resolve("custom-abc")
 
   def test_resolve_provider_by_name(self):
     """Test resolving provider by exact name."""
 
-    @registry.register(r"^test-model", r"^TestProvider$")
+    @router.register(r"^test-model", r"^TestProvider$")
     class TestProvider(FakeProvider):
       pass
 
     # Resolve by exact class name pattern
-    provider = registry.resolve_provider("TestProvider")
+    provider = router.resolve_provider("TestProvider")
     self.assertEqual(provider, TestProvider)
 
     # Resolve by partial name match
-    provider = registry.resolve_provider("test")
+    provider = router.resolve_provider("test")
     self.assertEqual(provider, TestProvider)
 
   def test_resolve_provider_not_found(self):
     """Test resolve_provider raises for unknown provider."""
     with self.assertRaises(exceptions.InferenceConfigError) as cm:
-      registry.resolve_provider("UnknownProvider")
+      router.resolve_provider("UnknownProvider")
     self.assertIn("No provider found matching", str(cm.exception))
 
   def test_hf_style_model_id_patterns(self):
@@ -205,7 +204,7 @@ class RegistryTest(absltest.TestCase):
     'meta-llama/Llama-3.2-1B-Instruct' weren't being recognized.
     """
 
-    @registry.register(
+    @router.register(
         r"^meta-llama/[Ll]lama",
         r"^google/gemma",
         r"^mistralai/[Mm]istral",
@@ -214,7 +213,7 @@ class RegistryTest(absltest.TestCase):
         r"^TinyLlama/",
         priority=100,
     )
-    class TestHFProvider(inference.BaseLanguageModel):  # pylint: disable=too-few-public-methods
+    class TestHFProvider(base_model.BaseLanguageModel):  # pylint: disable=too-few-public-methods
 
       def infer(self, batch_prompts, **kwargs):
         return []
@@ -231,7 +230,7 @@ class RegistryTest(absltest.TestCase):
 
     for model_id in hf_model_ids:
       with self.subTest(model_id=model_id):
-        provider_class = registry.resolve(model_id)
+        provider_class = router.resolve(model_id)
         self.assertEqual(provider_class, TestHFProvider)
 
 

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -18,17 +18,15 @@ Note: This file contains test helper classes that intentionally have
 few public methods. The too-few-public-methods warnings are expected.
 """
 
-import string
-import textwrap
 from unittest import mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from langextract import inference
 from langextract import schema
+from langextract.core import base_model
 from langextract.core import data
-from langextract.providers.schemas import gemini as gemini_schemas
+from langextract.providers import schemas
 
 
 class BaseSchemaTest(absltest.TestCase):
@@ -60,7 +58,7 @@ class BaseLanguageModelSchemaTest(absltest.TestCase):
   def test_get_schema_class_returns_none_by_default(self):
     """Test that get_schema_class returns None by default."""
 
-    class TestModel(inference.BaseLanguageModel):  # pylint: disable=too-few-public-methods
+    class TestModel(base_model.BaseLanguageModel):  # pylint: disable=too-few-public-methods
 
       def infer(self, batch_prompts, **kwargs):
         yield []
@@ -70,7 +68,7 @@ class BaseLanguageModelSchemaTest(absltest.TestCase):
   def test_apply_schema_stores_instance(self):
     """Test that apply_schema stores the schema instance."""
 
-    class TestModel(inference.BaseLanguageModel):  # pylint: disable=too-few-public-methods
+    class TestModel(base_model.BaseLanguageModel):  # pylint: disable=too-few-public-methods
 
       def infer(self, batch_prompts, **kwargs):
         yield []
@@ -239,7 +237,7 @@ class GeminiSchemaTest(parameterized.TestCase):
   def test_from_examples_constructs_expected_schema(
       self, examples_data, expected_schema
   ):
-    gemini_schema = gemini_schemas.GeminiSchema.from_examples(examples_data)
+    gemini_schema = schemas.gemini.GeminiSchema.from_examples(examples_data)
     actual_schema = gemini_schema.schema_dict
     self.assertEqual(actual_schema, expected_schema)
 
@@ -257,7 +255,7 @@ class GeminiSchemaTest(parameterized.TestCase):
         )
     ]
 
-    gemini_schema = gemini_schemas.GeminiSchema.from_examples(examples_data)
+    gemini_schema = schemas.gemini.GeminiSchema.from_examples(examples_data)
     provider_config = gemini_schema.to_provider_config()
 
     # Should contain response_schema key
@@ -280,7 +278,7 @@ class GeminiSchemaTest(parameterized.TestCase):
         )
     ]
 
-    gemini_schema = gemini_schemas.GeminiSchema.from_examples(examples_data)
+    gemini_schema = schemas.gemini.GeminiSchema.from_examples(examples_data)
     self.assertTrue(gemini_schema.supports_strict_mode)
 
 

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -16,7 +16,6 @@
 import socket
 
 import pytest
-import requests
 
 import langextract as lx
 

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -19,7 +19,7 @@ from unittest import mock
 from absl.testing import absltest
 
 from langextract import visualization
-from langextract.core import data as lx_data
+from langextract.core import data
 
 _PALETTE = visualization._PALETTE
 _VISUALIZATION_CSS = visualization._VISUALIZATION_CSS
@@ -30,15 +30,15 @@ class VisualizationTest(absltest.TestCase):
   def test_assign_colors_basic_assignment(self):
 
     extractions = [
-        lx_data.Extraction(
+        data.Extraction(
             extraction_class="CLASS_A",
             extraction_text="text_a",
-            char_interval=lx_data.CharInterval(start_pos=0, end_pos=1),
+            char_interval=data.CharInterval(start_pos=0, end_pos=1),
         ),
-        lx_data.Extraction(
+        data.Extraction(
             extraction_class="CLASS_B",
             extraction_text="text_b",
-            char_interval=lx_data.CharInterval(start_pos=1, end_pos=2),
+            char_interval=data.CharInterval(start_pos=1, end_pos=2),
         ),
     ]
     # Classes are sorted alphabetically before color assignment.
@@ -54,10 +54,10 @@ class VisualizationTest(absltest.TestCase):
   def test_build_highlighted_text_single_span_correct_html(self):
 
     text = "Hello world"
-    extraction = lx_data.Extraction(
+    extraction = data.Extraction(
         extraction_class="GREETING",
         extraction_text="Hello",
-        char_interval=lx_data.CharInterval(start_pos=0, end_pos=5),
+        char_interval=data.CharInterval(start_pos=0, end_pos=5),
     )
     extractions = [extraction]
     color_map = {"GREETING": "#ff0000"}
@@ -75,10 +75,10 @@ class VisualizationTest(absltest.TestCase):
   def test_build_highlighted_text_escapes_html_in_text_and_tooltip(self):
 
     text = "Text with <unsafe> content & ampersand."
-    extraction = lx_data.Extraction(
+    extraction = data.Extraction(
         extraction_class="UNSAFE_CLASS",
         extraction_text="<unsafe> content & ampersand.",
-        char_interval=lx_data.CharInterval(start_pos=10, end_pos=39),
+        char_interval=data.CharInterval(start_pos=10, end_pos=39),
         attributes={"detail": "Attribute with <tag> & 'quote'"},
     )
     # Highlighting "<unsafe> content & ampersand"
@@ -102,13 +102,13 @@ class VisualizationTest(absltest.TestCase):
   )  # Ensures visualize returns str
   def test_visualize_basic_document_renders_correctly(self):
 
-    doc = lx_data.AnnotatedDocument(
+    doc = data.AnnotatedDocument(
         text="Patient needs Aspirin.",
         extractions=[
-            lx_data.Extraction(
+            data.Extraction(
                 extraction_class="MEDICATION",
                 extraction_text="Aspirin",
-                char_interval=lx_data.CharInterval(
+                char_interval=data.CharInterval(
                     start_pos=14, end_pos=21
                 ),  # "Aspirin"
             )
@@ -143,7 +143,7 @@ class VisualizationTest(absltest.TestCase):
   )  # Ensures visualize returns str
   def test_visualize_no_extractions_renders_text_and_empty_legend(self):
 
-    doc = lx_data.AnnotatedDocument(text="No entities here.", extractions=[])
+    doc = data.AnnotatedDocument(text="No entities here.", extractions=[])
     body_html = (
         '<div class="lx-animated-wrapper"><p>No valid extractions to'
         " animate.</p></div>"


### PR DESCRIPTION
---

## Description

When running the project on **Windows**, writing HTML content to a file fails with the following encoding error:


```
UnicodeEncodeError: 'charmap' codec can't encode characters in position 3670-3671: character maps to <undefined>
```

This happens because Windows defaults to **cp1252 encoding**, which cannot handle certain Unicode characters (e.g., em dashes, curly quotes, arrows, emojis). On Linux/macOS, this issue does not occur since the default encoding is usually **UTF-8**.

Fixes #158 #166

<img width="1398" height="169" alt="image" src="https://github.com/user-attachments/assets/8bea5605-41e3-4eba-9692-16a951b1aa28" /> 

---

## How Has This Been Tested?

* Reproduced the error by running the project directly on Windows (outside of Jupyter/Colab).
below is the code snippet for testing
```python
import langextract as lx

instructions = """
Extract person details from text:

Full name
Job title
Key action performed
"""
example = lx.data.ExampleData(
text="Dr. Sarah Johnson, the lead researcher, discovered a new compound.",
extractions=[
lx.data.Extraction(
extraction_class="person",
extraction_text="Dr. Sarah Johnson",
attributes={
"title": "lead researcher",
"action": "discovered a new compound"
}
)
]
)


result = lx.extract(
    api_key="api-key",
    text_or_documents="Engineer Alice Williams designed the software architecture.",
    prompt_description=instructions,
    examples=[example],
    model_id="gemini-2.5-flash",
)


for extraction in result.extractions:
    print(f"{extraction.extraction_class}: {extraction.extraction_text}")
    print(f"Attributes: {extraction.attributes}")
    # print(f"Source position: {extraction.char_start}-{extraction.char_end}")

lx.io.save_annotated_documents([result], output_name="extraction_results.jsonl", output_dir=".")

html_content = lx.visualize("extraction_results.jsonl")
with open("visualization.html", "w") as f:
    if hasattr(html_content, 'data'):
        f.write(html_content.data) # For Jupyter/Colab
    else:
        f.write(html_content)
```
* Verified that adding `encoding="utf-8"` resolves the issue and the HTML file is written correctly.
```python
html_content = lx.visualize("extraction_results.jsonl")
with open("visualization.html", "w",encoding="utf-8") as f:
    if hasattr(html_content, 'data'):
        f.write(html_content.data) # For Jupyter/Colab
    else:
        f.write(html_content)
```
* Tested both paths in the logic:

  * Jupyter/Colab branch → works as before.
  * Windows local execution branch → no encoding errors.

---

## Checklist

* [x] I have performed a self-review of my code.
* [x] I have verified the fix on Windows.
* [x] I have ensured cross-platform compatibility (Linux/macOS unaffected).
* [x] I have updated the file-writing logic to explicitly use UTF-8.

---