### PR TITLE
Fix AttributeError for lx.data.* wildcard imports

### DIFF
--- a/langextract/core/data.py
+++ b/langextract/core/data.py
@@ -24,6 +24,16 @@ from langextract.core import types
 
 FormatType = types.FormatType  # Backward compat
 
+__all__ = [
+    "AlignmentStatus",
+    "CharInterval",
+    "Extraction",
+    "Document",
+    "AnnotatedDocument",
+    "ExampleData",
+    "FormatType",
+]
+
 
 class AlignmentStatus(enum.Enum):
   MATCH_EXACT = "match_exact"

--- a/langextract/core/tokenizer.py
+++ b/langextract/core/tokenizer.py
@@ -31,6 +31,20 @@ import re
 from langextract.core import debug_utils
 from langextract.core import exceptions
 
+__all__ = [
+    "BaseTokenizerError",
+    "InvalidTokenIntervalError",
+    "SentenceRangeError",
+    "CharInterval",
+    "TokenInterval",
+    "TokenType",
+    "Token",
+    "TokenizedText",
+    "tokenize",
+    "tokens_text",
+    "find_sentence_range",
+]
+
 
 class BaseTokenizerError(exceptions.LangExtractError):
   """Base class for all tokenizer-related errors."""

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -191,6 +191,48 @@ class InitTest(absltest.TestCase):
     _, kwargs = mock_model.infer.call_args
     self.assertEqual(kwargs.get("max_workers"), 5)
 
+  def test_data_module_exports_via_compatibility_shim(self):
+    """Verify data module exports are accessible via lx.data."""
+    expected_exports = [
+        "AlignmentStatus",
+        "CharInterval",
+        "Extraction",
+        "Document",
+        "AnnotatedDocument",
+        "ExampleData",
+        "FormatType",
+    ]
+
+    for name in expected_exports:
+      with self.subTest(export=name):
+        self.assertTrue(
+            hasattr(lx.data, name),
+            f"lx.data.{name} not accessible via compatibility shim",
+        )
+
+  def test_tokenizer_module_exports_via_compatibility_shim(self):
+    """Verify tokenizer module exports are accessible via lx.tokenizer."""
+    expected_exports = [
+        "BaseTokenizerError",
+        "InvalidTokenIntervalError",
+        "SentenceRangeError",
+        "CharInterval",
+        "TokenInterval",
+        "TokenType",
+        "Token",
+        "TokenizedText",
+        "tokenize",
+        "tokens_text",
+        "find_sentence_range",
+    ]
+
+    for name in expected_exports:
+      with self.subTest(export=name):
+        self.assertTrue(
+            hasattr(lx.tokenizer, name),
+            f"lx.tokenizer.{name} not accessible via compatibility shim",
+        )
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
# Description

Fix AttributeError when accessing `lx.data.*` classes due to missing `__all__` declarations in core modules after v1.0.5 refactoring.

Fixes #92

Bug fix

# How Has This Been Tested?

```bash
pytest tests/init_test.py -v  # 4 tests including 2 new compatibility tests
pytest tests -k "not live_api and not ollama_integration" -q  # 270 tests passing
tox -e format  # Passing
pylint --rcfile=.pylintrc langextract/core/data.py langextract/core/tokenizer.py  # No errors
pylint --rcfile=tests/.pylintrc tests/init_test.py  # 10.00/10
```

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes
- [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.