### PR TITLE
Multi-Document Extraction Bleed Fix

### DIFF
--- a/langextract/annotation.py
+++ b/langextract/annotation.py
@@ -357,13 +357,14 @@ class Annotator:
               "Completing annotation for document ID %s.",
               curr_document.document_id,
           )
+          doc_extractions = list(annotated_extractions)
           annotated_doc = data.AnnotatedDocument(
               document_id=curr_document.document_id,
-              extractions=annotated_extractions,
+              extractions=doc_extractions,
               text=curr_document.text,
           )
           yield annotated_doc
-          annotated_extractions.clear()
+          annotated_extractions = []  # Ensure next document gets a fresh list.
 
           curr_document = next(doc_iter, None)
           assert curr_document is not None, (
@@ -400,13 +401,15 @@ class Annotator:
       logging.info(
           "Finalizing annotation for document ID %s.", curr_document.document_id
       )
+      doc_extractions = list(annotated_extractions)
       annotated_doc = data.AnnotatedDocument(
           document_id=curr_document.document_id,
-          extractions=annotated_extractions,
+          extractions=doc_extractions,
           text=curr_document.text,
       )
 
       yield annotated_doc
+      annotated_extractions = []  # Fresh list prevents bleed into future docs.
 
     logging.info("Document annotation completed.")
 


### PR DESCRIPTION
This is a fix for my own issue #260.

- Edited apps/worker-py/.venv/lib/python3.11/site-packages/langextract/annotation.py.

  1. Inside _annotate_documents_single_pass, when creating annotated_doc before yielding (around the loop that flushes finished
     documents), wrap annotated_extractions in list(...) (or use copy()), then immediately reset annotated_extractions = [] so
     the next document gets its own list.
  2. Apply the same treatment in the final flush block at the end of the function so the last document is isolated as well.
  3. Ensure any other yield site in this function (including the sequential-pass helper if it reuses the same collector) also
     hands out a fresh list.
  4. Write a simple test.

Commits:
  - langextract/langextract/annotation.py:355 and langextract/langextract/annotation.py:404 now hand out a copied extraction list before each yield and immediately reset annotated_extractions so every document receives its own list without bleed- through.
  - langextract/tests/annotation_test.py:745 introduces a regression test with a fake resolver that asserts each annotated document keeps its own extraction payload and that the lists are distinct.