### PR TITLE
Fix: Enable suppress_parse_errors parameter in resolver_params

### DIFF
--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -121,7 +121,8 @@ def extract(
         reduce recall. Default is True. 'fuzzy_alignment_threshold' (float):
         Minimum token overlap ratio for fuzzy match (0.0-1.0). Default is 0.75.
         'accept_match_lesser' (bool): Whether to accept partial exact matches.
-        Default is True.
+        Default is True. 'suppress_parse_errors' (bool): Whether to suppress
+        parsing errors and continue pipeline. Default is False.
       language_model_params: Additional parameters for the language model.
       debug: Whether to enable debug logging. When True, enables detailed logging
         of function calls, arguments, return values, and timing for the langextract

--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -46,6 +46,7 @@ ALIGNMENT_PARAM_KEYS: Final[frozenset[str]] = frozenset({
     "enable_fuzzy_alignment",
     "fuzzy_alignment_threshold",
     "accept_match_lesser",
+    "suppress_parse_errors",
 })
 
 


### PR DESCRIPTION
# Description

Enables the `suppress_parse_errors` parameter to be passed through `resolver_params` in the `extract()` method. Previously, attempting to use this parameter would result in a TypeError.

The parameter was already supported by `Resolver.resolve()` but couldn't be accessed via the public API due to missing configuration in `ALIGNMENT_PARAM_KEYS`.

Fixes #253

Bug fix

# How Has This Been Tested?

Added test to verify the parameter flows correctly through the extraction pipeline. Ran full test suite:

```
$ tox -e py312,lint-src,lint-tests
...
====================== 333 passed, 1 deselected in 3.11s =======================
```

# Checklist:

-   [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.

Based on brightertiger's original work in PR #252.