### PR TITLE
docs: Clarify best practices for few-shot examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ examples = [
 ]
 ```
 
+> **Note:** Examples drive model behavior. Each `extraction_text` should ideally be verbatim from the example's `text` (no paraphrasing), listed in order of appearance. LangExtract raises `Prompt alignment` warnings by default if examples don't follow this pattern—resolve these for best results.
+
 ### 2. Run the Extraction
 
 Provide your input text and the prompt materials to the `lx.extract` function.


### PR DESCRIPTION
Adds a brief note after the example code in the Quick Start section clarifying that:

- `extraction_text` should ideally be verbatim from the example's `text`
- Extractions should be listed in order of appearance
- LangExtract raises `Prompt alignment` warnings by default when examples don't follow this pattern

Addresses #246.