### PR TITLE
Import modules not classes per Google style

### DIFF
--- a/langextract/annotation.py
+++ b/langextract/annotation.py
@@ -33,9 +33,9 @@ from langextract import chunking
 from langextract import progress
 from langextract import prompting
 from langextract import resolver as resolver_lib
+from langextract.core import base_model
 from langextract.core import data
 from langextract.core import exceptions
-from langextract.core.base_model import BaseLanguageModel
 
 ATTRIBUTE_SUFFIX = "_attributes"
 
@@ -160,7 +160,7 @@ class Annotator:
 
   def __init__(
       self,
-      language_model: BaseLanguageModel,
+      language_model: base_model.BaseLanguageModel,
       prompt_template: prompting.PromptTemplateStructured,
       format_type: data.FormatType = data.FormatType.YAML,
       attribute_suffix: str = ATTRIBUTE_SUFFIX,

--- a/langextract/core/base_model.py
+++ b/langextract/core/base_model.py
@@ -22,8 +22,7 @@ from typing import Any, Mapping
 
 import yaml
 
-from langextract.core import types as core_types
-from langextract.core.types import FormatType
+from langextract.core import types
 
 __all__ = ['BaseLanguageModel']
 
@@ -35,9 +34,7 @@ class BaseLanguageModel(abc.ABC):
     _constraint: A `Constraint` object specifying constraints for model output.
   """
 
-  def __init__(
-      self, constraint: core_types.Constraint | None = None, **kwargs: Any
-  ):
+  def __init__(self, constraint: types.Constraint | None = None, **kwargs: Any):
     """Initializes the BaseLanguageModel with an optional constraint.
 
     Args:
@@ -45,7 +42,7 @@ class BaseLanguageModel(abc.ABC):
         constraint.
       **kwargs: Additional keyword arguments passed to the model.
     """
-    self._constraint = constraint or core_types.Constraint()
+    self._constraint = constraint or types.Constraint()
     self._schema: Any = None  # BaseSchema instance
     self._fence_output_override: bool | None = None
     self._extra_kwargs: dict[str, Any] = kwargs.copy()
@@ -112,7 +109,7 @@ class BaseLanguageModel(abc.ABC):
   @abc.abstractmethod
   def infer(
       self, batch_prompts: Sequence[str], **kwargs
-  ) -> Iterator[Sequence[core_types.ScoredOutput]]:
+  ) -> Iterator[Sequence[types.ScoredOutput]]:
     """Implements language model inference.
 
     Args:
@@ -127,7 +124,7 @@ class BaseLanguageModel(abc.ABC):
 
   def infer_batch(
       self, prompts: Sequence[str], batch_size: int = 32  # pylint: disable=unused-argument
-  ) -> list[list[core_types.ScoredOutput]]:
+  ) -> list[list[types.ScoredOutput]]:
     """Batch inference with configurable batch size.
 
     This is a convenience method that collects all results from infer().
@@ -160,10 +157,10 @@ class BaseLanguageModel(abc.ABC):
       ValueError: If output cannot be parsed as JSON or YAML.
     """
     # Check if we have a format_type attribute (providers should set this)
-    format_type = getattr(self, 'format_type', FormatType.JSON)
+    format_type = getattr(self, 'format_type', types.FormatType.JSON)
 
     try:
-      if format_type == FormatType.JSON:
+      if format_type == types.FormatType.JSON:
         return json.loads(output)
       else:
         return yaml.safe_load(output)

--- a/langextract/core/data.py
+++ b/langextract/core/data.py
@@ -20,7 +20,9 @@ import enum
 import uuid
 
 from langextract.core import tokenizer
-from langextract.core.types import FormatType
+from langextract.core import types
+
+FormatType = types.FormatType  # Backward compat
 
 
 class AlignmentStatus(enum.Enum):

--- a/langextract/core/schema.py
+++ b/langextract/core/schema.py
@@ -19,9 +19,7 @@ import abc
 from collections.abc import Sequence
 from typing import Any, TYPE_CHECKING
 
-from langextract.core.types import Constraint
-from langextract.core.types import ConstraintType
-from langextract.core.types import FormatType
+from langextract.core import types
 
 if TYPE_CHECKING:
   from langextract.core import data
@@ -35,6 +33,10 @@ __all__ = [
 ]
 
 EXTRACTIONS_KEY = "extractions"  # Shared key for extraction arrays in JSON/YAML
+
+# Backward compat re-exports
+ConstraintType = types.ConstraintType
+Constraint = types.Constraint
 
 
 class BaseSchema(abc.ABC):
@@ -92,11 +94,11 @@ class FormatModeSchema(BaseSchema):
   support field-level constraints.
   """
 
-  def __init__(self, format_type: FormatType = FormatType.JSON):
+  def __init__(self, format_type: types.FormatType = types.FormatType.JSON):
     """Initialize with a format type."""
     self.format_type = format_type
     # Keep _format for backward compatibility with tests
-    self._format = "json" if format_type == FormatType.JSON else "yaml"
+    self._format = "json" if format_type == types.FormatType.JSON else "yaml"
 
   @classmethod
   def from_examples(
@@ -106,7 +108,7 @@ class FormatModeSchema(BaseSchema):
   ) -> FormatModeSchema:
     """Factory method to build a schema instance from example data."""
     # Default to JSON format
-    return cls(format_type=FormatType.JSON)
+    return cls(format_type=types.FormatType.JSON)
 
   def to_provider_config(self) -> dict[str, Any]:
     """Convert schema to provider-specific configuration."""
@@ -124,9 +126,13 @@ class FormatModeSchema(BaseSchema):
     """Sync format type with provider kwargs."""
     if "format_type" in kwargs:
       self.format_type = kwargs["format_type"]
-      self._format = "json" if self.format_type == FormatType.JSON else "yaml"
+      self._format = (
+          "json" if self.format_type == types.FormatType.JSON else "yaml"
+      )
     if "format" in kwargs:
       self._format = kwargs["format"]
       self.format_type = (
-          FormatType.JSON if self._format == "json" else FormatType.YAML
+          types.FormatType.JSON
+          if self._format == "json"
+          else types.FormatType.YAML
       )

--- a/langextract/exceptions.py
+++ b/langextract/exceptions.py
@@ -21,14 +21,16 @@ All new code should import directly from langextract.core.exceptions.
 
 from __future__ import annotations
 
-# Re-export all exceptions from core for backward compatibility
-from langextract.core.exceptions import InferenceConfigError
-from langextract.core.exceptions import InferenceError
-from langextract.core.exceptions import InferenceOutputError
-from langextract.core.exceptions import InferenceRuntimeError
-from langextract.core.exceptions import LangExtractError
-from langextract.core.exceptions import ProviderError
-from langextract.core.exceptions import SchemaError
+from langextract.core import exceptions as core_exceptions
+
+# Backward compat re-exports
+InferenceConfigError = core_exceptions.InferenceConfigError
+InferenceError = core_exceptions.InferenceError
+InferenceOutputError = core_exceptions.InferenceOutputError
+InferenceRuntimeError = core_exceptions.InferenceRuntimeError
+LangExtractError = core_exceptions.LangExtractError
+ProviderError = core_exceptions.ProviderError
+SchemaError = core_exceptions.SchemaError
 
 __all__ = [
     "LangExtractError",

--- a/langextract/factory.py
+++ b/langextract/factory.py
@@ -26,8 +26,8 @@ import os
 import typing
 
 from langextract import providers
+from langextract.core import base_model
 from langextract.core import exceptions
-from langextract.core.base_model import BaseLanguageModel
 from langextract.providers import router
 
 
@@ -93,7 +93,7 @@ def create_model(
     use_schema_constraints: bool = False,
     fence_output: bool | None = None,
     return_fence_output: bool = False,
-) -> BaseLanguageModel | tuple[BaseLanguageModel, bool]:
+) -> base_model.BaseLanguageModel | tuple[base_model.BaseLanguageModel, bool]:
   """Create a language model instance from configuration.
 
   Args:
@@ -166,7 +166,7 @@ def create_model_from_id(
     model_id: str | None = None,
     provider: str | None = None,
     **provider_kwargs: typing.Any,
-) -> BaseLanguageModel:
+) -> base_model.BaseLanguageModel:
   """Convenience function to create a model.
 
   Args:
@@ -188,7 +188,7 @@ def _create_model_with_schema(
     examples: typing.Sequence[typing.Any] | None = None,
     use_schema_constraints: bool = True,
     fence_output: bool | None = None,
-) -> BaseLanguageModel:
+) -> base_model.BaseLanguageModel:
   """Internal helper to create a model with optional schema constraints.
 
   This function creates a language model and optionally configures it with

--- a/langextract/plugins.py
+++ b/langextract/plugins.py
@@ -26,7 +26,7 @@ from typing import Dict, List, Type
 
 from absl import logging
 
-from langextract.core.base_model import BaseLanguageModel
+from langextract.core import base_model
 
 __all__ = ["available_providers", "get_provider_class"]
 
@@ -123,7 +123,7 @@ def available_providers(
   return providers
 
 
-def _load_class(spec: str) -> Type[BaseLanguageModel]:
+def _load_class(spec: str) -> Type[base_model.BaseLanguageModel]:
   """Load a provider class from module:Class specification.
 
   Args:
@@ -157,7 +157,9 @@ def _load_class(spec: str) -> Type[BaseLanguageModel]:
     ) from e
 
   # Validate it's a language model
-  if not isinstance(cls, type) or not issubclass(cls, BaseLanguageModel):
+  if not isinstance(cls, type) or not issubclass(
+      cls, base_model.BaseLanguageModel
+  ):
     # Fallback: check structural compatibility for non-ABC classes
     missing = []
     for method in ("infer", "parse_output"):
@@ -183,7 +185,7 @@ def _load_class(spec: str) -> Type[BaseLanguageModel]:
 @lru_cache(maxsize=None)  # Cache all loaded classes
 def get_provider_class(
     name: str, allow_override: bool = False, include_optional: bool = True
-) -> Type[BaseLanguageModel]:
+) -> Type[base_model.BaseLanguageModel]:
   """Get a provider class by name.
 
   Args:

--- a/langextract/providers/__init__.py
+++ b/langextract/providers/__init__.py
@@ -22,19 +22,22 @@ management in build systems.
 import importlib
 from importlib import metadata
 import os
-import warnings
 
 from absl import logging
 
+from langextract.providers import router
 from langextract.providers.builtin_registry import BUILTIN_PROVIDERS
 from langextract.providers.router import register
 from langextract.providers.router import register_lazy
+
+registry = router  # Backward compat alias
 
 __all__ = [
     'gemini',
     'openai',
     'ollama',
     'router',
+    'registry',  # Backward compat
     'schemas',
     'load_plugins_once',
     'load_builtins_once',
@@ -154,13 +157,6 @@ def _reset_for_testing() -> None:
 def __getattr__(name: str):
   """Lazy loading for submodules."""
   if name == 'router':
-    return importlib.import_module('langextract.providers.router')
-  elif name == 'registry':  # Backward compat
-    warnings.warn(
-        'providers.registry is deprecated, use providers.router instead',
-        FutureWarning,
-        stacklevel=2,
-    )
     return importlib.import_module('langextract.providers.router')
   elif name == 'schemas':
     return importlib.import_module('langextract.providers.schemas')

--- a/langextract/providers/gemini.py
+++ b/langextract/providers/gemini.py
@@ -21,11 +21,11 @@ import concurrent.futures
 import dataclasses
 from typing import Any, Final, Iterator, Sequence
 
+from langextract.core import base_model
 from langextract.core import data
 from langextract.core import exceptions
 from langextract.core import schema
 from langextract.core import types as core_types
-from langextract.core.base_model import BaseLanguageModel
 from langextract.providers import patterns
 from langextract.providers import router
 from langextract.providers.schemas import gemini as gemini_schemas
@@ -46,7 +46,7 @@ _API_CONFIG_KEYS: Final[set[str]] = {
     priority=patterns.GEMINI_PRIORITY,
 )
 @dataclasses.dataclass(init=False)
-class GeminiLanguageModel(BaseLanguageModel):
+class GeminiLanguageModel(base_model.BaseLanguageModel):
   """Language model inference using Google's Gemini API with structured output."""
 
   model_id: str = 'gemini-2.5-flash'

--- a/langextract/providers/ollama.py
+++ b/langextract/providers/ollama.py
@@ -78,11 +78,10 @@ import warnings
 import requests
 
 # Import from core modules directly
+from langextract.core import base_model
 from langextract.core import exceptions
 from langextract.core import schema
 from langextract.core import types as core_types
-from langextract.core.base_model import BaseLanguageModel
-from langextract.core.types import FormatType
 from langextract.providers import patterns
 from langextract.providers import router
 
@@ -99,7 +98,7 @@ _DEFAULT_NUM_CTX = 2048
     priority=patterns.OLLAMA_PRIORITY,
 )
 @dataclasses.dataclass(init=False)
-class OllamaLanguageModel(BaseLanguageModel):
+class OllamaLanguageModel(base_model.BaseLanguageModel):
   """Language model inference class using Ollama based host.
 
   Timeout can be set via constructor or passed through lx.extract():
@@ -108,7 +107,7 @@ class OllamaLanguageModel(BaseLanguageModel):
 
   _model: str
   _model_url: str
-  format_type: FormatType = FormatType.JSON
+  format_type: core_types.FormatType = core_types.FormatType.JSON
   _constraint: schema.Constraint = dataclasses.field(
       default_factory=schema.Constraint, repr=False, compare=False
   )
@@ -130,7 +129,7 @@ class OllamaLanguageModel(BaseLanguageModel):
       model_id: str,
       model_url: str = _OLLAMA_DEFAULT_MODEL_URL,
       base_url: str | None = None,  # Alias for model_url
-      format_type: FormatType | None = None,
+      format_type: core_types.FormatType | None = None,
       structured_output_format: str | None = None,  # Deprecated
       constraint: schema.Constraint = schema.Constraint(),
       timeout: int | None = None,
@@ -161,18 +160,22 @@ class OllamaLanguageModel(BaseLanguageModel):
       # Only use structured_output_format if format_type wasn't explicitly provided
       if format_type is None:
         format_type = (
-            FormatType.JSON
+            core_types.FormatType.JSON
             if structured_output_format == 'json'
-            else FormatType.YAML
+            else core_types.FormatType.YAML
         )
 
     fmt = kwargs.pop('format', None)
     if format_type is None and fmt in ('json', 'yaml'):
-      format_type = FormatType.JSON if fmt == 'json' else FormatType.YAML
+      format_type = (
+          core_types.FormatType.JSON
+          if fmt == 'json'
+          else core_types.FormatType.YAML
+      )
 
     # Default to JSON if neither parameter was provided
     if format_type is None:
-      format_type = FormatType.JSON
+      format_type = core_types.FormatType.JSON
 
     self._model = model_id
     # Support both model_url and base_url parameters
@@ -204,7 +207,7 @@ class OllamaLanguageModel(BaseLanguageModel):
             prompt=prompt,
             model=self._model,
             structured_output_format='json'
-            if self.format_type == FormatType.JSON
+            if self.format_type == core_types.FormatType.JSON
             else 'yaml',
             model_url=self._model_url,
             **combined_kwargs,
@@ -285,7 +288,7 @@ class OllamaLanguageModel(BaseLanguageModel):
     model_url = model_url or self._model_url
     if structured_output_format is None:
       structured_output_format = (
-          'json' if self.format_type == FormatType.JSON else 'yaml'
+          'json' if self.format_type == core_types.FormatType.JSON else 'yaml'
       )
 
     options: dict[str, Any] = {}

--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -21,11 +21,11 @@ import concurrent.futures
 import dataclasses
 from typing import Any, Iterator, Sequence
 
+from langextract.core import base_model
 from langextract.core import data
 from langextract.core import exceptions
 from langextract.core import schema
 from langextract.core import types as core_types
-from langextract.core.base_model import BaseLanguageModel
 from langextract.providers import patterns
 from langextract.providers import router
 
@@ -35,7 +35,7 @@ from langextract.providers import router
     priority=patterns.OPENAI_PRIORITY,
 )
 @dataclasses.dataclass(init=False)
-class OpenAILanguageModel(BaseLanguageModel):
+class OpenAILanguageModel(base_model.BaseLanguageModel):
   """Language model inference using OpenAI's API with structured output."""
 
   model_id: str = 'gpt-4o-mini'

--- a/langextract/providers/schemas/__init__.py
+++ b/langextract/providers/schemas/__init__.py
@@ -15,6 +15,8 @@
 """Provider-specific schema implementations."""
 from __future__ import annotations
 
-from langextract.providers.schemas.gemini import GeminiSchema
+from langextract.providers.schemas import gemini
+
+GeminiSchema = gemini.GeminiSchema  # Backward compat
 
 __all__ = ["GeminiSchema"]


### PR DESCRIPTION
# Description

Refactor imports to follow Google Python style guide - import modules instead of classes directly.

Fixes #N/A

Code health

# How Has This Been Tested?

```
$ tox -e format,lint-src,lint-tests,py313,live-api,ollama-integration,plugin-smoke,plugin-integration
```

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes
- [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.