### PR TITLE
feat: Add OpenAI reasoning and Ollama auth support

### DIFF
--- a/langextract/providers/ollama.py
+++ b/langextract/providers/ollama.py
@@ -73,6 +73,8 @@ from __future__ import annotations
 
 import dataclasses
 from typing import Any, Iterator, Mapping, Sequence
+from urllib.parse import urljoin
+from urllib.parse import urlparse
 import warnings
 
 import requests
@@ -103,6 +105,9 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
 
   Timeout can be set via constructor or passed through lx.extract():
     lx.extract(..., language_model_params={"timeout": 300})
+
+  Authentication is supported for proxied Ollama instances:
+    lx.extract(..., language_model_params={"api_key": "sk-..."})
   """
 
   _model: str
@@ -114,6 +119,10 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
   _extra_kwargs: dict[str, Any] = dataclasses.field(
       default_factory=dict, repr=False, compare=False
   )
+  # Authentication
+  _api_key: str | None = None
+  _auth_scheme: str = 'Bearer'
+  _auth_header: str = 'Authorization'
 
   @classmethod
   def get_schema_class(cls) -> type[schema.BaseSchema] | None:
@@ -123,6 +132,17 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
       The FormatModeSchema class that enables JSON mode (non-strict).
     """
     return schema.FormatModeSchema
+
+  def __repr__(self) -> str:
+    """Return string representation with redacted API key."""
+    api_key_display = '[REDACTED]' if self._api_key else None
+    return (
+        f'{self.__class__.__name__}('
+        f'model={self._model!r}, '
+        f'model_url={self._model_url!r}, '
+        f'format_type={self.format_type!r}, '
+        f'api_key={api_key_display})'
+    )
 
   def __init__(
       self,
@@ -178,10 +198,26 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
       format_type = core_types.FormatType.JSON
 
     self._model = model_id
-    # Support both model_url and base_url parameters
+    # Support both model_url and base_url
     self._model_url = base_url or model_url or _OLLAMA_DEFAULT_MODEL_URL
     self.format_type = format_type
     self._constraint = constraint
+
+    # Extract authentication
+    self._api_key = kwargs.pop('api_key', None)
+    self._auth_scheme = kwargs.pop('auth_scheme', 'Bearer')
+    self._auth_header = kwargs.pop('auth_header', 'Authorization')
+
+    if self._api_key:
+      host = urlparse(self._model_url).hostname
+      if host in ('localhost', '127.0.0.1', '::1'):
+        warnings.warn(
+            'API key provided for localhost Ollama instance. '
+            "Native Ollama doesn't require authentication. "
+            'This is typically only needed for proxied instances.',
+            UserWarning,
+        )
+
     super().__init__(constraint=constraint)
     if timeout is not None:
       kwargs['timeout'] = timeout
@@ -212,7 +248,6 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
             model_url=self._model_url,
             **combined_kwargs,
         )
-        # No score for Ollama. Default to 1.0
         yield [core_types.ScoredOutput(score=1.0, output=response['response'])]
       except Exception as e:
         raise exceptions.InferenceRuntimeError(
@@ -237,7 +272,7 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
       num_threads: int | None = None,
       num_ctx: int | None = None,
       stop: str | list[str] | None = None,
-      **kwargs,  # pylint: disable=unused-argument
+      **kwargs,
   ) -> Mapping[str, Any]:
     """Sends a prompt to an Ollama model and returns the generated response.
 
@@ -286,7 +321,7 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
     """
     model = model or self._model
     model_url = model_url or self._model_url
-    if structured_output_format is None:
+    if structured_output_format is None and self.format_type is not None:
       structured_output_format = (
           'json' if self.format_type == core_types.FormatType.JSON else 'yaml'
       )
@@ -316,31 +351,60 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
     else:
       options['num_ctx'] = _DEFAULT_NUM_CTX
 
-    api_url = model_url + '/api/generate'
+    reserved_top_level = {
+        'model',
+        'prompt',
+        'system',
+        'stop',
+        'format',
+        'stream',
+        'raw',
+    }
+    for key, value in kwargs.items():
+      if value is None:
+        continue
+      if key in reserved_top_level:
+        continue
+      if key not in options:
+        options[key] = value
 
-    payload = {
+    api_url = urljoin(
+        model_url if model_url.endswith('/') else model_url + '/',
+        'api/generate',
+    )
+
+    payload: dict[str, Any] = {
         'model': model,
         'prompt': prompt,
         'system': system,
         'stream': False,
         'raw': raw,
-        'format': structured_output_format,
         'options': options,
     }
 
-    # Add stop sequences if provided (top-level in Ollama API)
+    if structured_output_format is not None:
+      payload['format'] = structured_output_format
+
     if stop is not None:
       payload['stop'] = stop
 
     request_timeout = timeout if timeout is not None else _DEFAULT_TIMEOUT
 
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+    }
+
+    if self._api_key:
+      if self._auth_scheme:
+        headers[self._auth_header] = f'{self._auth_scheme} {self._api_key}'
+      else:
+        headers[self._auth_header] = self._api_key
+
     try:
       response = self._requests.post(
           api_url,
-          headers={
-              'Content-Type': 'application/json',
-              'Accept': 'application/json',
-          },
+          headers=headers,
           json=payload,
           timeout=request_timeout,
       )

--- a/tests/test_kwargs_passthrough.py
+++ b/tests/test_kwargs_passthrough.py
@@ -1,0 +1,455 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for enhanced kwargs pass-through in providers."""
+
+import unittest
+from unittest import mock
+import warnings
+
+from absl.testing import parameterized
+
+from langextract.providers import ollama
+from langextract.providers import openai
+
+
+class TestOpenAIKwargsPassthrough(unittest.TestCase):
+  """Test OpenAI provider's enhanced kwargs handling."""
+
+  @mock.patch('openai.OpenAI')
+  def test_reasoning_effort_alias_normalization(self, mock_openai_class):
+    """Reasoning_effort parameter should be normalized to {reasoning: {effort: ...}}."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-4o-mini',
+        api_key='test-key',
+        reasoning_effort='minimal',
+    )
+
+    list(model.infer(['test prompt']))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(call_args.kwargs.get('reasoning'), {'effort': 'minimal'})
+
+  @mock.patch('openai.OpenAI')
+  def test_reasoning_parameter_normalized(self, mock_openai_class):
+    """Runtime reasoning_effort should normalize even without constructor param."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-5-nano',
+        api_key='test-key',
+    )
+
+    list(model.infer(['test prompt'], reasoning_effort='maximal'))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(call_args.kwargs.get('reasoning'), {'effort': 'maximal'})
+
+  @mock.patch('openai.OpenAI')
+  def test_runtime_kwargs_override_stored(self, mock_openai_class):
+    """Runtime parameters should override constructor parameters."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-4o-mini',
+        api_key='test-key',
+        temperature=0.7,
+        top_p=0.9,
+    )
+
+    list(model.infer(['test prompt'], temperature=0.3, seed=42))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(call_args.kwargs.get('temperature'), 0.3)
+    self.assertEqual(call_args.kwargs.get('top_p'), 0.9)
+    self.assertEqual(call_args.kwargs.get('seed'), 42)
+
+  @mock.patch('openai.OpenAI')
+  def test_falsy_values_preserved(self, mock_openai_class):
+    """Falsy values like 0 should be preserved, not filtered as None."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-4o',
+        api_key='test-key',
+        temperature=0,
+        top_logprobs=0,
+    )
+
+    list(model.infer(['test prompt']))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(call_args.kwargs.get('temperature'), 0)
+    self.assertEqual(call_args.kwargs.get('top_logprobs'), 0)
+
+  @mock.patch('openai.OpenAI')
+  def test_both_reasoning_forms_merge(self, mock_openai_class):
+    """Both reasoning and reasoning_effort should merge without clobbering."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-5',
+        api_key='test-key',
+        reasoning={'other_field': 'value'},
+        reasoning_effort='maximal',
+    )
+
+    list(model.infer(['test prompt']))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(
+        call_args.kwargs.get('reasoning'),
+        {'other_field': 'value', 'effort': 'maximal'},
+    )
+
+  @mock.patch('openai.OpenAI')
+  def test_custom_response_format(self, mock_openai_class):
+    """Custom response_format should override default JSON format."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-4o',
+        api_key='test-key',
+        format_type=openai.data.FormatType.JSON,
+    )
+
+    list(
+        model.infer(
+            ['test prompt'],
+            response_format={'type': 'text', 'schema': 'custom'},
+        )
+    )
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(
+        call_args.kwargs.get('response_format'),
+        {'type': 'text', 'schema': 'custom'},
+    )
+
+  @mock.patch('openai.OpenAI')
+  def test_direct_reasoning_parameter(self, mock_openai_class):
+    """Direct reasoning parameter should pass through without modification."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-5',
+        api_key='test-key',
+    )
+
+    list(model.infer(['test prompt'], reasoning={'effort': 'minimal'}))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(call_args.kwargs.get('reasoning'), {'effort': 'minimal'})
+
+
+class TestOllamaAuthSupport(parameterized.TestCase):
+  """Test Ollama provider's authentication support for proxied instances."""
+
+  @mock.patch('requests.post')
+  def test_api_key_in_authorization_header(self, mock_post):
+    """API key should be sent in Authorization header with Bearer scheme."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'response': '{"test": "value"}'}
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(
+        model_id='gemma2:2b',
+        model_url='https://proxy.example.com',
+        api_key='sk-test-key-123',
+    )
+
+    list(model.infer(['test prompt']))
+
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    headers = call_args.kwargs.get('headers', {})
+    self.assertEqual(headers.get('Authorization'), 'Bearer sk-test-key-123')
+    self.assertEqual(headers.get('Content-Type'), 'application/json')
+
+  @mock.patch('requests.post')
+  def test_custom_auth_header_name(self, mock_post):
+    """Custom auth header name (e.g. X-API-Key) should be supported."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'response': '{"test": "value"}'}
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(
+        model_id='gemma2:2b',
+        model_url='https://api.example.com',
+        api_key='abc123',
+        auth_header='X-API-Key',
+        auth_scheme='',
+    )
+
+    list(model.infer(['test prompt']))
+
+    headers = mock_post.call_args.kwargs.get('headers', {})
+    self.assertEqual(headers.get('X-API-Key'), 'abc123')
+    self.assertNotIn('Authorization', headers)
+
+  @mock.patch('requests.post')
+  def test_pass_through_kwargs(self, mock_post):
+    """Future Ollama parameters should pass through without code changes."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'response': '{"test": "value"}'}
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(
+        model_id='mistral:7b',
+        temperature=0.5,
+        top_k=40,
+        repeat_penalty=1.1,
+        mirostat=2,
+    )
+
+    list(model.infer(['test prompt']))
+
+    call_args = mock_post.call_args
+    payload = call_args.kwargs['json']
+    options = payload['options']
+
+    self.assertEqual(options.get('temperature'), 0.5)
+    self.assertEqual(options.get('top_k'), 40)
+    self.assertEqual(options.get('repeat_penalty'), 1.1)
+    self.assertEqual(options.get('mirostat'), 2)
+
+  def test_api_key_redacted_in_repr(self):
+    """API key should be redacted in string representation for security."""
+    model = ollama.OllamaLanguageModel(
+        model_id='gemma2:2b',
+        api_key='super-secret-key',
+    )
+
+    repr_str = repr(model)
+    self.assertIn('[REDACTED]', repr_str, 'API key should be redacted')
+    self.assertNotIn(
+        'super-secret-key', repr_str, 'Actual API key should not appear'
+    )
+
+  @mock.patch('requests.post')
+  def test_localhost_auth_warning_but_still_works(self, mock_post):
+    """Should warn about localhost auth but still send the auth header."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'response': '{"test": "value"}'}
+    mock_post.return_value = mock_response
+
+    with warnings.catch_warnings(record=True) as w:
+      warnings.simplefilter('always')
+      model = ollama.OllamaLanguageModel(
+          model_id='gemma2:2b',
+          model_url='http://localhost:11434',
+          api_key='unnecessary-key',
+      )
+
+      self.assertTrue(
+          any('localhost' in str(warning.message) for warning in w),
+          'Expected warning about localhost auth',
+      )
+
+    # Verify auth header is still sent despite warning
+    list(model.infer(['test prompt']))
+    headers = mock_post.call_args.kwargs.get('headers', {})
+    self.assertEqual(headers.get('Authorization'), 'Bearer unnecessary-key')
+
+  @mock.patch('requests.post')
+  def test_runtime_kwargs_override(self, mock_post):
+    """Runtime parameters should override constructor parameters."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'response': '{"test": "value"}'}
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(
+        model_id='gemma2:2b',
+        temperature=0.7,
+        timeout=60,
+    )
+
+    list(model.infer(['test prompt'], temperature=0.3, timeout=120))
+
+    call_args = mock_post.call_args
+    payload = call_args.kwargs['json']
+    options = payload['options']
+
+    self.assertEqual(options.get('temperature'), 0.3)
+    self.assertEqual(call_args.kwargs.get('timeout'), 120)
+
+  @parameterized.named_parameters(
+      ('https_localhost', 'https://localhost:11434', True),
+      ('ipv6_localhost', 'http://[::1]:11434', True),
+      ('ipv4_localhost', 'http://127.0.0.1:8080/', True),
+      ('remote_proxy', 'https://proxy.example.com', False),
+  )
+  @mock.patch('requests.post')
+  def test_localhost_detection(self, url, should_warn, mock_post):
+    """Should detect localhost in various URL formats (IPv6, https, etc)."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'response': '{"test": "value"}'}
+    mock_post.return_value = mock_response
+
+    with warnings.catch_warnings(record=True) as w:
+      warnings.simplefilter('always')
+      _ = ollama.OllamaLanguageModel(
+          model_id='gemma2:2b',
+          model_url=url,
+          api_key='test-key',
+      )
+
+      if should_warn:
+        self.assertTrue(
+            any('localhost' in str(warning.message) for warning in w),
+            f'Expected warning for {url}',
+        )
+      else:
+        self.assertFalse(
+            any('localhost' in str(warning.message) for warning in w),
+            f'Unexpected warning for {url}',
+        )
+
+  @mock.patch('requests.post')
+  def test_format_none_not_in_payload(self, mock_post):
+    """Format key should be omitted from payload when None (not sent as null)."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'response': 'plain text'}
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(
+        model_id='gemma2:2b',
+    )
+
+    model.format_type = None
+
+    _ = model._ollama_query(
+        prompt='test prompt',
+        model='gemma2:2b',
+        structured_output_format=None,
+    )
+
+    call_args = mock_post.call_args
+    payload = call_args.kwargs['json']
+
+    self.assertNotIn('format', payload, 'format=None should not be in payload')
+
+  @mock.patch('requests.post')
+  def test_reserved_kwargs_not_in_options(self, mock_post):
+    """Reserved top-level keys (stop, format) should not go into options dict."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'response': '{"test": "value"}'}
+    mock_post.return_value = mock_response
+
+    model = ollama.OllamaLanguageModel(
+        model_id='gemma2:2b',
+        stop=['END'],
+        temperature=0.5,
+        custom_param='value',
+    )
+
+    list(model.infer(['test prompt']))
+
+    call_args = mock_post.call_args
+    payload = call_args.kwargs['json']
+    options = payload['options']
+
+    self.assertEqual(payload.get('stop'), ['END'])
+    self.assertNotIn(
+        'stop', options, 'stop should be at top level, not in options'
+    )
+    self.assertEqual(options.get('temperature'), 0.5)
+    self.assertEqual(options.get('custom_param'), 'value')
+
+  @mock.patch('requests.post')
+  def test_api_key_without_localhost_warning(self, mock_post):
+    """Should not warn when using auth with remote/proxied Ollama instances."""
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {'response': '{"test": "value"}'}
+    mock_post.return_value = mock_response
+
+    with warnings.catch_warnings(record=True) as w:
+      warnings.simplefilter('always')
+      model = ollama.OllamaLanguageModel(
+          model_id='gemma2:2b',
+          model_url='https://proxy.example.com',
+          api_key='necessary-key',
+      )
+
+      self.assertFalse(
+          any('localhost' in str(warning.message) for warning in w)
+      )
+
+    list(model.infer(['test prompt']))
+    headers = mock_post.call_args.kwargs.get('headers', {})
+    self.assertEqual(headers.get('Authorization'), 'Bearer necessary-key')
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
# Description

Add support for OpenAI GPT-5 reasoning_effort parameter and Ollama API key authentication for proxied instances.

Fixes #159
Fixes #156
Related to #136, #152, #157

Feature

# How Has This Been Tested?

```bash
pytest tests/test_kwargs_passthrough.py -v  # 20 new tests
pytest tests -v  # 288 tests passing
tox -e format  # Passing
tox -e lint-src lint-tests  # Passing
```

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes
- [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.

## Changes

**OpenAI**: Normalize `reasoning_effort` to `{"reasoning": {"effort": ...}}` for GPT-5 compatibility

**Ollama**: Add authentication support with API key, custom headers, and localhost detection