### PR TITLE
feat: Add show_progress parameter for independent progress bar control

### DIFF
--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -56,6 +56,7 @@ def extract(
     fetch_urls: bool = True,
     prompt_validation_level: pv.PromptValidationLevel = pv.PromptValidationLevel.WARNING,
     prompt_validation_strict: bool = False,
+    show_progress: bool = True,
 ) -> typing.Any:
   """Extracts structured information from text.
 
@@ -149,6 +150,7 @@ def extract(
         raises on failures. Defaults to WARNING.
       prompt_validation_strict: When True and prompt_validation_level is ERROR,
         raises on non-exact matches (MATCH_FUZZY, MATCH_LESSER). Defaults to False.
+      show_progress: Whether to show progress bar during extraction. Defaults to True.
 
   Returns:
       An AnnotatedDocument with the extracted information when input is a
@@ -326,6 +328,7 @@ def extract(
         additional_context=additional_context,
         debug=debug,
         extraction_passes=extraction_passes,
+        show_progress=show_progress,
         max_workers=max_workers,
         **alignment_kwargs,
     )
@@ -338,6 +341,7 @@ def extract(
         batch_length=batch_length,
         debug=debug,
         extraction_passes=extraction_passes,
+        show_progress=show_progress,
         max_workers=max_workers,
         **alignment_kwargs,
     )


### PR DESCRIPTION
# Description

Adds `show_progress` parameter to control progress bar visibility independently of debug logging. Users can now show/hide progress without affecting debug output.

Fixes #221

Choose one: Bug fix

# How Has This Been Tested?

```bash
# Formatted code
./autoformat.sh

# Linting passed
pylint --rcfile=.pylintrc langextract
pylint --rcfile=tests/.pylintrc tests

# Tests pass
pytest tests/init_test.py -k "test_show_progress" -v
```

All 4 parameterized test cases verify progress bar control works correctly.

# Checklist:

-   [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.