### PR TITLE
fix: continue extraction when chunk resolve/alignment fails

### DIFF
--- a/docs/examples/batch_api_example.md
+++ b/docs/examples/batch_api_example.md
@@ -70,6 +70,8 @@ results = lx.extract(
     model_id="gemini-2.5-flash",
     max_char_buffer=500,
     batch_length=1000,
+    # Optional: continue even if a few chunks return malformed output.
+    resolver_params={"suppress_parse_errors": True},
     language_model_params={
         "vertexai": True,
         "project": "your-gcp-project", # TODO: Replace with your Project ID.

--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -127,7 +127,10 @@ def extract(
         Minimum token overlap ratio for fuzzy match (0.0-1.0). Default is 0.75.
         'accept_match_lesser' (bool): Whether to accept partial exact matches.
         Default is True. 'suppress_parse_errors' (bool): Whether to suppress
-        parsing errors and continue pipeline. Default is False.
+        parsing/resolve/alignment errors for individual chunks and continue the
+        pipeline. This is especially useful for long-running batch jobs where a
+        single malformed model response would otherwise fail the entire run.
+        Default is False.
       language_model_params: Additional parameters for the language model.
       debug: Whether to enable debug logging. When True, enables detailed logging
         of function calls, arguments, return values, and timing for the langextract


### PR DESCRIPTION
## Summary
- Add an opt-in `suppress_parse_errors` flag to skip per-chunk resolver `resolve`/`align` failures during annotation (useful for long-running batch jobs).
- Document the new resolver param in the public `extract()` API and batch example.
- Add tests covering default (raise) vs opt-in (skip) behavior.

## Test plan
- [x] `python3 -m pytest -q`

Fixes #287 