### PR TITLE
docs: Fix broken community support link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -18,7 +18,7 @@ blank_issues_enabled: true
 # Redirect users to other channels for general support or security issues
 contact_links:
   - name: Community Support
-    url: https://github.com/google-health/langextract/discussions
+    url: https://github.com/google/langextract/discussions
     about: Please ask and answer questions here.
   - name: Security Bug Reporting
     url: https://g.co/vulnz


### PR DESCRIPTION
# Description

This pull request fixes a broken link in the issue creation template (`.github/ISSUE_TEMPLATE/config.yml`). The "Community Support" contact link was pointing to `https://github.com/google-health/langextract/discussions`, which resulted in a 404 error for users trying to access the discussions page.

The link has been corrected to point to the correct discussions URL for the repository: `https://github.com/google/langextract/discussions`. Please note that this link will still result in a 404 error until the repository's "Discussions" tab is enabled by a maintainer.

Fixes #220

(Bug fix)

# How Has This Been Tested?

I verified the fix by manually navigating to the corrected URL on a different repository (`https://github.com/google/mangle/discussions`) to ensure it leads to the correct page.

Since this is a simple URL change in a configuration file, no additional code tests were required.

# Checklist:

-   [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the [Contributing](https://github.com/google/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
-   [ ] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.

***

**Note to maintainers:** I noticed that the repository's "Discussions" tab is not yet enabled. Enabling it would make the "Community Support" link functional.