### PR TITLE
Use shields.io for DOI badge to avoid Zenodo badge timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 [![PyPI version](https://img.shields.io/pypi/v/langextract.svg)](https://pypi.org/project/langextract/)
 [![GitHub stars](https://img.shields.io/github/stars/google/langextract.svg?style=social&label=Star)](https://github.com/google/langextract)
 ![Tests](https://github.com/google/langextract/actions/workflows/ci.yaml/badge.svg)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17015089.svg)](https://doi.org/10.5281/zenodo.17015089)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.17015089-blue)](https://doi.org/10.5281/zenodo.17015089)
+
 
 ## Table of Contents
 


### PR DESCRIPTION
Zenodo’s DOI badge endpoint is unreliably slow, causing GitHub to render fallback text (“DOI”).
This PR switches the badge image to shields.io (already used elsewhere in the README) while keeping the DOI link unchanged.