### PR TITLE
Refactor: Use resolver_params for alignment configuration

### DIFF
--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -26,6 +26,7 @@ import functools
 import itertools
 import json
 import operator
+from typing import Final
 
 from absl import logging
 import yaml
@@ -36,6 +37,12 @@ from langextract.core import schema
 from langextract.core import tokenizer
 
 _FUZZY_ALIGNMENT_MIN_THRESHOLD = 0.75
+
+ALIGNMENT_PARAM_KEYS: Final[frozenset[str]] = frozenset({
+    "enable_fuzzy_alignment",
+    "fuzzy_alignment_threshold",
+    "accept_match_lesser",
+})
 
 
 class AbstractResolver(abc.ABC):


### PR DESCRIPTION
## Summary
Refactors alignment parameter implementation to use existing `resolver_params` instead of adding new `alignment_params` parameter.

## Changes
- Uses existing `resolver_params` dictionary to avoid API proliferation
- Centralizes alignment keys as immutable constant in `resolver.py`
- Splits params cleanly between Resolver and annotator layers
- Adds comprehensive test coverage and error handling

## Alignment Parameters
Available through `resolver_params`:
- `enable_fuzzy_alignment`: Use fuzzy matching if exact fails
- `fuzzy_alignment_threshold`: Token overlap ratio (0.0-1.0)
- `accept_match_lesser`: Accept partial exact matches

This is an alternative implementation of #211 that resolves merge conflicts while maintaining all performance optimizations.

cc @Skippou