### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Detect provider-related changes
         id: provider-changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             langextract/providers/**
@@ -216,7 +216,7 @@ jobs:
 
       - name: Detect file changes
         id: changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             langextract/inference.py


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `tj-actions/changed-files` | [`v46`](https://github.com/tj-actions/changed-files/releases/tag/v46) | [`v47`](https://github.com/tj-actions/changed-files/releases/tag/v47) | [Release](https://github.com/tj-actions/changed-files/releases/tag/v47) | ci.yaml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
