### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/auto-update-pr.yaml
+++ b/.github/workflows/auto-update-pr.yaml
@@ -40,7 +40,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Update PRs that are behind main
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.inputs?.pr_number;

--- a/.github/workflows/check-infrastructure-changes.yml
+++ b/.github/workflows/check-infrastructure-changes.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check for infrastructure file changes
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check linked issue and community support
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/check-pr-size.yml
+++ b/.github/workflows/check-pr-size.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get PR data for manual trigger
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number
         id: get_pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           result-encoding: string
           script: |
@@ -39,7 +39,7 @@ jobs:
 
       - name: Evaluate PR size
         if: github.event_name == 'pull_request_target' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_JSON: ${{ steps.get_pr.outputs.result }}
         with:

--- a/.github/workflows/check-pr-up-to-date.yaml
+++ b/.github/workflows/check-pr-up-to-date.yaml
@@ -32,7 +32,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2  # Sufficient for rev-list comparison
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Comment if PR needs update
         if: ${{ steps.check.outputs.commits_behind != '0' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const behind = ${{ steps.check.outputs.commits_behind }};

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,14 +39,14 @@ jobs:
       issues: write
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Comment on PR if formatting fails
         if: failure() && steps.format-check.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         continue-on-error: true
         with:
           script: |
@@ -93,12 +93,12 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -123,12 +123,12 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -161,7 +161,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -185,7 +185,7 @@ jobs:
           exit 0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -209,7 +209,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -231,7 +231,7 @@ jobs:
           exit 0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -275,7 +275,7 @@ jobs:
 
     steps:
       - name: Check if user is maintainer
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -297,7 +297,7 @@ jobs:
           echo "::notice title=Security::Pinned commit SHA for testing: ${SHA_TO_TEST}"
 
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -327,7 +327,7 @@ jobs:
           echo "::notice title=Security::Successfully verified commit SHA: $ACTUAL_SHA"
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -351,7 +351,7 @@ jobs:
           }
 
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -375,7 +375,7 @@ jobs:
           echo "::notice title=Security::Successfully merged verified commit"
 
       - name: Add status comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({
@@ -404,7 +404,7 @@ jobs:
 
       - name: Report success
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({
@@ -416,7 +416,7 @@ jobs:
 
       - name: Report failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,10 +30,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/revalidate-pr.yml
+++ b/.github/workflows/revalidate-pr.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get PR data
         id: pr_data
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({
@@ -40,7 +40,7 @@ jobs:
             return pr;
 
       - name: Create pending status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -54,7 +54,7 @@ jobs:
 
       - name: Validate PR
         id: validate
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = ${{ steps.pr_data.outputs.result }};
@@ -104,7 +104,7 @@ jobs:
 
       - name: Update commit status
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const passed = ${{ steps.validate.outputs.passed }};
@@ -122,7 +122,7 @@ jobs:
 
       - name: Add validation comment
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = ${{ steps.pr_data.outputs.result }};

--- a/.github/workflows/validate-community-providers.yaml
+++ b/.github/workflows/validate-community-providers.yaml
@@ -32,10 +32,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/validate_pr_template.yaml
+++ b/.github/workflows/validate_pr_template.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Check PR author permissions
         id: check
         if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/zenodo-publish.yml
+++ b/.github/workflows/zenodo-publish.yml
@@ -36,10 +36,10 @@ jobs:
       RELEASE_TAG: ${{ github.ref_name }}
       GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | check-pr-up-to-date.yaml, ci.yaml, publish.yml, validate-community-providers.yaml, zenodo-publish.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | auto-update-pr.yaml, check-infrastructure-changes.yml, check-linked-issue.yml, check-pr-size.yml, check-pr-up-to-date.yaml, ci.yaml, revalidate-pr.yml, validate_pr_template.yaml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | ci.yaml, publish.yml, validate-community-providers.yaml, zenodo-publish.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
