### PR TITLE
fix: health check failure curl not found

### DIFF
--- a/examples/ollama/docker-compose.yml
+++ b/examples/ollama/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ollama-data:/root/.ollama  # Cross-platform support
     command: serve
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/version"]
+      test: ["CMD", "ollama", "list"]
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
# Description
- Fix Docker healthcheck for the Ollama example that fails because curl is not available in the ollama/ollama image
- Replace curl -f http://localhost:11434/api/version with ollama list, which is guaranteed to exist in the image and verifies server responsiveness the same way

```
% docker inspect --format='{{json .State.Health}}' ollama-ollama-1
(...)
"ExitCode":-1,"Output":"OCI runtime exec failed: exec failed: unable to start container process: exec: \"curl\": executable file not found in $PATH: unknown"}]}
```

Fixes #361

# How Has This Been Tested?

# Checklist
