### PR TITLE
Fix: Unpack and store alignment parameters in Resolver

### DIFF
--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -126,9 +126,9 @@ class AbstractResolver(abc.ABC):
       source_text: str,
       token_offset: int,
       char_offset: int | None = None,
-      enable_fuzzy_alignment: bool = True,
-      fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD,
-      accept_match_lesser: bool = True,
+      enable_fuzzy_alignment: bool | None = None,
+      fuzzy_alignment_threshold: float | None = None,
+      accept_match_lesser: bool | None = None,
       **kwargs,
   ) -> Iterator[data.Extraction]:
     """Aligns extractions with source text, setting token/char intervals and alignment status.
@@ -216,6 +216,14 @@ class Resolver(AbstractResolver):
       else:
         format_handler = fh.FormatHandler()
 
+    # Consume alignment parameters
+    self.enable_fuzzy_alignment = kwargs.pop("enable_fuzzy_alignment", True)
+    self.fuzzy_alignment_threshold = kwargs.pop(
+        "fuzzy_alignment_threshold", _FUZZY_ALIGNMENT_MIN_THRESHOLD
+    )
+    self.accept_match_lesser = kwargs.pop("accept_match_lesser", True)
+    self.suppress_parse_errors = kwargs.pop("suppress_parse_errors", False)
+
     if kwargs:
       raise TypeError(
           f"got an unexpected keyword argument '{list(kwargs.keys())[0]}'"
@@ -234,7 +242,7 @@ class Resolver(AbstractResolver):
   def resolve(
       self,
       input_text: str,
-      suppress_parse_errors: bool = False,
+      suppress_parse_errors: bool | None = None,
       **kwargs,
   ) -> Sequence[data.Extraction]:
     """Runs resolve function on text with YAML/JSON extraction data.
@@ -253,6 +261,9 @@ class Resolver(AbstractResolver):
     """
     logging.debug("Starting resolver process for input text.")
     logging.debug("Input Text: %s", input_text)
+
+    if suppress_parse_errors is None:
+      suppress_parse_errors = getattr(self, "suppress_parse_errors", False)
 
     try:
       constraint = getattr(self, "_constraint", schema.Constraint())
@@ -282,9 +293,9 @@ class Resolver(AbstractResolver):
       source_text: str,
       token_offset: int,
       char_offset: int | None = None,
-      enable_fuzzy_alignment: bool = True,
-      fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD,
-      accept_match_lesser: bool = True,
+      enable_fuzzy_alignment: bool | None = None,
+      fuzzy_alignment_threshold: float | None = None,
+      accept_match_lesser: bool | None = None,
       tokenizer_inst: tokenizer_lib.Tokenizer | None = None,
       **kwargs,
   ) -> Iterator[data.Extraction]:
@@ -302,10 +313,11 @@ class Resolver(AbstractResolver):
       token_offset: The starting token index of the chunk.
       char_offset: The starting character index of the chunk.
       enable_fuzzy_alignment: Whether to enable fuzzy alignment fallback.
+        Defaults to instance setting or True.
       fuzzy_alignment_threshold: Minimum overlap ratio required for fuzzy
-        alignment.
+        alignment. Defaults to instance setting or 0.75.
       accept_match_lesser: Whether to accept partial exact matches (MATCH_LESSER
-        status).
+        status). Defaults to instance setting or True.
       tokenizer_inst: Optional tokenizer instance.
       **kwargs: Additional parameters.
 
@@ -322,6 +334,17 @@ class Resolver(AbstractResolver):
       return
     else:
       extractions_group = [extractions]
+
+    if enable_fuzzy_alignment is None:
+      enable_fuzzy_alignment = getattr(self, "enable_fuzzy_alignment", True)
+
+    if fuzzy_alignment_threshold is None:
+      fuzzy_alignment_threshold = getattr(
+          self, "fuzzy_alignment_threshold", _FUZZY_ALIGNMENT_MIN_THRESHOLD
+      )
+
+    if accept_match_lesser is None:
+      accept_match_lesser = getattr(self, "accept_match_lesser", True)
 
     aligner = WordAligner()
     aligned_yaml_extractions = aligner.align_extractions(
@@ -692,11 +715,11 @@ class WordAligner:
         character intervals.
       delim: Token used to separate multi-token extractions.
       enable_fuzzy_alignment: Whether to use fuzzy alignment when exact matching
-        fails.
+        fails. Defaults to instance setting or True.
       fuzzy_alignment_threshold: Minimum token overlap ratio for fuzzy alignment
-        (0-1).
+        (0-1). Defaults to instance setting or 0.75.
       accept_match_lesser: Whether to accept partial exact matches (MATCH_LESSER
-        status).
+        status). Defaults to instance setting or True.
       tokenizer_impl: Optional tokenizer instance.
 
     Returns:

--- a/tests/resolver_params_test.py
+++ b/tests/resolver_params_test.py
@@ -1,0 +1,73 @@
+import unittest
+from langextract import resolver as resolver_lib
+from langextract.core import data
+from langextract.core import tokenizer
+
+class ResolverParamsTest(unittest.TestCase):
+
+    def test_resolver_accepts_alignment_params(self):
+        # This should currently raise TypeError
+        resolver = resolver_lib.Resolver(
+            fuzzy_alignment_threshold=0.6,
+            enable_fuzzy_alignment=True
+        )
+        self.assertEqual(resolver.fuzzy_alignment_threshold, 0.6)
+        self.assertTrue(resolver.enable_fuzzy_alignment)
+
+    def test_align_uses_instance_threshold(self):
+        # Setup a case where default threshold (0.75) fails but 0.6 succeeds
+        # Extraction: "headache and fever" (3 tokens)
+        # Source: "Patient reports back pain and a fever."
+        # Intersection: "and", "fever" (2 tokens) -> 2/3 = 0.66
+
+        resolver = resolver_lib.Resolver(
+            fuzzy_alignment_threshold=0.6,
+            enable_fuzzy_alignment=True,
+            accept_match_lesser=False
+        )
+
+        extractions = [
+            data.Extraction(
+                extraction_class="symptom",
+                extraction_text="headache and fever"
+            )
+        ]
+        source_text = "Patient reports back pain and a fever."
+
+        aligned = list(resolver.align(
+            extractions,
+            source_text,
+            token_offset=0
+        ))
+
+        self.assertEqual(len(aligned), 1)
+        # Should match because 0.66 >= 0.6
+        self.assertEqual(aligned[0].alignment_status, data.AlignmentStatus.MATCH_FUZZY)
+
+    def test_align_uses_instance_threshold_fail(self):
+        # Same case, but threshold 0.8 -> should fail
+        resolver = resolver_lib.Resolver(
+            fuzzy_alignment_threshold=0.8,
+            enable_fuzzy_alignment=True,
+            accept_match_lesser=False
+        )
+
+        extractions = [
+            data.Extraction(
+                extraction_class="symptom",
+                extraction_text="headache and fever"
+            )
+        ]
+        source_text = "Patient reports back pain and a fever."
+
+        aligned = list(resolver.align(
+            extractions,
+            source_text,
+            token_offset=0
+        ))
+
+        # Should not match
+        self.assertIsNone(aligned[0].alignment_status)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Address: https://github.com/google/langextract/issues/245

This commit modifies `langextract/resolver.py` to properly unpack and store alignment parameters (e.g., `fuzzy_alignment_threshold`, `enable_fuzzy_alignment`) when they are passed to the `Resolver` constructor via `resolver_params` (or kwargs).

Previously, these parameters were causing a `TypeError` in `Resolver.__init__` because they were not popped from `kwargs` and `Resolver` did not expect them. Additionally, instance-level configuration was not persisted for use in `align` and `resolve` methods.

Changes:
- Update `Resolver.__init__` to consume alignment parameters from `kwargs` and store them as instance attributes.
- Update `Resolver.align` and `Resolver.resolve` to accept `None` for these parameters and fallback to instance attributes or default constants.
- Update `AbstractResolver` signatures to match.
- Add `tests/resolver_params_test.py` to verify the fix.