### PR TITLE
Remove duplicate model_id assignment in factory.create_model()

### DIFF
--- a/langextract/factory.py
+++ b/langextract/factory.py
@@ -156,8 +156,6 @@ def create_model(
 
   model_id = config.model_id
 
-  model_id = config.model_id
-
   kwargs = _kwargs_with_environment_defaults(
       model_id or config.provider or "", config.provider_kwargs
   )


### PR DESCRIPTION
# Description

Remove duplicate assignment in `factory.create_model()`: the line `model_id = config.model_id` appeared twice in a row (dead code). No behavior change.

Related to #357 https://github.com/google/langextract/issues/357

**Code health**

# How Has This Been Tested?

Existing test suite; no new tests (behavior unchanged).

pytest tests/

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google/langextract/blob/main/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes.
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.