### PR TITLE
Prevent semantic template collapse in VSA integration

### DIFF
--- a/langextract/core/__init__.py
+++ b/langextract/core/__init__.py
@@ -28,4 +28,7 @@ __all__ = [
     "schema",
     "data",
     "tokenizer",
+    "baf_vector",
+    "collapse_resistance",
+    "grammar_triangle",
 ]

--- a/langextract/core/baf_vector.py
+++ b/langextract/core/baf_vector.py
@@ -1,0 +1,362 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bipolar Awareness Field (BAF) vector operations for VSA integration.
+
+This module provides core vector operations for the Bipolar Awareness Field,
+which preserves semantic superposition during extraction while allowing
+template matching without collapsing meaning.
+
+The key insight is that templates "project" meaning rather than "bind" it,
+allowing the original semantic field to be preserved alongside structured
+extractions.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from typing import Sequence
+
+import numpy as np
+
+__all__ = [
+    "HyperVector",
+    "BAFConfig",
+    "bind",
+    "bundle",
+    "unbind",
+    "similarity",
+    "float_to_bipolar",
+    "bipolar_to_float",
+    "random_bipolar",
+]
+
+# Default dimension for bipolar hypervectors
+DEFAULT_DIM = 10000
+
+
+@dataclasses.dataclass
+class BAFConfig:
+    """Configuration for Bipolar Awareness Field operations.
+
+    Attributes:
+        dimension: The dimensionality of bipolar vectors (default 10000).
+        seed: Random seed for reproducible basis vector generation.
+        normalize_bundles: Whether to normalize bundled vectors.
+    """
+
+    dimension: int = DEFAULT_DIM
+    seed: int | None = None
+    normalize_bundles: bool = True
+
+
+@dataclasses.dataclass
+class HyperVector:
+    """A bipolar hypervector for Vector Symbolic Architecture operations.
+
+    Bipolar vectors use {-1, +1} values, which provide better mathematical
+    properties for binding and bundling operations than binary {0, 1} vectors.
+
+    Attributes:
+        data: The underlying numpy array of bipolar values.
+        label: Optional semantic label for the vector.
+        metadata: Optional dictionary of additional metadata.
+    """
+
+    data: np.ndarray
+    label: str | None = None
+    metadata: dict | None = None
+
+    def __post_init__(self):
+        """Validate the vector data."""
+        if self.data.dtype != np.int8:
+            self.data = self.data.astype(np.int8)
+
+    @property
+    def dimension(self) -> int:
+        """Return the dimensionality of the vector."""
+        return len(self.data)
+
+    def similarity(self, other: "HyperVector") -> float:
+        """Compute cosine similarity with another hypervector."""
+        return similarity(self, other)
+
+    def bind(self, other: "HyperVector") -> "HyperVector":
+        """Bind this vector with another (element-wise multiplication)."""
+        return bind(self, other)
+
+    def unbind(self, other: "HyperVector") -> "HyperVector":
+        """Unbind another vector from this one."""
+        return unbind(self, other)
+
+    def to_bytes(self) -> bytes:
+        """Serialize to bytes for storage (bit-packed for efficiency)."""
+        # Convert {-1, +1} to {0, 1} for bit packing
+        bits = (self.data + 1) // 2
+        # Pack 8 bits per byte
+        packed = np.packbits(bits.astype(np.uint8))
+        return packed.tobytes()
+
+    @classmethod
+    def from_bytes(
+        cls, data: bytes, dimension: int = DEFAULT_DIM, label: str | None = None
+    ) -> "HyperVector":
+        """Deserialize from bytes."""
+        packed = np.frombuffer(data, dtype=np.uint8)
+        bits = np.unpackbits(packed)[:dimension]
+        # Convert {0, 1} back to {-1, +1}
+        values = (bits.astype(np.int8) * 2) - 1
+        return cls(data=values, label=label)
+
+    def __repr__(self) -> str:
+        label_str = f", label={self.label!r}" if self.label else ""
+        return f"HyperVector(dim={self.dimension}{label_str})"
+
+
+def random_bipolar(
+    dimension: int = DEFAULT_DIM,
+    label: str | None = None,
+    rng: np.random.Generator | None = None,
+) -> HyperVector:
+    """Generate a random bipolar hypervector.
+
+    Args:
+        dimension: The dimensionality of the vector.
+        label: Optional semantic label.
+        rng: Optional numpy random generator for reproducibility.
+
+    Returns:
+        A new random bipolar hypervector.
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+    data = rng.choice([-1, 1], size=dimension).astype(np.int8)
+    return HyperVector(data=data, label=label)
+
+
+def bind(v1: HyperVector, v2: HyperVector) -> HyperVector:
+    """Bind two hypervectors using element-wise multiplication.
+
+    Binding creates a new vector that is dissimilar to both inputs but can
+    be "unbound" to recover the original vectors. This is used for creating
+    role-filler pairs (e.g., AGENT-John, TOPIC-Exchange).
+
+    Args:
+        v1: First hypervector.
+        v2: Second hypervector.
+
+    Returns:
+        The bound hypervector.
+
+    Raises:
+        ValueError: If vectors have different dimensions.
+    """
+    if v1.dimension != v2.dimension:
+        raise ValueError(
+            f"Cannot bind vectors of different dimensions: {v1.dimension} vs {v2.dimension}"
+        )
+    result = (v1.data * v2.data).astype(np.int8)
+    label = None
+    if v1.label and v2.label:
+        label = f"({v1.label}⊗{v2.label})"
+    return HyperVector(data=result, label=label)
+
+
+def unbind(bound: HyperVector, key: HyperVector) -> HyperVector:
+    """Unbind a key from a bound vector to recover the value.
+
+    Since bipolar vectors are self-inverse under multiplication,
+    unbinding is the same operation as binding.
+
+    Args:
+        bound: The bound hypervector.
+        key: The key vector to unbind.
+
+    Returns:
+        The unbound value vector.
+    """
+    return bind(bound, key)
+
+
+def bundle(
+    vectors: Sequence[HyperVector],
+    weights: Sequence[float] | None = None,
+    normalize: bool = True,
+) -> HyperVector:
+    """Bundle multiple hypervectors using weighted addition and thresholding.
+
+    Bundling creates a superposition that preserves similarity to all inputs.
+    This is the key operation for maintaining semantic ambiguity without
+    collapsing meaning.
+
+    Args:
+        vectors: Sequence of hypervectors to bundle.
+        weights: Optional weights for each vector (default: equal weights).
+        normalize: Whether to normalize back to bipolar {-1, +1}.
+
+    Returns:
+        The bundled hypervector.
+
+    Raises:
+        ValueError: If vectors list is empty or dimensions don't match.
+    """
+    if not vectors:
+        raise ValueError("Cannot bundle empty vector list")
+
+    dimension = vectors[0].dimension
+    for v in vectors[1:]:
+        if v.dimension != dimension:
+            raise ValueError(
+                f"All vectors must have same dimension: expected {dimension}, got {v.dimension}"
+            )
+
+    if weights is None:
+        weights = [1.0] * len(vectors)
+    elif len(weights) != len(vectors):
+        raise ValueError(
+            f"Weights length ({len(weights)}) must match vectors length ({len(vectors)})"
+        )
+
+    # Weighted sum
+    result = np.zeros(dimension, dtype=np.float32)
+    for v, w in zip(vectors, weights):
+        result += w * v.data.astype(np.float32)
+
+    if normalize:
+        # Threshold to bipolar: positive -> +1, negative/zero -> -1
+        # Add small random tiebreaker for exact zeros
+        result = np.sign(result)
+        result[result == 0] = np.random.choice([-1, 1], size=np.sum(result == 0))
+        result = result.astype(np.int8)
+    else:
+        result = result.astype(np.int8)
+
+    # Create combined label
+    labels = [v.label for v in vectors if v.label]
+    label = "⊕".join(labels) if labels else None
+
+    return HyperVector(data=result, label=label)
+
+
+def similarity(v1: HyperVector, v2: HyperVector) -> float:
+    """Compute cosine similarity between two hypervectors.
+
+    For bipolar vectors, this is equivalent to the normalized Hamming
+    similarity, ranging from -1 (opposite) to +1 (identical).
+
+    Args:
+        v1: First hypervector.
+        v2: Second hypervector.
+
+    Returns:
+        Cosine similarity in range [-1, 1].
+
+    Raises:
+        ValueError: If vectors have different dimensions.
+    """
+    if v1.dimension != v2.dimension:
+        raise ValueError(
+            f"Cannot compare vectors of different dimensions: {v1.dimension} vs {v2.dimension}"
+        )
+
+    # For bipolar {-1, +1} vectors, cosine = dot product / dimension
+    dot = np.dot(v1.data.astype(np.float32), v2.data.astype(np.float32))
+    return float(dot / v1.dimension)
+
+
+def float_to_bipolar(
+    float_vector: np.ndarray,
+    target_dim: int = DEFAULT_DIM,
+    method: str = "threshold",
+) -> HyperVector:
+    """Convert a float embedding to a bipolar hypervector.
+
+    This is used to convert dense embeddings (e.g., from Jina, BERT) into
+    the bipolar VSA representation while preserving semantic information.
+
+    Args:
+        float_vector: Input float vector (e.g., 1024-dim Jina embedding).
+        target_dim: Target dimension for the bipolar vector.
+        method: Conversion method:
+            - "threshold": Sign-based thresholding (fast, approximate)
+            - "expand": Random projection expansion (better for small inputs)
+
+    Returns:
+        Bipolar hypervector representation.
+
+    Raises:
+        ValueError: If method is unknown.
+    """
+    float_vector = np.asarray(float_vector, dtype=np.float32)
+
+    if method == "threshold":
+        if len(float_vector) >= target_dim:
+            # Subsample or truncate
+            indices = np.linspace(0, len(float_vector) - 1, target_dim, dtype=int)
+            sampled = float_vector[indices]
+        else:
+            # Tile and truncate
+            repeats = math.ceil(target_dim / len(float_vector))
+            tiled = np.tile(float_vector, repeats)[:target_dim]
+            sampled = tiled
+
+        # Threshold to bipolar
+        result = np.sign(sampled)
+        result[result == 0] = 1
+        return HyperVector(data=result.astype(np.int8))
+
+    elif method == "expand":
+        # Random projection expansion (preserves dot product similarity)
+        rng = np.random.default_rng(seed=42)  # Fixed seed for reproducibility
+        projection = rng.standard_normal((target_dim, len(float_vector)))
+        projected = projection @ float_vector
+        result = np.sign(projected)
+        result[result == 0] = 1
+        return HyperVector(data=result.astype(np.int8))
+
+    else:
+        raise ValueError(f"Unknown conversion method: {method}")
+
+
+def bipolar_to_float(
+    bipolar: HyperVector,
+    target_dim: int = 1024,
+) -> np.ndarray:
+    """Convert a bipolar hypervector back to a float representation.
+
+    This is a lossy conversion used primarily for compatibility with
+    systems expecting dense float embeddings.
+
+    Args:
+        bipolar: Input bipolar hypervector.
+        target_dim: Target dimension for output float vector.
+
+    Returns:
+        Float vector representation.
+    """
+    # Simple averaging over chunks
+    data = bipolar.data.astype(np.float32)
+    chunk_size = len(data) // target_dim
+    if chunk_size < 1:
+        chunk_size = 1
+
+    result = np.zeros(target_dim, dtype=np.float32)
+    for i in range(target_dim):
+        start = i * chunk_size
+        end = min(start + chunk_size, len(data))
+        if start < len(data):
+            result[i] = np.mean(data[start:end])
+
+    return result

--- a/langextract/core/collapse_resistance.py
+++ b/langextract/core/collapse_resistance.py
@@ -1,0 +1,360 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Collapse resistance computation for preserving semantic superposition.
+
+This module provides utilities for computing "collapse resistance" - a measure
+of how much an extraction should resist being bound to a fixed semantic role.
+
+The key insight is that:
+- High confidence, unambiguous extractions can safely collapse (bind)
+- Low confidence or ambiguous extractions should preserve superposition
+
+Collapse resistance ranges from 0.0 (fully bound/collapsed) to 1.0 (fully
+superposed/uncollapsed).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from langextract.core import data
+
+__all__ = [
+    "CollapseResistanceConfig",
+    "UncertaintyTensor",
+    "compute_collapse_resistance",
+    "compute_uncertainty_tensor",
+    "bind_with_awareness",
+]
+
+
+@dataclasses.dataclass
+class CollapseResistanceConfig:
+    """Configuration for collapse resistance computation.
+
+    Attributes:
+        confidence_weight: Weight for extraction confidence (0-1).
+        alignment_weight: Weight for alignment quality (0-1).
+        context_weight: Weight for contextual ambiguity (0-1).
+        base_resistance: Minimum collapse resistance (floor).
+        max_resistance: Maximum collapse resistance (ceiling).
+    """
+
+    confidence_weight: float = 0.4
+    alignment_weight: float = 0.3
+    context_weight: float = 0.3
+    base_resistance: float = 0.1
+    max_resistance: float = 0.95
+
+    def __post_init__(self):
+        """Validate configuration."""
+        total_weight = (
+            self.confidence_weight + self.alignment_weight + self.context_weight
+        )
+        if not math.isclose(total_weight, 1.0, rel_tol=1e-3):
+            raise ValueError(
+                f"Weights must sum to 1.0, got {total_weight:.3f}"
+            )
+        if not 0 <= self.base_resistance < self.max_resistance <= 1:
+            raise ValueError(
+                "base_resistance must be less than max_resistance, both in [0,1]"
+            )
+
+
+@dataclasses.dataclass
+class UncertaintyTensor:
+    """3x3 epistemic uncertainty tensor.
+
+    Represents uncertainty across two dimensions:
+    - Epistemic state: Known (K), Not-Known (¬K), Unknown-if-Known (?K)
+    - Temporal: Past, Present, Future
+
+    Each cell contains a probability [0, 1] representing the confidence
+    that the extraction holds the given epistemic-temporal state.
+
+    Layout:
+        [[K_past,  K_present,  K_future ],
+         [¬K_past, ¬K_present, ¬K_future],
+         [?K_past, ?K_present, ?K_future]]
+    """
+
+    tensor: np.ndarray  # Shape (3, 3)
+
+    def __post_init__(self):
+        """Validate tensor shape and values."""
+        if self.tensor.shape != (3, 3):
+            raise ValueError(f"Tensor must be 3x3, got {self.tensor.shape}")
+        if not np.all((self.tensor >= 0) & (self.tensor <= 1)):
+            raise ValueError("All tensor values must be in [0, 1]")
+
+    @classmethod
+    def from_confidence(cls, confidence: float) -> "UncertaintyTensor":
+        """Create uncertainty tensor from a simple confidence score.
+
+        High confidence -> concentrated on K_present
+        Low confidence -> spread across ?K states
+
+        Args:
+            confidence: Extraction confidence in [0, 1].
+
+        Returns:
+            An UncertaintyTensor reflecting the confidence.
+        """
+        tensor = np.zeros((3, 3), dtype=np.float32)
+
+        # Known state concentrates on present
+        tensor[0, 1] = confidence  # K_present
+
+        # Unknown state spreads uncertainty
+        uncertainty = 1.0 - confidence
+        tensor[2, 0] = uncertainty * 0.2  # ?K_past
+        tensor[2, 1] = uncertainty * 0.6  # ?K_present
+        tensor[2, 2] = uncertainty * 0.2  # ?K_future
+
+        return cls(tensor=tensor)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "UncertaintyTensor":
+        """Create from a dictionary with named keys.
+
+        Args:
+            d: Dictionary with keys like "K_past", "¬K_present", etc.
+
+        Returns:
+            An UncertaintyTensor.
+        """
+        keys = [
+            ["K_past", "K_present", "K_future"],
+            ["¬K_past", "¬K_present", "¬K_future"],
+            ["?K_past", "?K_present", "?K_future"],
+        ]
+        tensor = np.zeros((3, 3), dtype=np.float32)
+        for i, row in enumerate(keys):
+            for j, key in enumerate(row):
+                tensor[i, j] = d.get(key, 0.0)
+        return cls(tensor=tensor)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary with named keys."""
+        keys = [
+            ["K_past", "K_present", "K_future"],
+            ["¬K_past", "¬K_present", "¬K_future"],
+            ["?K_past", "?K_present", "?K_future"],
+        ]
+        result = {}
+        for i, row in enumerate(keys):
+            for j, key in enumerate(row):
+                result[key] = float(self.tensor[i, j])
+        return result
+
+    @property
+    def total_uncertainty(self) -> float:
+        """Compute total uncertainty (sum of ?K row)."""
+        return float(np.sum(self.tensor[2, :]))
+
+    @property
+    def temporal_spread(self) -> float:
+        """Compute how spread the uncertainty is across time."""
+        col_sums = np.sum(self.tensor, axis=0)
+        if col_sums.sum() == 0:
+            return 0.0
+        normalized = col_sums / col_sums.sum()
+        # Entropy-based spread measure
+        entropy = -np.sum(normalized * np.log2(normalized + 1e-10))
+        max_entropy = np.log2(3)  # Maximum for 3 states
+        return float(entropy / max_entropy)
+
+
+def compute_collapse_resistance(
+    extraction: "data.Extraction",
+    config: CollapseResistanceConfig | None = None,
+    context_ambiguity: float = 0.5,
+) -> float:
+    """Compute collapse resistance for an extraction.
+
+    Collapse resistance determines how much the extraction should resist
+    being bound to a fixed semantic role. High resistance preserves
+    superposition; low resistance allows binding.
+
+    Args:
+        extraction: The extraction to evaluate.
+        config: Configuration for resistance computation.
+        context_ambiguity: External measure of contextual ambiguity [0, 1].
+
+    Returns:
+        Collapse resistance in [0, 1].
+    """
+    if config is None:
+        config = CollapseResistanceConfig()
+
+    # Factor 1: Inverse of extraction confidence (if available)
+    # Lower confidence -> higher resistance
+    confidence_factor = 0.5  # Default neutral
+    if hasattr(extraction, "attributes") and extraction.attributes:
+        if "confidence" in extraction.attributes:
+            try:
+                conf = float(extraction.attributes["confidence"])
+                confidence_factor = 1.0 - conf
+            except (ValueError, TypeError):
+                pass
+
+    # Factor 2: Alignment quality
+    # Poor alignment -> higher resistance
+    alignment_factor = 0.5  # Default neutral
+    if extraction.alignment_status is not None:
+        from langextract.core.data import AlignmentStatus
+
+        alignment_scores = {
+            AlignmentStatus.MATCH_EXACT: 0.1,   # Low resistance for exact
+            AlignmentStatus.MATCH_LESSER: 0.4,  # Medium-low
+            AlignmentStatus.MATCH_GREATER: 0.5, # Medium
+            AlignmentStatus.MATCH_FUZZY: 0.7,   # Higher resistance for fuzzy
+        }
+        alignment_factor = alignment_scores.get(extraction.alignment_status, 0.5)
+
+    # Factor 3: Context ambiguity (passed in)
+    context_factor = context_ambiguity
+
+    # Weighted combination
+    raw_resistance = (
+        config.confidence_weight * confidence_factor
+        + config.alignment_weight * alignment_factor
+        + config.context_weight * context_factor
+    )
+
+    # Apply floor and ceiling
+    resistance = max(config.base_resistance, min(config.max_resistance, raw_resistance))
+
+    return resistance
+
+
+def compute_uncertainty_tensor(
+    extraction: "data.Extraction",
+    temporal_markers: dict[str, float] | None = None,
+) -> UncertaintyTensor:
+    """Compute the uncertainty tensor for an extraction.
+
+    The tensor captures epistemic uncertainty (known/unknown/uncertain)
+    across temporal dimensions (past/present/future).
+
+    Args:
+        extraction: The extraction to evaluate.
+        temporal_markers: Optional dict of temporal signals extracted from
+            context, e.g., {"past": 0.3, "present": 0.5, "future": 0.2}.
+
+    Returns:
+        A 3x3 UncertaintyTensor.
+    """
+    # Start with confidence-based default
+    confidence = 0.5
+    if hasattr(extraction, "attributes") and extraction.attributes:
+        if "confidence" in extraction.attributes:
+            try:
+                confidence = float(extraction.attributes["confidence"])
+            except (ValueError, TypeError):
+                pass
+
+    # Adjust based on alignment
+    if extraction.alignment_status is not None:
+        from langextract.core.data import AlignmentStatus
+
+        if extraction.alignment_status == AlignmentStatus.MATCH_EXACT:
+            confidence = min(1.0, confidence * 1.2)
+        elif extraction.alignment_status == AlignmentStatus.MATCH_FUZZY:
+            confidence = confidence * 0.8
+
+    tensor = np.zeros((3, 3), dtype=np.float32)
+
+    # Distribute across epistemic states
+    # Cap known_prob to leave room for unknown and uncertain
+    known_prob = min(0.85, confidence)
+    unknown_prob = 0.1
+    uncertain_prob = max(0.0, 1.0 - known_prob - unknown_prob)
+
+    # Normalize to ensure sum equals 1.0
+    total = known_prob + unknown_prob + uncertain_prob
+    if total > 0:
+        known_prob /= total
+        unknown_prob /= total
+        uncertain_prob /= total
+
+    # Default temporal distribution (concentrated on present)
+    if temporal_markers is None:
+        temporal_markers = {"past": 0.2, "present": 0.6, "future": 0.2}
+
+    # Normalize temporal markers
+    total = sum(temporal_markers.values())
+    if total > 0:
+        temporal_markers = {k: v / total for k, v in temporal_markers.items()}
+
+    # Fill tensor
+    # Row 0: Known (K)
+    tensor[0, 0] = known_prob * temporal_markers.get("past", 0.2)
+    tensor[0, 1] = known_prob * temporal_markers.get("present", 0.6)
+    tensor[0, 2] = known_prob * temporal_markers.get("future", 0.2)
+
+    # Row 1: Not-Known (¬K)
+    tensor[1, 0] = unknown_prob * temporal_markers.get("past", 0.2)
+    tensor[1, 1] = unknown_prob * temporal_markers.get("present", 0.6)
+    tensor[1, 2] = unknown_prob * temporal_markers.get("future", 0.2)
+
+    # Row 2: Uncertain (?K)
+    tensor[2, 0] = uncertain_prob * temporal_markers.get("past", 0.2)
+    tensor[2, 1] = uncertain_prob * temporal_markers.get("present", 0.6)
+    tensor[2, 2] = uncertain_prob * temporal_markers.get("future", 0.2)
+
+    return UncertaintyTensor(tensor=tensor)
+
+
+def bind_with_awareness(
+    vector: "baf_vector.HyperVector",
+    role_vector: "baf_vector.HyperVector",
+    collapse_resistance: float,
+) -> "baf_vector.HyperVector":
+    """Bind a vector to a role while preserving awareness based on resistance.
+
+    When collapse_resistance is high, the result preserves more of the original
+    semantic superposition. When low, it allows full binding/collapse.
+
+    Args:
+        vector: The original semantic vector.
+        role_vector: The role to bind to (e.g., AGENT, TOPIC).
+        collapse_resistance: How much to resist collapse [0, 1].
+
+    Returns:
+        A hypervector blending original and bound representations.
+    """
+    from langextract.core import baf_vector
+
+    bound = baf_vector.bind(vector, role_vector)
+
+    if collapse_resistance > 0.5:
+        # High resistance: bundle original with bound
+        # Weight original more heavily
+        return baf_vector.bundle(
+            [vector, bound],
+            weights=[collapse_resistance, 1.0 - collapse_resistance],
+        )
+    else:
+        # Low resistance: mostly collapsed
+        return baf_vector.bundle(
+            [bound, vector],
+            weights=[1.0 - collapse_resistance, collapse_resistance],
+        )

--- a/langextract/core/grammar_triangle.py
+++ b/langextract/core/grammar_triangle.py
@@ -1,0 +1,577 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Grammar Triangle Field for semantic modulation without collapse.
+
+The Grammar Triangle embeds meaning in a three-way field:
+1. NSM (Natural Semantic Metalanguage) - Primitives like FEEL, WANT, KNOW
+2. Causality - Flow of agency, temporality, and dependency
+3. ICC (Qualia) - Continuous felt-sense dimensions
+
+Instead of classifying meaning into discrete buckets, the triangle creates
+a continuous field where meaning flows without collapsing. Templates become
+projections, not classifications.
+
+The triangle:
+        CAUSALITY (flows, not causes)
+              /\\
+             /  \\
+            /    \\
+    NSM <--⊕--> ICC (Qualia field)
+  (primitives)    (continuous)
+        |
+        ↓
+   BIPOLAR VSA FIELD
+   (holds superposition)
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from langextract.core import baf_vector
+
+if TYPE_CHECKING:
+    from langextract.core import data
+
+__all__ = [
+    "GrammarTriangleField",
+    "NSMField",
+    "CausalityFlow",
+    "QualiaField",
+    "NSM_PRIMITIVES",
+    "QUALIA_DIMENSIONS",
+]
+
+# NSM (Natural Semantic Metalanguage) primitives
+# Based on Wierzbicka's semantic primes
+NSM_PRIMITIVES = [
+    # Substantives
+    "I", "YOU", "SOMEONE", "SOMETHING", "PEOPLE", "BODY",
+    # Determiners
+    "THIS", "THE_SAME", "OTHER",
+    # Quantifiers
+    "ONE", "TWO", "SOME", "ALL", "MUCH", "MANY",
+    # Evaluators
+    "GOOD", "BAD",
+    # Descriptors
+    "BIG", "SMALL",
+    # Mental predicates
+    "THINK", "KNOW", "WANT", "FEEL", "SEE", "HEAR",
+    # Speech
+    "SAY", "WORDS", "TRUE",
+    # Actions/Events
+    "DO", "HAPPEN", "MOVE", "TOUCH",
+    # Existence/Possession
+    "THERE_IS", "HAVE",
+    # Life/Death
+    "LIVE", "DIE",
+    # Time
+    "WHEN", "NOW", "BEFORE", "AFTER", "A_LONG_TIME", "A_SHORT_TIME", "FOR_SOME_TIME", "MOMENT",
+    # Space
+    "WHERE", "HERE", "ABOVE", "BELOW", "FAR", "NEAR", "SIDE", "INSIDE",
+    # Logical
+    "NOT", "MAYBE", "CAN", "BECAUSE", "IF",
+    # Intensifier
+    "VERY",
+    # Similarity
+    "LIKE",
+]
+
+# Qualia dimensions (18D phenomenal field)
+# Based on experiential qualities relevant to meaning
+QUALIA_DIMENSIONS = [
+    "valence",           # Positive/negative feeling
+    "arousal",           # Activation level
+    "dominance",         # Control/power
+    "certainty",         # Epistemic confidence
+    "agency",            # Self as cause
+    "urgency",           # Time pressure
+    "intimacy",          # Personal closeness
+    "novelty",           # Familiarity/newness
+    "complexity",        # Cognitive load
+    "concreteness",      # Abstract/concrete
+    "temporality",       # Past/present/future orientation
+    "sociality",         # Individual/collective
+    "formality",         # Casual/formal register
+    "intensity",         # Strength of experience
+    "scope",             # Local/global relevance
+    "stability",         # Transient/enduring
+    "salience",          # Attention-grabbing
+    "coherence",         # Integration with context
+]
+
+
+@dataclasses.dataclass
+class NSMField:
+    """NSM primitives as continuous weights, not discrete labels.
+
+    Instead of: ["FEEL", "WANT"]
+    We store:   {"FEEL": 0.8, "WANT": 0.6, "KNOW": 0.3, ...}
+
+    Attributes:
+        weights: Dictionary mapping NSM primitives to weights [0, 1].
+    """
+
+    weights: dict[str, float]
+
+    def __post_init__(self):
+        """Validate weights."""
+        for prim, weight in self.weights.items():
+            if prim not in NSM_PRIMITIVES:
+                raise ValueError(f"Unknown NSM primitive: {prim}")
+            if not 0 <= weight <= 1:
+                raise ValueError(f"Weight must be in [0, 1], got {weight} for {prim}")
+
+    @classmethod
+    def from_text(cls, text: str) -> "NSMField":
+        """Compute NSM field from text using keyword matching.
+
+        This is a simple heuristic implementation. For production use,
+        this should be replaced with a learned model.
+
+        Args:
+            text: Input text to analyze.
+
+        Returns:
+            NSMField with computed weights.
+        """
+        text_lower = text.lower()
+        weights = {}
+
+        # Simple keyword-based heuristics
+        keyword_map = {
+            "FEEL": ["feel", "emotion", "sense", "experience"],
+            "WANT": ["want", "desire", "wish", "need", "prefer"],
+            "KNOW": ["know", "understand", "aware", "realize", "believe"],
+            "THINK": ["think", "consider", "suppose", "believe", "opinion"],
+            "DO": ["do", "make", "create", "perform", "execute"],
+            "SAY": ["say", "tell", "speak", "mention", "discuss"],
+            "SEE": ["see", "look", "watch", "observe", "notice"],
+            "HEAR": ["hear", "listen", "sound"],
+            "GOOD": ["good", "great", "excellent", "positive", "beneficial"],
+            "BAD": ["bad", "wrong", "negative", "harmful", "terrible"],
+            "NOW": ["now", "current", "present", "today"],
+            "BEFORE": ["before", "previous", "earlier", "past", "ago"],
+            "AFTER": ["after", "later", "future", "next", "tomorrow"],
+            "BECAUSE": ["because", "since", "due", "reason", "cause"],
+            "IF": ["if", "when", "unless", "whether", "condition"],
+            "CAN": ["can", "could", "able", "possible", "capability"],
+            "SOMEONE": ["someone", "person", "people", "anyone", "everybody"],
+            "SOMETHING": ["something", "thing", "object", "item"],
+        }
+
+        for primitive in NSM_PRIMITIVES:
+            keywords = keyword_map.get(primitive, [primitive.lower()])
+            count = sum(1 for kw in keywords if kw in text_lower)
+            # Normalize to [0, 1] with saturation
+            weights[primitive] = min(1.0, count * 0.3)
+
+        return cls(weights=weights)
+
+    def to_vector(self, dimension: int = 1000) -> np.ndarray:
+        """Convert NSM field to a float vector.
+
+        Args:
+            dimension: Target vector dimension.
+
+        Returns:
+            Float vector representation.
+        """
+        # Create basis vectors for each primitive (deterministic)
+        rng = np.random.default_rng(seed=42)
+        result = np.zeros(dimension, dtype=np.float32)
+
+        for i, prim in enumerate(NSM_PRIMITIVES):
+            weight = self.weights.get(prim, 0.0)
+            if weight > 0:
+                # Generate deterministic basis vector
+                basis = rng.standard_normal(dimension).astype(np.float32)
+                basis /= np.linalg.norm(basis)
+                result += weight * basis
+
+        return result
+
+    @property
+    def dominant_primitives(self) -> list[str]:
+        """Return primitives with weight > 0.5."""
+        return [p for p, w in self.weights.items() if w > 0.5]
+
+
+@dataclasses.dataclass
+class CausalityFlow:
+    """Causality as a 3D flow vector, not discrete edges.
+
+    Dimensions:
+    - agency: causing (-1) ← → caused (+1)
+    - temporality: before (-1) ← → after (+1)
+    - dependency: grounding (-1) ← → dependent (+1)
+
+    Attributes:
+        flow: 3D numpy array representing the causal flow.
+    """
+
+    flow: np.ndarray  # Shape (3,)
+
+    def __post_init__(self):
+        """Validate flow shape."""
+        self.flow = np.asarray(self.flow, dtype=np.float32)
+        if self.flow.shape != (3,):
+            raise ValueError(f"Flow must be 3D, got shape {self.flow.shape}")
+
+    @classmethod
+    def from_markers(
+        cls,
+        caused_by: bool = False,
+        causes: bool = False,
+        temporal_marker: str | None = None,
+        depends_on: bool = False,
+        grounds: bool = False,
+    ) -> "CausalityFlow":
+        """Create causality flow from discrete markers.
+
+        Args:
+            caused_by: Whether this is caused by something else.
+            causes: Whether this causes something else.
+            temporal_marker: "before", "after", or None.
+            depends_on: Whether this depends on something else.
+            grounds: Whether this grounds something else.
+
+        Returns:
+            CausalityFlow representing the causal relationship.
+        """
+        flow = np.zeros(3, dtype=np.float32)
+
+        # Agency dimension
+        if caused_by:
+            flow[0] = 0.8
+        elif causes:
+            flow[0] = -0.8
+
+        # Temporality dimension
+        if temporal_marker == "before":
+            flow[1] = -0.5
+        elif temporal_marker == "after":
+            flow[1] = 0.5
+
+        # Dependency dimension
+        if depends_on:
+            flow[2] = 0.7
+        elif grounds:
+            flow[2] = -0.7
+
+        return cls(flow=flow)
+
+    @property
+    def agency(self) -> float:
+        """Return agency dimension value."""
+        return float(self.flow[0])
+
+    @property
+    def temporality(self) -> float:
+        """Return temporality dimension value."""
+        return float(self.flow[1])
+
+    @property
+    def dependency(self) -> float:
+        """Return dependency dimension value."""
+        return float(self.flow[2])
+
+    def to_vector(self, dimension: int = 1000) -> np.ndarray:
+        """Expand 3D flow to higher-dimensional vector.
+
+        Args:
+            dimension: Target vector dimension.
+
+        Returns:
+            Float vector representation.
+        """
+        # Use deterministic projection
+        rng = np.random.default_rng(seed=43)
+        projection = rng.standard_normal((dimension, 3)).astype(np.float32)
+        projection /= np.linalg.norm(projection, axis=0, keepdims=True)
+        return projection @ self.flow
+
+
+@dataclasses.dataclass
+class QualiaField:
+    """18D phenomenal qualia field.
+
+    Represents continuous felt-sense dimensions relevant to meaning.
+
+    Attributes:
+        values: Dictionary mapping qualia dimensions to values [-1, 1].
+    """
+
+    values: dict[str, float]
+
+    def __post_init__(self):
+        """Validate values."""
+        for dim, val in self.values.items():
+            if dim not in QUALIA_DIMENSIONS:
+                raise ValueError(f"Unknown qualia dimension: {dim}")
+            if not -1 <= val <= 1:
+                raise ValueError(f"Value must be in [-1, 1], got {val} for {dim}")
+
+    @classmethod
+    def from_text(cls, text: str) -> "QualiaField":
+        """Compute qualia field from text using heuristics.
+
+        Args:
+            text: Input text to analyze.
+
+        Returns:
+            QualiaField with computed values.
+        """
+        text_lower = text.lower()
+        values = {}
+
+        # Heuristic mappings
+        positive_words = {"good", "great", "excellent", "happy", "love", "wonderful"}
+        negative_words = {"bad", "terrible", "awful", "hate", "sad", "horrible"}
+        urgent_words = {"urgent", "immediately", "asap", "now", "critical", "emergency"}
+        formal_words = {"hereby", "pursuant", "whereas", "therefore", "accordingly"}
+        casual_words = {"hey", "yeah", "cool", "awesome", "gonna", "wanna"}
+
+        # Valence
+        pos_count = sum(1 for w in positive_words if w in text_lower)
+        neg_count = sum(1 for w in negative_words if w in text_lower)
+        values["valence"] = np.clip((pos_count - neg_count) * 0.3, -1, 1)
+
+        # Arousal (based on punctuation and caps)
+        exclaim_count = text.count("!")
+        caps_ratio = sum(1 for c in text if c.isupper()) / max(len(text), 1)
+        values["arousal"] = np.clip(exclaim_count * 0.2 + caps_ratio * 2, -1, 1)
+
+        # Urgency
+        urgent_count = sum(1 for w in urgent_words if w in text_lower)
+        values["urgency"] = np.clip(urgent_count * 0.4, -1, 1)
+
+        # Formality
+        formal_count = sum(1 for w in formal_words if w in text_lower)
+        casual_count = sum(1 for w in casual_words if w in text_lower)
+        values["formality"] = np.clip((formal_count - casual_count) * 0.3, -1, 1)
+
+        # Default values for other dimensions
+        for dim in QUALIA_DIMENSIONS:
+            if dim not in values:
+                values[dim] = 0.0
+
+        return cls(values=values)
+
+    def to_vector(self) -> np.ndarray:
+        """Convert to 18D vector.
+
+        Returns:
+            18D float vector.
+        """
+        result = np.zeros(len(QUALIA_DIMENSIONS), dtype=np.float32)
+        for i, dim in enumerate(QUALIA_DIMENSIONS):
+            result[i] = self.values.get(dim, 0.0)
+        return result
+
+    def to_expanded_vector(self, dimension: int = 1000) -> np.ndarray:
+        """Expand 18D qualia to higher dimension.
+
+        Args:
+            dimension: Target vector dimension.
+
+        Returns:
+            Float vector representation.
+        """
+        base = self.to_vector()
+        rng = np.random.default_rng(seed=44)
+        projection = rng.standard_normal((dimension, len(base))).astype(np.float32)
+        projection /= np.linalg.norm(projection, axis=0, keepdims=True)
+        return projection @ base
+
+
+@dataclasses.dataclass
+class GrammarTriangleField:
+    """Grammar that doesn't collapse meaning.
+
+    Instead of: extract → classify → store
+    We do:      extract → embed in field → store field
+
+    The field combines NSM primitives, causality flow, and qualia into
+    a unified representation that preserves semantic superposition.
+
+    Attributes:
+        nsm_field: NSM primitive weights.
+        causality_flow: 3D causal flow vector.
+        qualia_field: 18D qualia values.
+        awareness_vector: Fused bipolar hypervector.
+    """
+
+    nsm_field: NSMField
+    causality_flow: CausalityFlow
+    qualia_field: QualiaField
+    awareness_vector: baf_vector.HyperVector | None = None
+
+    @classmethod
+    def from_extraction(
+        cls,
+        extraction: "data.Extraction",
+        base_embedding: np.ndarray | None = None,
+        dimension: int = baf_vector.DEFAULT_DIM,
+    ) -> "GrammarTriangleField":
+        """Create a GrammarTriangleField from an extraction.
+
+        Args:
+            extraction: The extraction to analyze.
+            base_embedding: Optional dense embedding (e.g., from Jina).
+            dimension: Target dimension for the awareness vector.
+
+        Returns:
+            GrammarTriangleField with all components computed.
+        """
+        text = extraction.extraction_text
+
+        # Compute triangle components
+        nsm = NSMField.from_text(text)
+        causality = CausalityFlow.from_markers()  # Default flow
+        qualia = QualiaField.from_text(text)
+
+        # Parse causal markers from attributes if available
+        if extraction.attributes:
+            causality = CausalityFlow.from_markers(
+                caused_by="caused_by" in extraction.attributes,
+                causes="causes" in extraction.attributes,
+                temporal_marker=extraction.attributes.get("temporal_marker"),
+                depends_on="depends_on" in extraction.attributes,
+                grounds="grounds" in extraction.attributes,
+            )
+
+        # Create the field
+        field = cls(
+            nsm_field=nsm,
+            causality_flow=causality,
+            qualia_field=qualia,
+        )
+
+        # Fuse to bipolar awareness vector
+        field.awareness_vector = field._fuse_to_bipolar(
+            base_embedding=base_embedding,
+            dimension=dimension,
+        )
+
+        return field
+
+    def _fuse_to_bipolar(
+        self,
+        base_embedding: np.ndarray | None = None,
+        dimension: int = baf_vector.DEFAULT_DIM,
+    ) -> baf_vector.HyperVector:
+        """Fuse all triangle components into single bipolar hypervector.
+
+        This is where the magic happens:
+        - Base embedding provides semantic foundation
+        - NSM/causal/qualia MODULATE but don't COLLAPSE
+
+        Args:
+            base_embedding: Optional dense embedding to use as base.
+            dimension: Target dimension for the hypervector.
+
+        Returns:
+            Fused bipolar hypervector.
+        """
+        vectors = []
+        weights = []
+
+        # Base embedding (highest weight if provided)
+        if base_embedding is not None:
+            base = baf_vector.float_to_bipolar(base_embedding, dimension)
+            base.label = "semantic_base"
+            vectors.append(base)
+            weights.append(0.5)
+        else:
+            # Use random base if no embedding provided
+            base = baf_vector.random_bipolar(dimension, label="random_base")
+            vectors.append(base)
+            weights.append(0.3)
+
+        # NSM component
+        nsm_vec = self.nsm_field.to_vector(dimension)
+        nsm_bipolar = baf_vector.float_to_bipolar(nsm_vec, dimension)
+        nsm_bipolar.label = "nsm"
+        vectors.append(nsm_bipolar)
+        weights.append(0.2)
+
+        # Causality component
+        causal_vec = self.causality_flow.to_vector(dimension)
+        causal_bipolar = baf_vector.float_to_bipolar(causal_vec, dimension)
+        causal_bipolar.label = "causality"
+        vectors.append(causal_bipolar)
+        weights.append(0.15)
+
+        # Qualia component
+        qualia_vec = self.qualia_field.to_expanded_vector(dimension)
+        qualia_bipolar = baf_vector.float_to_bipolar(qualia_vec, dimension)
+        qualia_bipolar.label = "qualia"
+        vectors.append(qualia_bipolar)
+        weights.append(0.15)
+
+        # Normalize weights
+        total = sum(weights)
+        weights = [w / total for w in weights]
+
+        # Bundle (not bind) - preserves superposition
+        return baf_vector.bundle(vectors, weights)
+
+    def to_dict(self) -> dict:
+        """Serialize to dictionary for storage.
+
+        Returns:
+            Dictionary representation.
+        """
+        return {
+            "nsm_field": self.nsm_field.weights,
+            "causality_flow": self.causality_flow.flow.tolist(),
+            "qualia_field": self.qualia_field.values,
+            "awareness_vector_bytes": (
+                self.awareness_vector.to_bytes() if self.awareness_vector else None
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict, dimension: int = baf_vector.DEFAULT_DIM) -> "GrammarTriangleField":
+        """Deserialize from dictionary.
+
+        Args:
+            d: Dictionary representation.
+            dimension: Dimension for the awareness vector.
+
+        Returns:
+            GrammarTriangleField instance.
+        """
+        nsm = NSMField(weights=d["nsm_field"])
+        causality = CausalityFlow(flow=np.array(d["causality_flow"]))
+        qualia = QualiaField(values=d["qualia_field"])
+
+        awareness_vector = None
+        if d.get("awareness_vector_bytes"):
+            awareness_vector = baf_vector.HyperVector.from_bytes(
+                d["awareness_vector_bytes"], dimension=dimension
+            )
+
+        return cls(
+            nsm_field=nsm,
+            causality_flow=causality,
+            qualia_field=qualia,
+            awareness_vector=awareness_vector,
+        )

--- a/tests/baf_vector_test.py
+++ b/tests/baf_vector_test.py
@@ -1,0 +1,248 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for baf_vector module."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import numpy as np
+
+from langextract.core import baf_vector
+
+
+class HyperVectorTest(absltest.TestCase):
+
+  def test_random_bipolar_dimension(self):
+    """Test that random_bipolar creates vectors with correct dimension."""
+    dim = 1000
+    vec = baf_vector.random_bipolar(dimension=dim)
+    self.assertEqual(vec.dimension, dim)
+
+  def test_random_bipolar_values(self):
+    """Test that random_bipolar creates bipolar {-1, +1} values."""
+    vec = baf_vector.random_bipolar(dimension=100)
+    unique_values = set(vec.data)
+    self.assertEqual(unique_values, {-1, 1})
+
+  def test_random_bipolar_label(self):
+    """Test that label is preserved."""
+    vec = baf_vector.random_bipolar(dimension=100, label="test_label")
+    self.assertEqual(vec.label, "test_label")
+
+  def test_random_bipolar_reproducibility(self):
+    """Test that same RNG produces same vector."""
+    rng1 = np.random.default_rng(seed=42)
+    rng2 = np.random.default_rng(seed=42)
+    vec1 = baf_vector.random_bipolar(dimension=100, rng=rng1)
+    vec2 = baf_vector.random_bipolar(dimension=100, rng=rng2)
+    np.testing.assert_array_equal(vec1.data, vec2.data)
+
+  def test_to_bytes_roundtrip(self):
+    """Test serialization/deserialization roundtrip."""
+    original = baf_vector.random_bipolar(dimension=1000, label="test")
+    data = original.to_bytes()
+    restored = baf_vector.HyperVector.from_bytes(data, dimension=1000)
+    np.testing.assert_array_equal(original.data, restored.data)
+
+  def test_to_bytes_size(self):
+    """Test that bit-packing produces expected size."""
+    vec = baf_vector.random_bipolar(dimension=10000)
+    data = vec.to_bytes()
+    expected_size = 10000 // 8
+    self.assertEqual(len(data), expected_size)
+
+
+class BindTest(absltest.TestCase):
+
+  def test_bind_dimension_match(self):
+    """Test that bind requires matching dimensions."""
+    v1 = baf_vector.random_bipolar(dimension=100)
+    v2 = baf_vector.random_bipolar(dimension=200)
+    with self.assertRaises(ValueError) as ctx:
+      baf_vector.bind(v1, v2)
+    self.assertIn("different dimensions", str(ctx.exception))
+
+  def test_bind_result_is_bipolar(self):
+    """Test that binding preserves bipolar values."""
+    v1 = baf_vector.random_bipolar(dimension=100)
+    v2 = baf_vector.random_bipolar(dimension=100)
+    bound = baf_vector.bind(v1, v2)
+    unique_values = set(bound.data)
+    self.assertEqual(unique_values, {-1, 1})
+
+  def test_bind_is_dissimilar(self):
+    """Test that binding produces dissimilar result."""
+    v1 = baf_vector.random_bipolar(dimension=1000)
+    v2 = baf_vector.random_bipolar(dimension=1000)
+    bound = baf_vector.bind(v1, v2)
+    # Bound vector should be nearly orthogonal to both inputs
+    sim1 = baf_vector.similarity(bound, v1)
+    sim2 = baf_vector.similarity(bound, v2)
+    self.assertLess(abs(sim1), 0.2)  # Near zero
+    self.assertLess(abs(sim2), 0.2)
+
+  def test_bind_unbind_recovery(self):
+    """Test that unbinding recovers original vector."""
+    v1 = baf_vector.random_bipolar(dimension=1000, label="value")
+    v2 = baf_vector.random_bipolar(dimension=1000, label="key")
+    bound = baf_vector.bind(v1, v2)
+    recovered = baf_vector.unbind(bound, v2)
+    # Should be identical since bind is XOR-like for bipolar
+    np.testing.assert_array_equal(v1.data, recovered.data)
+
+
+class BundleTest(absltest.TestCase):
+
+  def test_bundle_empty_list(self):
+    """Test that bundling empty list raises error."""
+    with self.assertRaises(ValueError) as ctx:
+      baf_vector.bundle([])
+    self.assertIn("empty", str(ctx.exception).lower())
+
+  def test_bundle_dimension_mismatch(self):
+    """Test that bundling mismatched dimensions raises error."""
+    v1 = baf_vector.random_bipolar(dimension=100)
+    v2 = baf_vector.random_bipolar(dimension=200)
+    with self.assertRaises(ValueError) as ctx:
+      baf_vector.bundle([v1, v2])
+    self.assertIn("same dimension", str(ctx.exception))
+
+  def test_bundle_preserves_similarity(self):
+    """Test that bundling preserves similarity to inputs."""
+    v1 = baf_vector.random_bipolar(dimension=1000, label="a")
+    v2 = baf_vector.random_bipolar(dimension=1000, label="b")
+    bundled = baf_vector.bundle([v1, v2])
+    # Bundle should be similar to both inputs
+    sim1 = baf_vector.similarity(bundled, v1)
+    sim2 = baf_vector.similarity(bundled, v2)
+    self.assertGreater(sim1, 0.3)  # Positive similarity
+    self.assertGreater(sim2, 0.3)
+
+  def test_bundle_weighted(self):
+    """Test that weighted bundling respects weights."""
+    v1 = baf_vector.random_bipolar(dimension=1000)
+    v2 = baf_vector.random_bipolar(dimension=1000)
+    # Heavy weight on v1
+    bundled = baf_vector.bundle([v1, v2], weights=[0.9, 0.1])
+    sim1 = baf_vector.similarity(bundled, v1)
+    sim2 = baf_vector.similarity(bundled, v2)
+    # Should be more similar to v1
+    self.assertGreater(sim1, sim2)
+
+  def test_bundle_label_combination(self):
+    """Test that bundling combines labels."""
+    v1 = baf_vector.random_bipolar(dimension=100, label="a")
+    v2 = baf_vector.random_bipolar(dimension=100, label="b")
+    bundled = baf_vector.bundle([v1, v2])
+    self.assertEqual(bundled.label, "a⊕b")
+
+
+class SimilarityTest(absltest.TestCase):
+
+  def test_similarity_identical(self):
+    """Test that identical vectors have similarity 1.0."""
+    v = baf_vector.random_bipolar(dimension=100)
+    sim = baf_vector.similarity(v, v)
+    self.assertAlmostEqual(sim, 1.0)
+
+  def test_similarity_opposite(self):
+    """Test that opposite vectors have similarity -1.0."""
+    v1 = baf_vector.random_bipolar(dimension=100)
+    v2 = baf_vector.HyperVector(data=-v1.data)
+    sim = baf_vector.similarity(v1, v2)
+    self.assertAlmostEqual(sim, -1.0)
+
+  def test_similarity_range(self):
+    """Test that similarity is in [-1, 1]."""
+    v1 = baf_vector.random_bipolar(dimension=100)
+    v2 = baf_vector.random_bipolar(dimension=100)
+    sim = baf_vector.similarity(v1, v2)
+    self.assertGreaterEqual(sim, -1.0)
+    self.assertLessEqual(sim, 1.0)
+
+  def test_similarity_dimension_mismatch(self):
+    """Test that similarity requires matching dimensions."""
+    v1 = baf_vector.random_bipolar(dimension=100)
+    v2 = baf_vector.random_bipolar(dimension=200)
+    with self.assertRaises(ValueError):
+      baf_vector.similarity(v1, v2)
+
+
+class FloatConversionTest(parameterized.TestCase):
+
+  @parameterized.named_parameters(
+      dict(testcase_name="threshold", method="threshold"),
+      dict(testcase_name="expand", method="expand"),
+  )
+  def test_float_to_bipolar_dimension(self, method):
+    """Test that conversion produces correct dimension."""
+    float_vec = np.random.randn(1024).astype(np.float32)
+    bipolar = baf_vector.float_to_bipolar(float_vec, target_dim=10000, method=method)
+    self.assertEqual(bipolar.dimension, 10000)
+
+  @parameterized.named_parameters(
+      dict(testcase_name="threshold", method="threshold"),
+      dict(testcase_name="expand", method="expand"),
+  )
+  def test_float_to_bipolar_values(self, method):
+    """Test that conversion produces bipolar values."""
+    float_vec = np.random.randn(1024).astype(np.float32)
+    bipolar = baf_vector.float_to_bipolar(float_vec, target_dim=10000, method=method)
+    unique_values = set(bipolar.data)
+    self.assertEqual(unique_values, {-1, 1})
+
+  def test_float_to_bipolar_similarity_preservation(self):
+    """Test that similar float vectors produce similar bipolar vectors."""
+    v1 = np.random.randn(1024).astype(np.float32)
+    v2 = v1 + 0.1 * np.random.randn(1024).astype(np.float32)  # Small perturbation
+
+    b1 = baf_vector.float_to_bipolar(v1, target_dim=10000, method="expand")
+    b2 = baf_vector.float_to_bipolar(v2, target_dim=10000, method="expand")
+
+    sim = baf_vector.similarity(b1, b2)
+    self.assertGreater(sim, 0.5)  # Should preserve similarity
+
+  def test_bipolar_to_float_dimension(self):
+    """Test that bipolar_to_float produces correct dimension."""
+    bipolar = baf_vector.random_bipolar(dimension=10000)
+    float_vec = baf_vector.bipolar_to_float(bipolar, target_dim=1024)
+    self.assertEqual(len(float_vec), 1024)
+
+  def test_unknown_method_raises(self):
+    """Test that unknown conversion method raises error."""
+    float_vec = np.random.randn(1024).astype(np.float32)
+    with self.assertRaises(ValueError) as ctx:
+      baf_vector.float_to_bipolar(float_vec, method="unknown")
+    self.assertIn("unknown", str(ctx.exception).lower())
+
+
+class BAFConfigTest(absltest.TestCase):
+
+  def test_default_config(self):
+    """Test default configuration values."""
+    config = baf_vector.BAFConfig()
+    self.assertEqual(config.dimension, 10000)
+    self.assertIsNone(config.seed)
+    self.assertTrue(config.normalize_bundles)
+
+  def test_custom_config(self):
+    """Test custom configuration."""
+    config = baf_vector.BAFConfig(dimension=5000, seed=42, normalize_bundles=False)
+    self.assertEqual(config.dimension, 5000)
+    self.assertEqual(config.seed, 42)
+    self.assertFalse(config.normalize_bundles)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/collapse_resistance_test.py
+++ b/tests/collapse_resistance_test.py
@@ -1,0 +1,286 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for collapse_resistance module."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import numpy as np
+
+from langextract.core import collapse_resistance as cr
+from langextract.core import data
+
+
+class CollapseResistanceConfigTest(absltest.TestCase):
+
+  def test_default_config(self):
+    """Test default configuration."""
+    config = cr.CollapseResistanceConfig()
+    self.assertAlmostEqual(config.confidence_weight, 0.4)
+    self.assertAlmostEqual(config.alignment_weight, 0.3)
+    self.assertAlmostEqual(config.context_weight, 0.3)
+    self.assertAlmostEqual(config.base_resistance, 0.1)
+    self.assertAlmostEqual(config.max_resistance, 0.95)
+
+  def test_weights_must_sum_to_one(self):
+    """Test that weights must sum to 1.0."""
+    with self.assertRaises(ValueError) as ctx:
+      cr.CollapseResistanceConfig(
+          confidence_weight=0.5,
+          alignment_weight=0.5,
+          context_weight=0.5,  # Total = 1.5
+      )
+    self.assertIn("sum to 1.0", str(ctx.exception))
+
+  def test_resistance_bounds_validation(self):
+    """Test that resistance bounds are validated."""
+    with self.assertRaises(ValueError) as ctx:
+      cr.CollapseResistanceConfig(
+          base_resistance=0.9,
+          max_resistance=0.5,  # max < base
+      )
+    self.assertIn("less than max_resistance", str(ctx.exception))
+
+
+class UncertaintyTensorTest(absltest.TestCase):
+
+  def test_tensor_shape_validation(self):
+    """Test that tensor must be 3x3."""
+    with self.assertRaises(ValueError) as ctx:
+      cr.UncertaintyTensor(tensor=np.zeros((2, 2)))
+    self.assertIn("3x3", str(ctx.exception))
+
+  def test_tensor_value_validation(self):
+    """Test that tensor values must be in [0, 1]."""
+    tensor = np.ones((3, 3)) * 2  # Values > 1
+    with self.assertRaises(ValueError) as ctx:
+      cr.UncertaintyTensor(tensor=tensor)
+    self.assertIn("[0, 1]", str(ctx.exception))
+
+  def test_from_confidence_high(self):
+    """Test tensor generation from high confidence."""
+    tensor = cr.UncertaintyTensor.from_confidence(0.9)
+    # High confidence should concentrate on K_present
+    self.assertGreater(tensor.tensor[0, 1], 0.5)  # K_present
+    self.assertLess(tensor.total_uncertainty, 0.2)
+
+  def test_from_confidence_low(self):
+    """Test tensor generation from low confidence."""
+    tensor = cr.UncertaintyTensor.from_confidence(0.2)
+    # Low confidence should spread to ?K states
+    self.assertGreater(tensor.total_uncertainty, 0.4)
+
+  def test_from_dict_roundtrip(self):
+    """Test dict serialization roundtrip."""
+    original = cr.UncertaintyTensor.from_confidence(0.7)
+    d = original.to_dict()
+    restored = cr.UncertaintyTensor.from_dict(d)
+    np.testing.assert_array_almost_equal(original.tensor, restored.tensor)
+
+  def test_total_uncertainty(self):
+    """Test total uncertainty calculation."""
+    tensor = np.zeros((3, 3))
+    tensor[2, :] = [0.1, 0.2, 0.3]  # ?K row
+    ut = cr.UncertaintyTensor(tensor=tensor)
+    self.assertAlmostEqual(ut.total_uncertainty, 0.6)
+
+  def test_temporal_spread_uniform(self):
+    """Test temporal spread for uniform distribution."""
+    tensor = np.ones((3, 3)) / 3
+    ut = cr.UncertaintyTensor(tensor=tensor)
+    # Uniform distribution should have maximum spread
+    self.assertGreater(ut.temporal_spread, 0.9)
+
+
+class ComputeCollapseResistanceTest(parameterized.TestCase):
+
+  def test_default_extraction(self):
+    """Test collapse resistance for basic extraction."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test entity",
+    )
+    resistance = cr.compute_collapse_resistance(ext)
+    # Should be within bounds
+    self.assertGreaterEqual(resistance, 0.1)
+    self.assertLessEqual(resistance, 0.95)
+
+  def test_high_confidence_low_resistance(self):
+    """Test that high confidence leads to lower resistance."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+        attributes={"confidence": "0.95"},
+    )
+    resistance = cr.compute_collapse_resistance(ext)
+    # High confidence should allow more collapse (lower resistance)
+    self.assertLess(resistance, 0.5)
+
+  def test_low_confidence_high_resistance(self):
+    """Test that low confidence leads to higher resistance."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+        attributes={"confidence": "0.1"},
+    )
+    resistance = cr.compute_collapse_resistance(ext)
+    # Low confidence should resist collapse (higher resistance)
+    self.assertGreater(resistance, 0.5)
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="exact_match",
+          alignment_status=data.AlignmentStatus.MATCH_EXACT,
+          expected_range=(0.1, 0.5),
+      ),
+      dict(
+          testcase_name="fuzzy_match",
+          alignment_status=data.AlignmentStatus.MATCH_FUZZY,
+          expected_range=(0.5, 0.95),
+      ),
+  )
+  def test_alignment_status_affects_resistance(self, alignment_status, expected_range):
+    """Test that alignment status affects resistance."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+        alignment_status=alignment_status,
+    )
+    resistance = cr.compute_collapse_resistance(ext)
+    self.assertGreaterEqual(resistance, expected_range[0])
+    self.assertLessEqual(resistance, expected_range[1])
+
+  def test_context_ambiguity_affects_resistance(self):
+    """Test that context ambiguity parameter affects resistance."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+    )
+    low_ambiguity = cr.compute_collapse_resistance(ext, context_ambiguity=0.1)
+    high_ambiguity = cr.compute_collapse_resistance(ext, context_ambiguity=0.9)
+    self.assertGreater(high_ambiguity, low_ambiguity)
+
+  def test_custom_config(self):
+    """Test with custom configuration."""
+    config = cr.CollapseResistanceConfig(
+        confidence_weight=0.6,
+        alignment_weight=0.2,
+        context_weight=0.2,
+        base_resistance=0.2,
+        max_resistance=0.8,
+    )
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+    )
+    resistance = cr.compute_collapse_resistance(ext, config=config)
+    self.assertGreaterEqual(resistance, 0.2)
+    self.assertLessEqual(resistance, 0.8)
+
+
+class ComputeUncertaintyTensorTest(absltest.TestCase):
+
+  def test_basic_extraction(self):
+    """Test uncertainty tensor for basic extraction."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+    )
+    tensor = cr.compute_uncertainty_tensor(ext)
+    self.assertIsInstance(tensor, cr.UncertaintyTensor)
+    self.assertEqual(tensor.tensor.shape, (3, 3))
+
+  def test_temporal_markers(self):
+    """Test uncertainty tensor with temporal markers."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+    )
+    tensor = cr.compute_uncertainty_tensor(
+        ext,
+        temporal_markers={"past": 0.8, "present": 0.1, "future": 0.1},
+    )
+    # Past should dominate
+    past_sum = tensor.tensor[:, 0].sum()
+    present_sum = tensor.tensor[:, 1].sum()
+    self.assertGreater(past_sum, present_sum)
+
+  def test_high_confidence_extraction(self):
+    """Test tensor for high confidence extraction."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+        attributes={"confidence": "0.9"},
+    )
+    tensor = cr.compute_uncertainty_tensor(ext)
+    # Should concentrate on Known states
+    known_sum = tensor.tensor[0, :].sum()
+    uncertain_sum = tensor.tensor[2, :].sum()
+    self.assertGreater(known_sum, uncertain_sum)
+
+
+class BindWithAwarenessTest(absltest.TestCase):
+
+  def test_low_resistance_favors_bound(self):
+    """Test that low resistance favors the bound result."""
+    from langextract.core import baf_vector
+
+    vector = baf_vector.random_bipolar(dimension=1000)
+    role = baf_vector.random_bipolar(dimension=1000)
+
+    result = cr.bind_with_awareness(vector, role, collapse_resistance=0.1)
+
+    # Low resistance should be more similar to pure bind
+    pure_bound = baf_vector.bind(vector, role)
+    sim_to_bound = baf_vector.similarity(result, pure_bound)
+    sim_to_original = baf_vector.similarity(result, vector)
+
+    self.assertGreater(sim_to_bound, sim_to_original)
+
+  def test_high_resistance_preserves_original(self):
+    """Test that high resistance preserves original vector."""
+    from langextract.core import baf_vector
+
+    vector = baf_vector.random_bipolar(dimension=1000)
+    role = baf_vector.random_bipolar(dimension=1000)
+
+    result = cr.bind_with_awareness(vector, role, collapse_resistance=0.9)
+
+    # High resistance should be more similar to original
+    pure_bound = baf_vector.bind(vector, role)
+    sim_to_bound = baf_vector.similarity(result, pure_bound)
+    sim_to_original = baf_vector.similarity(result, vector)
+
+    self.assertGreater(sim_to_original, sim_to_bound)
+
+  def test_medium_resistance_blends(self):
+    """Test that medium resistance produces blend."""
+    from langextract.core import baf_vector
+
+    vector = baf_vector.random_bipolar(dimension=1000)
+    role = baf_vector.random_bipolar(dimension=1000)
+
+    result = cr.bind_with_awareness(vector, role, collapse_resistance=0.5)
+
+    # Should have some similarity to both
+    pure_bound = baf_vector.bind(vector, role)
+    sim_to_bound = baf_vector.similarity(result, pure_bound)
+    sim_to_original = baf_vector.similarity(result, vector)
+
+    self.assertGreater(sim_to_bound, 0.1)
+    self.assertGreater(sim_to_original, 0.1)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/grammar_triangle_test.py
+++ b/tests/grammar_triangle_test.py
@@ -1,0 +1,304 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for grammar_triangle module."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import numpy as np
+
+from langextract.core import baf_vector
+from langextract.core import data
+from langextract.core import grammar_triangle as gt
+
+
+class NSMFieldTest(absltest.TestCase):
+
+  def test_from_text_basic(self):
+    """Test NSM field extraction from basic text."""
+    nsm = gt.NSMField.from_text("I feel happy and want to know more")
+    # Should detect mental predicates
+    self.assertGreater(nsm.weights.get("FEEL", 0), 0)
+    self.assertGreater(nsm.weights.get("WANT", 0), 0)
+    self.assertGreater(nsm.weights.get("KNOW", 0), 0)
+
+  def test_from_text_action(self):
+    """Test NSM field for action-oriented text."""
+    nsm = gt.NSMField.from_text("I will do this and make it happen")
+    self.assertGreater(nsm.weights.get("DO", 0), 0)
+
+  def test_from_text_temporal(self):
+    """Test NSM field for temporal text."""
+    # Note: Using base form "say" since simple keyword matching doesn't handle verb tenses
+    nsm = gt.NSMField.from_text("Before that, I say something now")
+    self.assertGreater(nsm.weights.get("BEFORE", 0), 0)
+    self.assertGreater(nsm.weights.get("SAY", 0), 0)
+
+  def test_invalid_primitive(self):
+    """Test that invalid primitive raises error."""
+    with self.assertRaises(ValueError) as ctx:
+      gt.NSMField(weights={"INVALID_PRIMITIVE": 0.5})
+    self.assertIn("Unknown NSM primitive", str(ctx.exception))
+
+  def test_invalid_weight_range(self):
+    """Test that weight outside [0,1] raises error."""
+    with self.assertRaises(ValueError) as ctx:
+      gt.NSMField(weights={"FEEL": 1.5})
+    self.assertIn("[0, 1]", str(ctx.exception))
+
+  def test_to_vector(self):
+    """Test conversion to vector."""
+    nsm = gt.NSMField.from_text("I feel good")
+    vec = nsm.to_vector(dimension=1000)
+    self.assertEqual(len(vec), 1000)
+    self.assertEqual(vec.dtype, np.float32)
+
+  def test_dominant_primitives(self):
+    """Test extraction of dominant primitives."""
+    nsm = gt.NSMField(weights={"FEEL": 0.8, "WANT": 0.6, "KNOW": 0.3})
+    dominant = nsm.dominant_primitives
+    self.assertIn("FEEL", dominant)
+    self.assertIn("WANT", dominant)
+    self.assertNotIn("KNOW", dominant)
+
+
+class CausalityFlowTest(absltest.TestCase):
+
+  def test_from_markers_caused_by(self):
+    """Test causality flow for 'caused_by' marker."""
+    flow = gt.CausalityFlow.from_markers(caused_by=True)
+    self.assertGreater(flow.agency, 0.5)  # Positive = caused
+
+  def test_from_markers_causes(self):
+    """Test causality flow for 'causes' marker."""
+    flow = gt.CausalityFlow.from_markers(causes=True)
+    self.assertLess(flow.agency, -0.5)  # Negative = causing
+
+  def test_from_markers_temporal(self):
+    """Test causality flow for temporal markers."""
+    before = gt.CausalityFlow.from_markers(temporal_marker="before")
+    after = gt.CausalityFlow.from_markers(temporal_marker="after")
+    self.assertLess(before.temporality, 0)
+    self.assertGreater(after.temporality, 0)
+
+  def test_from_markers_dependency(self):
+    """Test causality flow for dependency markers."""
+    depends = gt.CausalityFlow.from_markers(depends_on=True)
+    grounds = gt.CausalityFlow.from_markers(grounds=True)
+    self.assertGreater(depends.dependency, 0.5)
+    self.assertLess(grounds.dependency, -0.5)
+
+  def test_flow_shape(self):
+    """Test that flow is 3D."""
+    flow = gt.CausalityFlow.from_markers()
+    self.assertEqual(flow.flow.shape, (3,))
+
+  def test_invalid_flow_shape(self):
+    """Test that invalid flow shape raises error."""
+    with self.assertRaises(ValueError) as ctx:
+      gt.CausalityFlow(flow=np.zeros(5))
+    self.assertIn("3D", str(ctx.exception))
+
+  def test_to_vector(self):
+    """Test expansion to higher dimension."""
+    flow = gt.CausalityFlow.from_markers(causes=True, temporal_marker="after")
+    vec = flow.to_vector(dimension=1000)
+    self.assertEqual(len(vec), 1000)
+
+
+class QualiaFieldTest(absltest.TestCase):
+
+  def test_from_text_positive(self):
+    """Test qualia extraction for positive text."""
+    qualia = gt.QualiaField.from_text("This is great and wonderful!")
+    self.assertGreater(qualia.values.get("valence", 0), 0)
+
+  def test_from_text_negative(self):
+    """Test qualia extraction for negative text."""
+    qualia = gt.QualiaField.from_text("This is terrible and awful")
+    self.assertLess(qualia.values.get("valence", 0), 0)
+
+  def test_from_text_urgent(self):
+    """Test qualia extraction for urgent text."""
+    qualia = gt.QualiaField.from_text("URGENT! Do this immediately!")
+    self.assertGreater(qualia.values.get("urgency", 0), 0)
+    self.assertGreater(qualia.values.get("arousal", 0), 0)
+
+  def test_from_text_formal(self):
+    """Test qualia extraction for formal text."""
+    qualia = gt.QualiaField.from_text("Hereby pursuant to the agreement")
+    self.assertGreater(qualia.values.get("formality", 0), 0)
+
+  def test_from_text_casual(self):
+    """Test qualia extraction for casual text."""
+    qualia = gt.QualiaField.from_text("Hey yeah that's cool!")
+    self.assertLess(qualia.values.get("formality", 0), 0)
+
+  def test_invalid_dimension(self):
+    """Test that invalid dimension raises error."""
+    with self.assertRaises(ValueError) as ctx:
+      gt.QualiaField(values={"invalid_dimension": 0.5})
+    self.assertIn("Unknown qualia dimension", str(ctx.exception))
+
+  def test_invalid_value_range(self):
+    """Test that value outside [-1,1] raises error."""
+    with self.assertRaises(ValueError) as ctx:
+      gt.QualiaField(values={"valence": 2.0})
+    self.assertIn("[-1, 1]", str(ctx.exception))
+
+  def test_to_vector(self):
+    """Test conversion to 18D vector."""
+    qualia = gt.QualiaField.from_text("test")
+    vec = qualia.to_vector()
+    self.assertEqual(len(vec), len(gt.QUALIA_DIMENSIONS))
+
+  def test_to_expanded_vector(self):
+    """Test expansion to higher dimension."""
+    qualia = gt.QualiaField.from_text("test")
+    vec = qualia.to_expanded_vector(dimension=1000)
+    self.assertEqual(len(vec), 1000)
+
+
+class GrammarTriangleFieldTest(absltest.TestCase):
+
+  def test_from_extraction_basic(self):
+    """Test creating grammar triangle from basic extraction."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="I feel happy about this",
+    )
+    triangle = gt.GrammarTriangleField.from_extraction(ext)
+
+    self.assertIsInstance(triangle.nsm_field, gt.NSMField)
+    self.assertIsInstance(triangle.causality_flow, gt.CausalityFlow)
+    self.assertIsInstance(triangle.qualia_field, gt.QualiaField)
+    self.assertIsInstance(triangle.awareness_vector, baf_vector.HyperVector)
+
+  def test_from_extraction_with_attributes(self):
+    """Test grammar triangle uses extraction attributes."""
+    ext = data.Extraction(
+        extraction_class="action",
+        extraction_text="caused the change",
+        attributes={
+            "caused_by": "true",
+            "temporal_marker": "before",
+        },
+    )
+    triangle = gt.GrammarTriangleField.from_extraction(ext)
+
+    # Should detect causal markers from attributes
+    self.assertGreater(triangle.causality_flow.agency, 0)
+
+  def test_from_extraction_with_base_embedding(self):
+    """Test grammar triangle with base embedding."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+    )
+    base_embedding = np.random.randn(1024).astype(np.float32)
+    triangle = gt.GrammarTriangleField.from_extraction(
+        ext, base_embedding=base_embedding
+    )
+
+    self.assertIsNotNone(triangle.awareness_vector)
+    self.assertEqual(triangle.awareness_vector.dimension, baf_vector.DEFAULT_DIM)
+
+  def test_awareness_vector_dimension(self):
+    """Test custom dimension for awareness vector."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+    )
+    triangle = gt.GrammarTriangleField.from_extraction(ext, dimension=5000)
+
+    self.assertEqual(triangle.awareness_vector.dimension, 5000)
+
+  def test_to_dict_roundtrip(self):
+    """Test serialization roundtrip."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="I want to know",
+    )
+    original = gt.GrammarTriangleField.from_extraction(ext, dimension=1000)
+    d = original.to_dict()
+    restored = gt.GrammarTriangleField.from_dict(d, dimension=1000)
+
+    # Check NSM weights preserved
+    for prim, weight in original.nsm_field.weights.items():
+      self.assertAlmostEqual(weight, restored.nsm_field.weights[prim], places=5)
+
+    # Check causality flow preserved
+    np.testing.assert_array_almost_equal(
+        original.causality_flow.flow, restored.causality_flow.flow
+    )
+
+    # Check qualia preserved
+    for dim, val in original.qualia_field.values.items():
+      self.assertAlmostEqual(val, restored.qualia_field.values[dim], places=5)
+
+
+class ExtractionBAFIntegrationTest(absltest.TestCase):
+  """Test BAF integration with Extraction dataclass."""
+
+  def test_compute_baf_components(self):
+    """Test computing BAF components for an extraction."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="I feel excited about this project",
+        alignment_status=data.AlignmentStatus.MATCH_EXACT,
+    )
+    ext.compute_baf_components()
+
+    # Check all components computed
+    self.assertIsNotNone(ext.grammar_triangle)
+    self.assertIsNotNone(ext.baf_vector)
+    self.assertIsNotNone(ext.collapse_resistance)
+    self.assertIsNotNone(ext.uncertainty_tensor)
+
+  def test_collapse_resistance_range(self):
+    """Test that collapse resistance is in valid range."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+    )
+    ext.compute_baf_components()
+
+    self.assertGreaterEqual(ext.collapse_resistance, 0.0)
+    self.assertLessEqual(ext.collapse_resistance, 1.0)
+
+  def test_compute_baf_with_base_embedding(self):
+    """Test computing BAF with external embedding."""
+    ext = data.Extraction(
+        extraction_class="entity",
+        extraction_text="test",
+    )
+    base_embedding = np.random.randn(1024).astype(np.float32)
+    ext.compute_baf_components(base_embedding=base_embedding)
+
+    self.assertIsNotNone(ext.baf_vector)
+
+  def test_compute_baf_with_context_ambiguity(self):
+    """Test that context_ambiguity affects collapse resistance."""
+    ext1 = data.Extraction(extraction_class="entity", extraction_text="test")
+    ext2 = data.Extraction(extraction_class="entity", extraction_text="test")
+
+    ext1.compute_baf_components(context_ambiguity=0.1)
+    ext2.compute_baf_components(context_ambiguity=0.9)
+
+    # Higher ambiguity should lead to higher resistance
+    self.assertGreater(ext2.collapse_resistance, ext1.collapse_resistance)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
This adds the Bipolar Awareness Field (BAF) integration to prevent semantic templates from collapsing meaning during extraction. Key components:

- baf_vector.py: Core VSA operations (bind, bundle, similarity) with 10kD bipolar hypervectors for preserving semantic superposition
- collapse_resistance.py: Collapse resistance computation (0-1) based on extraction confidence, alignment quality, and context ambiguity
- grammar_triangle.py: Grammar Triangle Field combining NSM primitives, causality flow, and 18D qualia field for semantic modulation
- Extended Extraction dataclass with BAF fields and compute_baf_components()
- Updated resolver.py with compute_baf option for alignment pipeline

The key insight is that templates should "project" meaning rather than "bind" it, allowing the original semantic field to be preserved alongside structured extractions.