### PR TITLE
Internal: Strengthen CI/CD security for fork PR validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -289,6 +289,13 @@ jobs:
               throw new Error(`User ${context.actor} does not have maintainer permissions.`);
             }
 
+      - name: Pin commit SHA for security
+        id: sha-pin
+        run: |
+          SHA_TO_TEST="${{ github.event.pull_request.head.sha }}"
+          echo "SHA_TO_TEST=${SHA_TO_TEST}" >> $GITHUB_OUTPUT
+          echo "::notice title=Security::Pinned commit SHA for testing: ${SHA_TO_TEST}"
+
       - name: Checkout base repo
         uses: actions/checkout@v4
         with:
@@ -296,15 +303,28 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Fetch and checkout PR head
+      - name: Fetch and verify exact PR commit
         run: |
           set -euo pipefail
-          git fetch --no-tags --prune --no-recurse-submodules origin \
-            +refs/pull/${{ github.event.pull_request.number }}/head:pr-to-test || {
-            echo "::error::Failed to fetch PR branch. The branch may have been deleted."
+          EXPECTED_SHA="${{ steps.sha-pin.outputs.SHA_TO_TEST }}"
+          echo "Fetching exact commit: $EXPECTED_SHA"
+          
+          # Fetch the specific commit SHA
+          git fetch --no-tags --prune --no-recurse-submodules origin "$EXPECTED_SHA" || {
+            echo "::error::Failed to fetch PR commit $EXPECTED_SHA. The commit may have been deleted."
             exit 1
           }
-          git checkout pr-to-test
+          
+          git checkout -b pr-to-test "$EXPECTED_SHA"
+          
+          # Verify checkout
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::SHA verification failed! Expected $EXPECTED_SHA but got $ACTUAL_SHA"
+            exit 1
+          fi
+          
+          echo "::notice title=Security::Successfully verified commit SHA: $ACTUAL_SHA"
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -314,7 +334,8 @@ jobs:
       - name: Install format tools
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          # Install formatter tools with pinned versions
+          pip install pyink==24.3.0 isort==5.13.2 lint-imports==0.3.1
 
       - name: Validate PR formatting
         run: |
@@ -336,25 +357,22 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Merge PR commit with verification
+      - name: Merge verified PR commit
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Verify commit hasn't changed since labeling
-          git fetch --no-tags --prune --no-recurse-submodules origin +refs/pull/${{ github.event.pull_request.number }}/head:pr-to-test
-          EXPECTED_SHA="${{ github.event.pull_request.head.sha }}"
-          FETCHED_SHA="$(git rev-parse pr-to-test)"
-          echo "Expected commit: $EXPECTED_SHA"
-          echo "Fetched commit:  $FETCHED_SHA"
-
-          if [ "$FETCHED_SHA" != "$EXPECTED_SHA" ]; then
-            echo "::error::PR was modified after labeling. Remove and re-apply 'ready-to-merge' label to test latest changes."
+          SHA_TO_MERGE="${{ steps.sha-pin.outputs.SHA_TO_TEST }}"
+          echo "Merging verified commit: $SHA_TO_MERGE"
+          
+          git fetch --no-tags --prune --no-recurse-submodules origin "$SHA_TO_MERGE"
+          git merge --no-ff --no-edit "$SHA_TO_MERGE" || {
+            echo "::error::Failed to merge commit $SHA_TO_MERGE"
             exit 1
-          fi
-
-          git merge --no-ff --no-edit "$EXPECTED_SHA"
+          }
+          
+          echo "::notice title=Security::Successfully merged verified commit"
 
       - name: Add status comment
         uses: actions/github-script@v7


### PR DESCRIPTION
Fetch exact commit SHA instead of branch HEAD to prevent race conditions.