### PR TITLE
fix: Allow T-prefixed TypeVars in pylint config

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -133,7 +133,7 @@ good-names=i,j,k,ex,Run,_,id,ok
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted
-good-names-rgxs=
+good-names-rgxs=^T[A-Z][a-zA-Z]*$
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no

--- a/langextract/data.py
+++ b/langextract/data.py
@@ -21,5 +21,5 @@ langextract.data. All functionality has moved to langextract.core.data.
 from __future__ import annotations
 
 # Re-export everything from core.data for backward compatibility
-# pylint: disable=wildcard-import,unused-wildcard-import
+# pylint: disable=unused-wildcard-import
 from langextract.core.data import *

--- a/langextract/tokenizer.py
+++ b/langextract/tokenizer.py
@@ -21,5 +21,5 @@ langextract.tokenizer. All functionality has moved to langextract.core.tokenizer
 from __future__ import annotations
 
 # Re-export everything from core.tokenizer for backward compatibility
-# pylint: disable=wildcard-import,unused-wildcard-import
+# pylint: disable=unused-wildcard-import
 from langextract.core.tokenizer import *


### PR DESCRIPTION
# Description

Configures pylint to accept descriptive TypeVar names like TLanguageModel.

Related to #190

Code health

# How Has This Been Tested?

```bash
tox -e format  # Pass
tox -e lint-src  # Pass
pytest tests -m "not live_api" -q  # 273 passed
```

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.