### PR TITLE
Corrected filename for relationship json

### DIFF
--- a/docs/examples/medication_examples.md
+++ b/docs/examples/medication_examples.md
@@ -198,7 +198,7 @@ for med_name, extractions in medication_groups.items():
 # Save and visualize the results
 lx.io.save_annotated_documents(
     [result],
-    output_name="medical_ner_extraction.jsonl",
+    output_name="medical_relationship_extraction.jsonl",
     output_dir="."
 )
 


### PR DESCRIPTION
The relationship extraction example saves the output to "medical_ner_extraction.jsonl" but then loads from "medical_relationship_extraction.jsonl". Corrected the filename to save as "medical_relationship_extraction.jsonl"