### PR TITLE
Adding SA key authentication to gemini model initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,20 @@ result = lx.extract(
 )
 ```
 
+**Option 4: GCP project authentication**
+If you don't have an API key, you can initialize your model through Vertex AI with a Project ID and location;
+```python
+result = lx.extract(
+    text_or_documents=input_text,
+    prompt_description="Extract information...",
+    examples=[...],
+    model_id="gemini-2.5-flash",
+    project_id="your-gcp-project-id"
+    location="your-project-location" # For example, 'us-central1'
+)
+```
+
+
 ## Adding Custom Model Providers
 
 LangExtract supports custom LLM providers via a lightweight plugin system. You can add support for new models without changing core code.


### PR DESCRIPTION
This PR adds an option to initialize a gemini model based on a Google Cloud platform project's SA key using the project name + location. This is helpful for situations when a user might have access to a company GCP project and SA key, but without access to a Gemini API key-- this is the situation I was in, and this fix let me skip the hoops of requesting the tech team to provision me a specific API key.
Achieving this is simple; when calling a gemini model, a user now has an option of 2 additional parameters; location and project_id. If the API key is not set, the code now attempts to create a genai instance using an SA key before throwing the "No API key detected" exception. The ReadMe and in-line documentation have been updated to reflect this change as well.

Fixes #58 