### PR TITLE
Fix URL detection to prevent unintended fetching

### DIFF
--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -51,6 +51,8 @@ def extract(
     extraction_passes: int = 1,
     config: typing.Any = None,
     model: typing.Any = None,
+    *,
+    fetch_urls: bool = True,
 ) -> typing.Any:
   """Extracts structured information from text.
 
@@ -61,8 +63,8 @@ def extract(
 
   Args:
       text_or_documents: The source text to extract information from, a URL to
-        download text from (starting with http:// or https://), or an iterable
-        of Document objects.
+        download text from (starting with http:// or https:// when fetch_urls
+        is True), or an iterable of Document objects.
       prompt_description: Instructions for what to extract from the text.
       examples: List of ExampleData objects to guide the extraction.
       api_key: API key for Gemini or other LLM services (can also use
@@ -129,6 +131,10 @@ def extract(
         and config are provided, model takes precedence.
       model: Pre-configured language model to use for extraction. Takes
         precedence over all other parameters including config.
+      fetch_urls: Whether to automatically download content when the input is a
+        URL string. When True (default), strings starting with http:// or
+        https:// are fetched. When False, all strings are treated as literal
+        text to analyze. This is a keyword-only parameter.
 
   Returns:
       An AnnotatedDocument with the extracted information when input is a
@@ -163,7 +169,11 @@ def extract(
         UserWarning,
     )
 
-  if isinstance(text_or_documents, str) and io.is_url(text_or_documents):
+  if (
+      fetch_urls
+      and isinstance(text_or_documents, str)
+      and io.is_url(text_or_documents)
+  ):
     text_or_documents = io.download_text_from_url(text_or_documents)
 
   prompt_template = prompting.PromptTemplateStructured(

--- a/langextract/io.py
+++ b/langextract/io.py
@@ -242,11 +242,10 @@ def is_url(text: str) -> bool:
 
   try:
     result = urlparse.urlparse(text)
-    if not (result.scheme in ('http', 'https') and result.netloc):
-      return False
-
     hostname = result.hostname
-    if not hostname:
+
+    # Must have valid scheme, netloc, and hostname
+    if not (result.scheme in ('http', 'https') and result.netloc and hostname):
       return False
 
     # Accept IPs, localhost, or domains with dots

--- a/langextract/io.py
+++ b/langextract/io.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 
 import abc
 import dataclasses
+import ipaddress
 import json
 import os
 import pathlib
 from typing import Any, Iterator
+from urllib import parse as urlparse
 
 import pandas as pd
 import requests
@@ -218,16 +220,43 @@ def _read_csv(
 
 
 def is_url(text: str) -> bool:
-  """Check if the given text is a URL.
+  """Check if the given text is a valid URL.
+
+  Uses urllib.parse to validate that the text is a properly formed URL
+  with http or https scheme and a valid network location.
 
   Args:
     text: The string to check.
 
   Returns:
-    True if the text is a URL (starts with http:// or https://), False
-    otherwise.
+    True if the text is a valid URL with http(s) scheme, False otherwise.
   """
-  return text.startswith('http://') or text.startswith('https://')
+  if not text or not isinstance(text, str):
+    return False
+
+  text = text.strip()
+
+  # Reject text with whitespace (not a pure URL)
+  if ' ' in text or '\n' in text or '\t' in text:
+    return False
+
+  try:
+    result = urlparse.urlparse(text)
+    if not (result.scheme in ('http', 'https') and result.netloc):
+      return False
+
+    hostname = result.hostname
+    if not hostname:
+      return False
+
+    # Accept IPs, localhost, or domains with dots
+    try:
+      ipaddress.ip_address(hostname)
+      return True
+    except ValueError:
+      return hostname == 'localhost' or '.' in hostname
+  except (ValueError, AttributeError):
+    return False
 
 
 def download_text_from_url(

--- a/tests/data_lib_test.py
+++ b/tests/data_lib_test.py
@@ -19,6 +19,7 @@ from absl.testing import parameterized
 import numpy as np
 
 from langextract import data_lib
+from langextract import io
 from langextract.core import data
 from langextract.core import tokenizer
 
@@ -201,6 +202,31 @@ class DataLibToDictParameterizedTest(parameterized.TestCase):
 
     json_str = json.dumps(doc_dict, ensure_ascii=False)
     self.assertIn('"extraction_index": 42', json_str)
+
+
+class IsUrlTest(absltest.TestCase):
+  """Tests for io.is_url function validation."""
+
+  def test_valid_urls(self):
+    """Test that valid URLs are recognized."""
+    self.assertTrue(io.is_url("http://example.com"))
+    self.assertTrue(io.is_url("https://www.example.com"))
+    self.assertTrue(io.is_url("http://localhost:8080"))
+    self.assertTrue(io.is_url("http://192.168.1.1"))
+    self.assertTrue(io.is_url("http://[2001:db8::1]"))  # IPv6
+    self.assertTrue(io.is_url("http://[::1]:8080"))  # IPv6 localhost with port
+
+  def test_invalid_urls_with_text(self):
+    """Test that URLs with additional text are rejected."""
+    # Validates fix for issue where text starting with URL was incorrectly fetched
+    self.assertFalse(io.is_url("http://example.com is a website"))
+    self.assertFalse(io.is_url("http://medical-journal.com published a study"))
+
+  def test_invalid_urls_no_scheme(self):
+    """Test that URLs without proper scheme are rejected."""
+    self.assertFalse(io.is_url("example.com"))
+    self.assertFalse(io.is_url("www.example.com"))
+    self.assertFalse(io.is_url("ftp://example.com"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Fix URL detection to prevent unintended fetching of text that starts with URLs. Add `fetch_urls` keyword-only parameter for explicit control.

Fixes #177

Bug fix

# How Has This Been Tested?

```bash
pytest tests/data_lib_test.py::IsUrlTest -v  # 3 new URL validation tests
pytest tests -m "not live_api" -q  # 273 tests passing
./autoformat.sh langextract/extraction.py langextract/io.py tests/data_lib_test.py  # Passing
```

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.