### PR TITLE
fix (router): typings for provider plugin registration decorator

### DIFF
--- a/langextract/providers/router.py
+++ b/langextract/providers/router.py
@@ -32,6 +32,10 @@ from absl import logging
 from langextract.core import base_model
 from langextract.core import exceptions
 
+TLanguageModel = typing.TypeVar(
+    "TLanguageModel", bound=base_model.BaseLanguageModel
+)
+
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class _Entry:
@@ -103,9 +107,7 @@ def register_lazy(
 
 def register(
     *patterns: str | re.Pattern[str], priority: int = 0
-) -> typing.Callable[
-    [type[base_model.BaseLanguageModel]], type[base_model.BaseLanguageModel]
-]:
+) -> typing.Callable[[type[TLanguageModel]], type[TLanguageModel]]:
   """Decorator to register a provider class directly.
 
   Args:
@@ -117,9 +119,7 @@ def register(
   """
   compiled = tuple(re.compile(p) if isinstance(p, str) else p for p in patterns)
 
-  def _decorator(
-      cls: type[base_model.BaseLanguageModel],
-  ) -> type[base_model.BaseLanguageModel]:
+  def _decorator(cls: type[TLanguageModel]) -> type[TLanguageModel]:
     def _loader() -> type[base_model.BaseLanguageModel]:
       return cls
 


### PR DESCRIPTION
# Description

fixes typing on `registry.register()` call to enable proper inference and documentation of built-in and custom provider classes
Fixes/Related to #179 

Choose one: Bug

# How Has This Been Tested?

Replace this with a description of the tests that you ran to verify your
changes. If executing the existing test suite without customization, simply
paste the command line used.

> built-in provider 

<img width="561" height="369" alt="image" src="https://github.com/user-attachments/assets/f435f6b4-af3c-49cf-a6bb-a6e3cc0405be" />

> custom / external provider

<img width="619" height="381" alt="image" src="https://github.com/user-attachments/assets/6df896ba-c06a-4bf0-a466-63636b22cf1a" />


```sh
uv run pytest tests
...
============================================ short test summary info ============================================
SKIPPED [1] tests/provider_plugin_test.py:483: pip not available in test environment
================================== 272 passed, 1 skipped, 55 warnings in 0.75s ==================================
```

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.
  - running `uv run pylint --rcfile=.pylintrc langextract tests` produced diffs in `langextract/plugins.py` and `langextract/providers/__init__.py` to reorder imports. this is inconsistent with running `uv run pre-commit run --all-files`. its unclear if i should commit these changes - i have not included them in this PR but can if requested.