### PR TITLE
Fix: Correctly load built-in providers when using explicit 'provider' in ModelConfig

### DIFF
--- a/langextract/factory.py
+++ b/langextract/factory.py
@@ -219,12 +219,12 @@ def _create_model_with_schema(
   Returns:
     A model instance with fence_output configured appropriately.
   """
+  providers.load_builtins_once()
+  providers.load_plugins_once()
 
   if config.provider:
     provider_class = router.resolve_provider(config.provider)
   else:
-    providers.load_builtins_once()
-    providers.load_plugins_once()
     provider_class = router.resolve(config.model_id)
 
   schema_instance = None

--- a/tests/factory_provider_loading_test.py
+++ b/tests/factory_provider_loading_test.py
@@ -18,6 +18,7 @@ from absl.testing import absltest
 
 from langextract import exceptions
 from langextract import factory
+from langextract import providers
 from langextract.providers import router
 
 
@@ -25,6 +26,8 @@ class FactoryProviderLoadingTest(absltest.TestCase):
 
   def setUp(self):
     super().setUp()
+    # Reset loading state so builtins are re-registered
+    providers._reset_for_testing()  # pylint: disable=protected-access
     # Clear registry to ensure we are testing the loading mechanism
     router.clear()
 
@@ -48,7 +51,6 @@ class FactoryProviderLoadingTest(absltest.TestCase):
 
       # If we get "API key not provided" or similar, it means the class WAS found!
       # This is SUCCESS.
-      pass
     except ImportError:
       # Also success - means we tried to import dependencies (so we found the class)
       pass

--- a/tests/factory_provider_loading_test.py
+++ b/tests/factory_provider_loading_test.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for verifying provider loading behavior in factory."""
+
+from absl.testing import absltest
+
+from langextract import exceptions
+from langextract import factory
+from langextract.providers import router
+
+
+class FactoryProviderLoadingTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    # Clear registry to ensure we are testing the loading mechanism
+    router.clear()
+
+  def test_create_model_with_schema_loads_builtins_explicit_provider(self):
+    """Test that builtins are loaded when provider is explicitly set."""
+    # This configuration caused a crash before the fix because
+    # load_builtins_once() was skipped.
+    config = factory.ModelConfig(
+        model_id="gpt-4o",
+        provider="openai",
+        provider_kwargs={"api_key": "dummy-key"},
+    )
+
+    try:
+      # This calls the method that had the bug
+      factory._create_model_with_schema(config)
+    except exceptions.InferenceConfigError as e:
+      # If the bug exists, the error message starts with "No provider found matching"
+      if "No provider found matching" in str(e):
+        self.fail(f"Bug reproduced: Builtin provider not loaded! Error: {e}")
+
+      # If we get "API key not provided" or similar, it means the class WAS found!
+      # This is SUCCESS.
+      pass
+    except ImportError:
+      # Also success - means we tried to import dependencies (so we found the class)
+      pass
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      self.fail(f"Unexpected exception raised: {type(e).__name__}: {e}")
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
# Description

Fixes a crash in `_create_model_with_schema` where built-in providers were not loaded when `ModelConfig` was initialized with an explicit `provider` argument.

Previously, `providers.load_builtins_once()` and `providers.load_plugins_once()` were only called inside the `else` block — meaning they were **skipped** when `config.provider` was set. This caused provider resolution to fail with an `InferenceConfigError`.

**Root cause** (in `langextract/factory.py`, `_create_model_with_schema`):

```python
# BEFORE (buggy):
if config.provider:
    provider_class = router.resolve_provider(config.provider)  # builtins NOT loaded!
else:
    providers.load_builtins_once()   # only called here
    providers.load_plugins_once()
    provider_class = router.resolve(config.model_id)
```

**Fix:**

```python
# AFTER (fixed):
providers.load_builtins_once()   # always load first
providers.load_plugins_once()

if config.provider:
    provider_class = router.resolve_provider(config.provider)
else:
    provider_class = router.resolve(config.model_id)
```

This aligns `_create_model_with_schema` with `create_model`, which already handles this correctly (lines 142-149).

**Reproduction:**

```python
from langextract import factory
config = factory.ModelConfig(model_id='gpt-4o', provider='openai')
factory._create_model_with_schema(config)
```

**Error before fix:**

```
Traceback (most recent call last):
  File "langextract/factory.py", line 224, in _create_model_with_schema
    provider_class = router.resolve_provider(config.provider)
  File "langextract/providers/router.py", line 211, in resolve_provider
    raise exceptions.InferenceConfigError(
langextract.core.exceptions.InferenceConfigError: No provider found matching: 'openai'. Available providers can be listed with list_providers()
```

**After fix:** Provider resolves successfully ✅

Fixes #320

Bug fix

# How Has This Been Tested?

Added a new unit test file `tests/factory_provider_loading_test.py`:

```
$ python -m unittest tests/factory_provider_loading_test.py
.
----------------------------------------------------------------------
Ran 1 test in 2.316s

OK
```

**Test details:**

- Clears the provider registry to simulate a fresh state.
- Creates a `ModelConfig` with explicit `provider="openai"`.
- Calls `_create_model_with_schema` and asserts that we do **not** get a `"No provider found matching"` error.
- Accepts other errors (e.g., missing API key) as success — they prove the provider class _was_ found and loaded.

Code style verified with `./autoformat.sh` (all pre-commit hooks passed).

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [ ] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes
- [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.
