### PR TITLE
ollama: send keep_alive at top level

### DIFF
--- a/langextract/providers/ollama.py
+++ b/langextract/providers/ollama.py
@@ -348,10 +348,12 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
       )
 
     options: dict[str, Any] = {}
-    if keep_alive is not None:
-      options['keep_alive'] = keep_alive
-    else:
-      options['keep_alive'] = _DEFAULT_KEEP_ALIVE
+    # Compute keep_alive once; retain in options for back-compat and
+    # also send at the top level to match Ollama API.
+    keep_alive_value = (
+        keep_alive if keep_alive is not None else _DEFAULT_KEEP_ALIVE
+    )
+    options['keep_alive'] = keep_alive_value
 
     if seed is not None:
       options['seed'] = seed
@@ -402,6 +404,8 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
         'raw': raw,
         'options': options,
     }
+    # Canonical: keep_alive should be at the top level per Ollama API
+    payload['keep_alive'] = keep_alive_value
 
     if structured_output_format is not None:
       payload['format'] = structured_output_format

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -185,6 +185,8 @@ class TestOllamaLanguageModel(absltest.TestCase):
     call_args = mock_post.call_args
     json_payload = call_args.kwargs["json"]
 
+    # keep_alive should be present at top-level for Ollama API
+    self.assertEqual(json_payload["keep_alive"], 600)
     self.assertEqual(json_payload["options"]["keep_alive"], 600)
     self.assertEqual(json_payload["options"]["num_thread"], 8)
     # timeout is passed to requests.post, not in the JSON payload
@@ -238,6 +240,8 @@ class TestOllamaLanguageModel(absltest.TestCase):
     call_args = mock_post.call_args
     json_payload = call_args.kwargs["json"]
 
+    # keep_alive defaults at the top-level too
+    self.assertEqual(json_payload["keep_alive"], 300)
     self.assertEqual(json_payload["options"]["temperature"], 0.1)
     self.assertEqual(json_payload["options"]["keep_alive"], 300)
     self.assertEqual(json_payload["options"]["num_ctx"], 2048)


### PR DESCRIPTION

fixes #256 This PR aligns the Ollama provider with the Ollama API by sending keep_alive at the payload’s top level while keeping options.keep_alive for backward compatibility.

Changes
Provider: compute keep_alive once, set payload['keep_alive'] and options['keep_alive'].

Tests: in tests/inference_test.py:
test_ollama_extra_kwargs_passed_to_api: assert payload['keep_alive'] == 600.
test_ollama_defaults_when_unspecified: assert payload['keep_alive'] == 300.

Compatibility
Backward-compatible: options.keep_alive is still present. No breaking API changes.