### PR TITLE
Fix incorrect char_interval for non-ASCII text due to tokenizer merging (Fixes #334)

### DIFF
--- a/docs/examples/japanese_extraction.md
+++ b/docs/examples/japanese_extraction.md
@@ -51,7 +51,7 @@ for entity in result.extractions:
     if entity.char_interval:
         start, end = entity.char_interval.start_pos, entity.char_interval.end_pos
         position_info = f" (pos: {start}-{end})"
-    
+
     print(f"• {entity.extraction_class}: {entity.extraction_text}{position_info}")
 
 # Expected Output:

--- a/langextract/core/tokenizer.py
+++ b/langextract/core/tokenizer.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC.
+
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -145,16 +145,31 @@ class TokenizedText:
   tokens: list[Token] = dataclasses.field(default_factory=list)
 
 
-_LETTERS_PATTERN = r"[^\W\d_]+"
+
+# CJK Scripts that typically don't use spaces but should be separated from Latin
+_CJK_SCRIPTS = r"\p{Han}\p{Hiragana}\p{Katakana}\p{Hangul}"
+
+# Enhanced logic: "Word chars" MINUS "CJK chars".
+# This prevents "Hello世界" from being one token. instead: "Hello" and "世界".
+# Requires regex V1 flag for set subtraction operations.
+_LETTERS_PATTERN = rf"[[^\W\d_]--[{_CJK_SCRIPTS}]]+"
 _DIGITS_PATTERN = r"\d+"
 # Group identical symbols (e.g. "!!") but split mixed ones.
 _SYMBOLS_PATTERN = r"([^\w\s]|_)\1*"
+# CJK characters are treated as their own group of "letters"
+_CJK_PATTERN = rf"[{_CJK_SCRIPTS}]+"
+
 _END_OF_SENTENCE_PATTERN = regex.compile(r"[.?!。！？\u0964][\"'”’»)\]}]*$")
 
 _TOKEN_PATTERN = regex.compile(
-    rf"{_LETTERS_PATTERN}|{_DIGITS_PATTERN}|{_SYMBOLS_PATTERN}"
+    rf"{_LETTERS_PATTERN}|{_DIGITS_PATTERN}|{_CJK_PATTERN}|{_SYMBOLS_PATTERN}",
+    flags=regex.V1,
 )
-_WORD_PATTERN = regex.compile(rf"(?:{_LETTERS_PATTERN}|{_DIGITS_PATTERN})\Z")
+_WORD_PATTERN = regex.compile(
+    rf"(?:{_LETTERS_PATTERN}|{_DIGITS_PATTERN}|{_CJK_PATTERN})\Z",
+    flags=regex.V1,
+)
+
 
 # Abbreviations that do not end sentences.
 # TODO: Evaluate removal for large-context use cases.

--- a/langextract/core/tokenizer.py
+++ b/langextract/core/tokenizer.py
@@ -1,4 +1,3 @@
-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -143,7 +142,6 @@ class TokenizedText:
 
   text: str
   tokens: list[Token] = dataclasses.field(default_factory=list)
-
 
 
 # CJK Scripts that typically don't use spaces but should be separated from Latin


### PR DESCRIPTION
# Description

This PR fixes Issue #334 where `RegexTokenizer` was incorrectly merging Latin characters with adjacent non-ASCII characters (e.g., 'Hello世界') into a single token. This caused `WordAligner` to fail when identifying entities that are substrings of these merged tokens.

The fix involves:
- Updating `langextract/core/tokenizer.py` to use `regex` library's V1 features.
- Refining `_LETTERS_PATTERN` to strictly exclude CJK scripts using set subtraction.
- Explicitly handling CJK characters as their own token group.

Fixes #334

Bug fix

# How Has This Been Tested?

I verified the fix using a reproduction script that specifically tests mixed script inputs (Latin + CJK, Emojis). 
I also ran the full test suite locally:

```
$ pytest tests/
```
All tests passed.

# Checklist:

-   [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.
