### PR TITLE
feat: Add LiteLLM community provider to the plugin registry

### DIFF
--- a/COMMUNITY_PROVIDERS.md
+++ b/COMMUNITY_PROVIDERS.md
@@ -11,6 +11,7 @@ Community-developed provider plugins that extend LangExtract with additional mod
 | Plugin Name | PyPI Package | Maintainer | GitHub Repo | Description | Issue Link |
 |-------------|--------------|------------|-------------|-------------|------------|
 | Example Provider | `langextract-provider-example` | [@google](https://github.com/google) | [google/langextract](https://github.com/google/langextract) | Reference implementation for creating custom providers | [#123](https://github.com/google/langextract/issues/123) |
+| LiteLLM | `langextract-provider-litellm` | [@JustStas](https://github.com/JustStas) | [JustStas/langextract-provider-litellm](https://github.com/JustStas/langextract-litellm) | LiteLLM provider for LangExtract, supports all models covered in LiteLLM, including OpenAI, Azure, Anthropic, etc., See [LiteLLM's supported models](https://docs.litellm.ai/docs/providers) | [#99](https://github.com/google/langextract/issues/99) |
 
 <!-- ADD NEW PLUGINS ABOVE THIS LINE -->
 


### PR DESCRIPTION
Include LiteLLM provider details in the community plugins table, supporting various models including OpenAI and Azure. This addition enhances the LangExtract functionality by providing users with more options for integration.