### PR TITLE
feat: Add prompt alignment validation for few-shot examples

### DIFF
--- a/langextract/prompt_validation.py
+++ b/langextract/prompt_validation.py
@@ -1,0 +1,253 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prompt validation for alignment checks on few-shot examples."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import copy
+import dataclasses
+import enum
+
+from absl import logging
+
+from langextract import resolver
+from langextract.core import data
+
+__all__ = [
+    "PromptValidationLevel",
+    "ValidationIssue",
+    "ValidationReport",
+    "PromptAlignmentError",
+    "AlignmentPolicy",
+    "validate_prompt_alignment",
+    "handle_alignment_report",
+]
+
+
+_FUZZY_ALIGNMENT_MIN_THRESHOLD = 0.75
+
+
+class PromptValidationLevel(enum.Enum):
+  """Validation levels for prompt alignment checks."""
+
+  OFF = "off"
+  WARNING = "warning"
+  ERROR = "error"
+
+
+class _IssueKind(enum.Enum):
+  """Internal categorization of alignment issues."""
+
+  FAILED = "failed"  # alignment_status is None
+  NON_EXACT = "non_exact"  # MATCH_FUZZY or MATCH_LESSER
+
+
+@dataclasses.dataclass(frozen=True)
+class ValidationIssue:
+  """Represents a single validation issue found during alignment."""
+
+  example_index: int
+  example_id: str | None
+  extraction_class: str
+  extraction_text_preview: str
+  alignment_status: data.AlignmentStatus | None
+  issue_kind: _IssueKind
+  char_interval: tuple[int, int] | None = None
+  token_interval: tuple[int, int] | None = None
+
+  def short_msg(self) -> str:
+    """Returns a concise message describing the issue."""
+    ex_id = f" id={self.example_id}" if self.example_id else ""
+    span = ""
+    if self.char_interval:
+      span = f" char_span={self.char_interval}"
+    return (
+        f"[example#{self.example_index}{ex_id}] "
+        f"class='{self.extraction_class}' "
+        f"status={self.alignment_status} "
+        f"text='{self.extraction_text_preview}'{span}"
+    )
+
+
+@dataclasses.dataclass
+class ValidationReport:
+  """Collection of validation issues from prompt alignment checks."""
+
+  issues: list[ValidationIssue]
+
+  @property
+  def has_failed(self) -> bool:
+    """Returns True if any extraction failed to align."""
+    return any(i.issue_kind is _IssueKind.FAILED for i in self.issues)
+
+  @property
+  def has_non_exact(self) -> bool:
+    """Returns True if any extraction has non-exact alignment."""
+    return any(i.issue_kind is _IssueKind.NON_EXACT for i in self.issues)
+
+
+class PromptAlignmentError(RuntimeError):
+  """Raised when prompt alignment validation fails under ERROR mode."""
+
+
+@dataclasses.dataclass(frozen=True)
+class AlignmentPolicy:
+  """Configuration for alignment validation behavior."""
+
+  enable_fuzzy_alignment: bool = True
+  fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD
+  accept_match_lesser: bool = True
+
+
+def _preview(s: str, n: int = 120) -> str:
+  """Creates a preview of text for logging, collapsing whitespace."""
+  s = " ".join(s.split())  # Collapse whitespace for logs
+  return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def validate_prompt_alignment(
+    examples: Sequence[data.ExampleData],
+    aligner: resolver.WordAligner | None = None,
+    policy: AlignmentPolicy | None = None,
+) -> ValidationReport:
+  """Align extractions to their own example text and collect issues.
+
+  Args:
+    examples: The few-shot examples to validate.
+    aligner: WordAligner instance to use (creates new if None).
+    policy: Alignment configuration (uses defaults if None).
+
+  Returns:
+    ValidationReport containing any alignment issues found.
+  """
+  if not examples:
+    return ValidationReport(issues=[])
+
+  aligner = aligner or resolver.WordAligner()
+  policy = policy or AlignmentPolicy()
+
+  issues: list[ValidationIssue] = []
+
+  for idx, ex in enumerate(examples):
+    # Defensive copy so validation never mutates user examples.
+    copied_extractions = [[copy.deepcopy(e) for e in ex.extractions]]
+    aligned_groups = aligner.align_extractions(
+        extraction_groups=copied_extractions,
+        source_text=ex.text,
+        token_offset=0,
+        char_offset=0,
+        enable_fuzzy_alignment=policy.enable_fuzzy_alignment,
+        fuzzy_alignment_threshold=policy.fuzzy_alignment_threshold,
+        accept_match_lesser=policy.accept_match_lesser,
+    )
+
+    for aligned in aligned_groups[0]:
+      status = getattr(aligned, "alignment_status", None)
+      char_interval = getattr(aligned, "char_interval", None)
+      token_interval = getattr(aligned, "token_interval", None)
+      klass = getattr(aligned, "extraction_class", "<unknown>")
+      text = getattr(aligned, "extraction_text", "")
+
+      if status is None:
+        issues.append(
+            ValidationIssue(
+                example_index=idx,
+                example_id=getattr(ex, "example_id", None),
+                extraction_class=klass,
+                extraction_text_preview=_preview(text),
+                alignment_status=None,
+                issue_kind=_IssueKind.FAILED,
+                char_interval=None,
+                token_interval=None,
+            )
+        )
+      elif status in (
+          data.AlignmentStatus.MATCH_FUZZY,
+          data.AlignmentStatus.MATCH_LESSER,
+      ):
+        char_interval_tuple = None
+        token_interval_tuple = None
+        if char_interval:
+          char_interval_tuple = (char_interval.start_pos, char_interval.end_pos)
+        if token_interval:
+          token_interval_tuple = (
+              token_interval.start_index,
+              token_interval.end_index,
+          )
+
+        issues.append(
+            ValidationIssue(
+                example_index=idx,
+                example_id=getattr(ex, "example_id", None),
+                extraction_class=klass,
+                extraction_text_preview=_preview(text),
+                alignment_status=status,
+                issue_kind=_IssueKind.NON_EXACT,
+                char_interval=char_interval_tuple,
+                token_interval=token_interval_tuple,
+            )
+        )
+
+  return ValidationReport(issues=issues)
+
+
+def handle_alignment_report(
+    report: ValidationReport,
+    level: PromptValidationLevel,
+    *,
+    strict_non_exact: bool = False,
+) -> None:
+  """Log or raise based on validation level.
+
+  Args:
+    report: The validation report to handle.
+    level: The validation level determining behavior.
+    strict_non_exact: If True, treat non-exact matches as errors in ERROR mode.
+
+  Raises:
+    PromptAlignmentError: If validation fails in ERROR mode.
+  """
+  if level is PromptValidationLevel.OFF:
+    return
+
+  for issue in report.issues:
+    if issue.issue_kind is _IssueKind.NON_EXACT:
+      logging.warning(
+          "Prompt alignment: non-exact match: %s", issue.short_msg()
+      )
+    else:
+      logging.warning(
+          "Prompt alignment: FAILED to align: %s", issue.short_msg()
+      )
+
+  if level is PromptValidationLevel.ERROR:
+    failed = [i for i in report.issues if i.issue_kind is _IssueKind.FAILED]
+    non_exact = [
+        i for i in report.issues if i.issue_kind is _IssueKind.NON_EXACT
+    ]
+
+    if failed:
+      sample = failed[0].short_msg()
+      raise PromptAlignmentError(
+          f"Prompt alignment validation failed: {len(failed)} extraction(s) "
+          f"could not be aligned (e.g., {sample})"
+      )
+    if strict_non_exact and non_exact:
+      sample = non_exact[0].short_msg()
+      raise PromptAlignmentError(
+          "Prompt alignment validation failed under strict mode: "
+          f"{len(non_exact)} non-exact match(es) found (e.g., {sample})"
+      )

--- a/tests/prompt_validation_test.py
+++ b/tests/prompt_validation_test.py
@@ -1,0 +1,426 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for prompt validation module."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from langextract import extraction
+from langextract import prompt_validation
+from langextract.core import data
+
+
+class PromptAlignmentValidationTest(parameterized.TestCase):
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="exact_alignment",
+          text="Patient takes lisinopril.",
+          extraction_class="Medication",
+          extraction_text="lisinopril",
+          expected_issues=0,
+          expected_has_failed=False,
+          expected_has_non_exact=False,
+          expected_alignment_status=None,
+      ),
+      dict(
+          testcase_name="fuzzy_match_lesser",
+          text="Type 2 diabetes.",
+          extraction_class="Diagnosis",
+          extraction_text="type-2 diabetes",
+          expected_issues=1,
+          expected_has_failed=False,
+          expected_has_non_exact=True,
+          expected_alignment_status=data.AlignmentStatus.MATCH_LESSER,
+      ),
+      dict(
+          testcase_name="extraction_not_found",
+          text="No medications mentioned in this text.",
+          extraction_class="Medication",
+          extraction_text="lisinopril",
+          expected_issues=1,
+          expected_has_failed=True,
+          expected_has_non_exact=False,
+          expected_alignment_status=None,
+      ),
+  )
+  def test_alignment_detection(
+      self,
+      text,
+      extraction_class,
+      extraction_text,
+      expected_issues,
+      expected_has_failed,
+      expected_has_non_exact,
+      expected_alignment_status,
+  ):
+    """Test that different alignment types are correctly detected."""
+    example = data.ExampleData(
+        text=text,
+        extractions=[
+            data.Extraction(
+                extraction_class=extraction_class,
+                extraction_text=extraction_text,
+                attributes={},
+            )
+        ],
+    )
+
+    report = prompt_validation.validate_prompt_alignment([example])
+
+    self.assertLen(report.issues, expected_issues)
+    self.assertEqual(report.has_failed, expected_has_failed)
+    self.assertEqual(report.has_non_exact, expected_has_non_exact)
+
+    if expected_issues > 0:
+      issue = report.issues[0]
+      self.assertEqual(issue.alignment_status, expected_alignment_status)
+      self.assertEqual(issue.extraction_class, extraction_class)
+      if expected_has_failed:
+        self.assertIsNone(issue.alignment_status)
+      elif expected_has_non_exact:
+        self.assertIsNotNone(issue.alignment_status)
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="one_fails",
+          text="Patient takes lisinopril and has diabetes mellitus.",
+          extractions=[
+              ("Medication", "lisinopril"),  # PASSES - found exactly
+              ("Diagnosis", "diabetes"),  # PASSES - found exactly
+              ("Medication", "metformin"),  # FAILS - not in text
+          ],
+          expected_issues=1,
+          expected_has_failed=True,
+          expected_has_non_exact=False,
+          expected_failed_text="metformin",
+      ),
+      dict(
+          testcase_name="all_pass",
+          text="Patient takes lisinopril and aspirin for diabetes management.",
+          extractions=[
+              ("Medication", "lisinopril"),
+              ("Medication", "aspirin"),
+              ("Diagnosis", "diabetes"),
+          ],
+          expected_issues=0,
+          expected_has_failed=False,
+          expected_has_non_exact=False,
+          expected_failed_text=None,
+      ),
+  )
+  def test_multiple_extractions_per_example(
+      self,
+      text,
+      extractions,
+      expected_issues,
+      expected_has_failed,
+      expected_has_non_exact,
+      expected_failed_text,
+  ):
+    """Test validation with multiple extractions in a single example."""
+    example = data.ExampleData(
+        text=text,
+        extractions=[
+            data.Extraction(
+                extraction_class=extraction_class,
+                extraction_text=extraction_text,
+                attributes={},
+            )
+            for extraction_class, extraction_text in extractions
+        ],
+    )
+
+    report = prompt_validation.validate_prompt_alignment([example])
+
+    self.assertLen(report.issues, expected_issues)
+    self.assertEqual(report.has_failed, expected_has_failed)
+    self.assertEqual(report.has_non_exact, expected_has_non_exact)
+
+    if expected_failed_text:
+      issue = report.issues[0]
+      self.assertIsNone(issue.alignment_status)
+      self.assertEqual(issue.extraction_text_preview, expected_failed_text)
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="warning_mode_with_failed",
+          text="Patient has no known allergies.",
+          extraction_text="penicillin",
+          validation_level=prompt_validation.PromptValidationLevel.WARNING,
+          strict_non_exact=False,
+      ),
+      dict(
+          testcase_name="off_mode_with_failed",
+          text="Patient history incomplete.",
+          extraction_text="aspirin",
+          validation_level=prompt_validation.PromptValidationLevel.OFF,
+          strict_non_exact=False,
+      ),
+  )
+  def test_validation_levels_that_dont_raise(
+      self, text, extraction_text, validation_level, strict_non_exact
+  ):
+    """Test that WARNING and OFF modes don't raise exceptions."""
+    example = data.ExampleData(
+        text=text,
+        extractions=[
+            data.Extraction(
+                extraction_class="Medication",
+                extraction_text=extraction_text,
+                attributes={},
+            )
+        ],
+    )
+
+    report = prompt_validation.validate_prompt_alignment([example])
+
+    # This should not raise an exception in WARNING or OFF modes
+    prompt_validation.handle_alignment_report(
+        report, validation_level, strict_non_exact=strict_non_exact
+    )
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="error_mode_failed_alignment",
+          text="Patient has no known allergies.",
+          extraction_class="Medication",
+          extraction_text="penicillin",
+          strict_non_exact=False,
+          error_pattern=r"1 extraction\(s\).*could not be aligned",
+      ),
+      dict(
+          testcase_name="error_mode_strict_fuzzy_match",
+          text="Type 2 diabetes.",
+          extraction_class="Diagnosis",
+          extraction_text="type-2 diabetes",
+          strict_non_exact=True,
+          error_pattern=r"strict mode.*1 non-exact",
+      ),
+  )
+  def test_error_mode_raises_appropriately(
+      self,
+      text,
+      extraction_class,
+      extraction_text,
+      strict_non_exact,
+      error_pattern,
+  ):
+    """Test that ERROR mode raises with appropriate messages."""
+    example = data.ExampleData(
+        text=text,
+        extractions=[
+            data.Extraction(
+                extraction_class=extraction_class,
+                extraction_text=extraction_text,
+                attributes={},
+            )
+        ],
+    )
+
+    report = prompt_validation.validate_prompt_alignment([example])
+
+    with self.assertRaisesRegex(
+        prompt_validation.PromptAlignmentError, error_pattern
+    ):
+      prompt_validation.handle_alignment_report(
+          report,
+          prompt_validation.PromptValidationLevel.ERROR,
+          strict_non_exact=strict_non_exact,
+      )
+
+  def test_empty_examples_produces_empty_report(self):
+    report = prompt_validation.validate_prompt_alignment([])
+
+    self.assertEmpty(report.issues)
+    self.assertFalse(report.has_failed)
+    self.assertFalse(report.has_non_exact)
+
+  def test_multiple_examples_preserve_indices(self):
+    examples = [
+        data.ExampleData(  # Example 0: FAILS - "metformin" not in text
+            text="First patient record.",
+            extractions=[
+                data.Extraction(
+                    extraction_class="Medication",
+                    extraction_text="metformin",
+                    attributes={},
+                )
+            ],
+        ),
+        data.ExampleData(  # Example 1: PASSES - "aspirin" found exactly
+            text="Patient takes aspirin daily.",
+            extractions=[
+                data.Extraction(
+                    extraction_class="Medication",
+                    extraction_text="aspirin",
+                    attributes={},
+                )
+            ],
+        ),
+        data.ExampleData(  # Example 2: NON-EXACT - "type-2" fuzzy matches "Type 2"
+            text="Type 2 diabetes mellitus.",
+            extractions=[
+                data.Extraction(
+                    extraction_class="Diagnosis",
+                    extraction_text="type-2 diabetes",
+                    attributes={},
+                )
+            ],
+        ),
+    ]
+
+    report = prompt_validation.validate_prompt_alignment(examples)
+
+    # Expect 2 issues: example 0 (failed) and example 2 (non-exact)
+    self.assertLen(report.issues, 2)
+    self.assertTrue(report.has_failed)
+    self.assertTrue(report.has_non_exact)
+
+    issue_by_index = {issue.example_index: issue for issue in report.issues}
+
+    # Example 0: Failed alignment (metformin not found)
+    self.assertIn(0, issue_by_index)
+    self.assertIsNone(issue_by_index[0].alignment_status)
+
+    # Example 1: No issue (aspirin found exactly)
+    self.assertNotIn(1, issue_by_index)
+
+    # Example 2: Non-exact match (type-2 vs Type 2)
+    self.assertIn(2, issue_by_index)
+    self.assertIsNotNone(issue_by_index[2].alignment_status)
+
+  def test_validation_does_not_mutate_input(self):
+    example = data.ExampleData(
+        text="Patient takes lisinopril 10mg daily.",
+        extractions=[
+            data.Extraction(
+                extraction_class="Medication",
+                extraction_text="lisinopril",
+                attributes={},
+            )
+        ],
+    )
+
+    original_extraction = example.extractions[0]
+
+    self.assertIsNone(getattr(original_extraction, "token_interval", None))
+    self.assertIsNone(getattr(original_extraction, "char_interval", None))
+    self.assertIsNone(getattr(original_extraction, "alignment_status", None))
+
+    _ = prompt_validation.validate_prompt_alignment([example])
+
+    self.assertIsNone(getattr(original_extraction, "token_interval", None))
+    self.assertIsNone(getattr(original_extraction, "char_interval", None))
+    self.assertIsNone(getattr(original_extraction, "alignment_status", None))
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="fuzzy_disabled_rejects_non_exact",
+          text="Patient has type 2 diabetes.",
+          extraction_class="Diagnosis",
+          extraction_text="Type-2 Diabetes",
+          enable_fuzzy=False,
+          accept_lesser=False,
+          fuzzy_threshold=0.75,
+          expected_has_failed=True,
+          expected_has_non_exact=False,
+      ),
+      dict(
+          testcase_name="fuzzy_enabled_accepts_close_match",
+          text="Patient has type 2 diabetes.",
+          extraction_class="Diagnosis",
+          extraction_text="Type-2 Diabetes",
+          enable_fuzzy=True,
+          accept_lesser=False,
+          fuzzy_threshold=0.75,
+          expected_has_failed=False,
+          expected_has_non_exact=True,
+      ),
+  )
+  def test_alignment_policies(
+      self,
+      text,
+      extraction_class,
+      extraction_text,
+      enable_fuzzy,
+      accept_lesser,
+      fuzzy_threshold,
+      expected_has_failed,
+      expected_has_non_exact,
+  ):
+    """Test different alignment policy configurations."""
+    example = data.ExampleData(
+        text=text,
+        extractions=[
+            data.Extraction(
+                extraction_class=extraction_class,
+                extraction_text=extraction_text,
+                attributes={},
+            )
+        ],
+    )
+
+    if not enable_fuzzy:
+      default_report = prompt_validation.validate_prompt_alignment([example])
+      self.assertFalse(default_report.has_failed)
+      self.assertTrue(default_report.has_non_exact)
+
+    policy = prompt_validation.AlignmentPolicy(
+        enable_fuzzy_alignment=enable_fuzzy,
+        accept_match_lesser=accept_lesser,
+        fuzzy_alignment_threshold=fuzzy_threshold,
+    )
+    report = prompt_validation.validate_prompt_alignment(
+        [example], policy=policy
+    )
+
+    self.assertEqual(report.has_failed, expected_has_failed)
+    self.assertEqual(report.has_non_exact, expected_has_non_exact)
+
+
+class ExtractIntegrationTest(absltest.TestCase):
+  """Minimal integration test for extract() entry point validation."""
+
+  def test_extract_validates_in_error_mode(self):
+    """Verify extract() runs validation when configured."""
+    examples = [
+        data.ExampleData(
+            text="Patient takes aspirin.",
+            extractions=[
+                data.Extraction(
+                    extraction_class="Medication",
+                    extraction_text="ibuprofen",
+                    attributes={},
+                )
+            ],
+        )
+    ]
+
+    with self.assertRaisesRegex(
+        prompt_validation.PromptAlignmentError,
+        r"1 extraction\(s\).*could not be aligned",
+    ):
+      extraction.extract(
+          text_or_documents="Test document",
+          prompt_description="Extract medications",
+          examples=examples,
+          prompt_validation_level=prompt_validation.PromptValidationLevel.ERROR,
+          model_id="fake-model",
+      )
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
# Description

Adds validation to ensure few-shot example extractions can be found in their source text. Catches prompt typos/mistakes and ensures examples are compatible with the alignment system.

**Modes:**
- `OFF`: Skip validation
- `WARNING` (default): Log issues, continue
- `ERROR`: Raise exception on misalignment

**Changes:**
- New `prompt_validation.py` module with alignment checking
- Added `prompt_validation_level` and `prompt_validation_strict` params to `extract()`
- 15 comprehensive tests, no new dependencies

Related to #209, #151, #210

(Feature)

# How Has This Been Tested?

```bash
$ python -m pytest tests/prompt_validation_test.py -v
...
============================== 15 passed in 0.47s ==============================
```

- Added 15 tests covering all alignment scenarios
- All existing tests pass (backward compatible)
- Verified README/docs examples pass validation
- Code formatted with `./autoformat.sh`, no pylint issues

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.