### PR TITLE
relax: Add 11 popular ollama model name regex patterns for provider routing

### DIFF
--- a/langextract/providers/patterns.py
+++ b/langextract/providers/patterns.py
@@ -48,6 +48,17 @@ OLLAMA_PATTERNS = (
     r'^tinyllama',  # tinyllama:1.1b
     r'^wizardcoder',  # wizardcoder:7b, wizardcoder:13b, etc.
     r'^gpt-oss',  # Open source GPT variants
+    r'^ministral',  # ministral-3:3b, ministral-3:8b, etc.
+    r'^devstral',  # devstral-small-2:24b, etc.
+    r'^nemotron',  # nemotron-mini:4b, nemotron-3-nano:30b, etc.
+    r'^granite',  # granite4:350m, granite4:1b, granite4:3b, etc.
+    r'^glm',  # glm4:9b, etc.
+    r'^rnj',  # rnj-1:8b, etc.
+    r'^olmo',  # olmo-3:7b, etc.
+    r'^smollm',  # smollm2:135m, smollm2:360m, smollm2:1.7b, etc.
+    r'^lfm',  # lfm2.5-thinking, etc.
+    r'^falcon',  # falcon3:1b, falcon3:3b, falcon3:7b, falcon3:10b, etc.
+    r'^yi',  # yi:6b, yi:9b, yi-coder:1.5b, yi-coder:9b, etc.
     # HuggingFace model patterns
     r'^meta-llama/[Ll]lama',
     r'^google/gemma',


### PR DESCRIPTION
# Description

Add regex patterns for 11 popular Ollama model families: ministral, devstral, nemotron, granite, glm, rnj, olmo, smollm, lfm, falcon, yi. This enables users to use these models via the standard model_id API.

Fixes #328

Out of provided PR case selection, closest to "feature" but @aksg87 refers to similar changes as "relax".

# How Has This Been Tested?

```
$ python -c "from langextract.providers import router; from langextract import providers; providers.load_builtins_once(); cls = router.resolve('ministral-3:8b'); print(f'Resolved to: {cls.__name__}')"

> Resolved to: OllamaLanguageModel
```

# Checklist:
-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [ ] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.