### PR TITLE
docs: Fix typo and improve professionalism in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ examples = [
 ]
 ```
 
-> **Note:** Examples drive model behavior. Each `extraction_text` should ideally be verbatim from the example's `text` (no paraphrasing), listed in order of appearance. LangExtract raises `Prompt alignment` warnings by default if examples don't follow this pattern—resolve these for best results.
+> **Note:** Examples guide model behavior. Each `extraction_text` should ideally be verbatim from the example's `text` (no paraphrasing), listed in order of appearance. LangExtract raises `Prompt alignment` warnings by default if examples don't follow this pattern—resolve these for best results.
 
 ### 2. Run the Extraction
 
@@ -456,5 +456,5 @@ For health-related applications, use of LangExtract is also subject to the
 [Health AI Developer Foundations Terms of Use](https://developers.google.com/health-ai-developer-foundations/terms).
 
 ---
-
+**We hope you find LangExtract useful for your projects.**
 **Happy Extracting!**


### PR DESCRIPTION
This PR makes small but meaningful improvements to the README.md:

-  Updated "Examples drive model behavior" → "Examples guide model behavior" for more professional wording.
- Added a professional closing sentence above the original "Happy Extracting!" to balance professionalism with the author’s original tone.

These changes improve clarity and professionalism without altering the technical meaning or removing the original author’s words.
