### PR TITLE
feat: Add AWS Bedrock community provider to the plugin registry

### DIFF
--- a/COMMUNITY_PROVIDERS.md
+++ b/COMMUNITY_PROVIDERS.md
@@ -11,6 +11,7 @@ Community-developed provider plugins that extend LangExtract with additional mod
 | Plugin Name | PyPI Package | Maintainer | GitHub Repo | Description | Issue Link |
 |-------------|--------------|------------|-------------|-------------|------------|
 | Example Provider | `langextract-provider-example` | [@google](https://github.com/google) | [google/langextract](https://github.com/google/langextract) | Reference implementation for creating custom providers | [#123](https://github.com/google/langextract/issues/123) |
+| AWS Bedrock | `langextract-bedrock` | [@andyxhadji](https://github.com/andyxhadji) | [andyxhadji/langextract-bedrock](https://github.com/andyxhadji/langextract-bedrock) | AWS Bedrock provider for LangExtract, supports all models & inference profiles | [#148](https://github.com/google/langextract/issues/148) |
 | LiteLLM | `langextract-litellm` | [@JustStas](https://github.com/JustStas) | [JustStas/langextract-litellm](https://github.com/JustStas/langextract-litellm) | LiteLLM provider for LangExtract, supports all models covered in LiteLLM, including OpenAI, Azure, Anthropic, etc., See [LiteLLM's supported models](https://docs.litellm.ai/docs/providers) | [#187](https://github.com/google/langextract/issues/187) |
 
 <!-- ADD NEW PLUGINS ABOVE THIS LINE -->


### PR DESCRIPTION
# Description

Adding AWS Bedrock community provider information to the plugin registry.

[Related to #148](https://github.com/google/langextract/issues/148
)

Documentation

# How Has This Been Tested?
N/A

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.