### PR TITLE
fix: resolve batch inference crash by handling non-serializable objects in GCS cache

### DIFF
--- a/langextract/providers/gemini_batch.py
+++ b/langextract/providers/gemini_batch.py
@@ -392,7 +392,7 @@ class GCSBatchCache:
 
   def _compute_hash(self, key_data: dict) -> str:
     """Compute SHA256 hash of the canonicalized request data."""
-     # to prevent crash added default=_json_serializer
+     # to prevent crash  added default=_json_serializer
     canonical_json = json.dumps(
         key_data, sort_keys=True, ensure_ascii=False, default=_json_serializer
     )

--- a/langextract/providers/gemini_batch.py
+++ b/langextract/providers/gemini_batch.py
@@ -52,7 +52,13 @@ _EXT_JSONL = ".jsonl"
 _KEY_IDX = "idx-"
 _CACHE_PREFIX = "cache"
 _UNSET = object()
-
+def _json_serializer(obj: Any) -> Any:
+  """JSON serializer for objects not serializable by default json code."""
+  if dataclasses.is_dataclass(obj):
+    return dataclasses.asdict(obj)
+  if isinstance(obj, enum.Enum):
+    return obj.value
+  raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
 @dataclasses.dataclass(slots=True, frozen=True)
 class BatchConfig:
@@ -386,7 +392,10 @@ class GCSBatchCache:
 
   def _compute_hash(self, key_data: dict) -> str:
     """Compute SHA256 hash of the canonicalized request data."""
-    canonical_json = json.dumps(key_data, sort_keys=True, ensure_ascii=False)
+     # to prevent crash added default=_json_serializer
+    canonical_json = json.dumps(
+        key_data, sort_keys=True, ensure_ascii=False, default=_json_serializer
+    )
     return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
 
   def _get_single(self, key_hash: str) -> str | None:


### PR DESCRIPTION
Problem: The batch inference process was crashing when trying to compute a cache hash for requests containing non-serializable objects, such as Enum (used in SafetySettings) or Dataclasses. This triggered a TypeError: Object of type ... is not JSON serializable during json.dumps.

Solution:

1. Added a private helper function _json_serializer to handle dataclasses and Enum types during JSON serialization.

2. Updated GCSBatchCache._compute_hash to use this serializer, ensuring stable and reliable hashing even with complex request configurations.

Impact: Prevents runtime crashes during batch processing and ensures caching works correctly with all Gemini model configurations.

Resolves #353