### PR TITLE
fix: add OpenAI JSON schema constraints support

### DIFF
--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -28,6 +28,7 @@ from langextract.core import schema
 from langextract.core import types as core_types
 from langextract.providers import patterns
 from langextract.providers import router
+from langextract.providers import schemas as provider_schemas
 
 
 @router.register(
@@ -42,6 +43,7 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
   api_key: str | None = None
   base_url: str | None = None
   organization: str | None = None
+  openai_schema: provider_schemas.OpenAISchema | None = None
   format_type: data.FormatType = data.FormatType.JSON
   temperature: float | None = None
   max_workers: int = 10
@@ -53,9 +55,27 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
   @property
   def requires_fence_output(self) -> bool:
     """OpenAI JSON mode returns raw JSON without fences."""
+    if (
+        hasattr(self, "_fence_output_override")
+        and self._fence_output_override is not None
+    ):
+      return self._fence_output_override
     if self.format_type == data.FormatType.JSON:
       return False
     return super().requires_fence_output
+
+  @classmethod
+  def get_schema_class(cls) -> type[schema.BaseSchema] | None:
+    """Return OpenAISchema for structured output support."""
+    return provider_schemas.OpenAISchema
+
+  def apply_schema(self, schema_instance: schema.BaseSchema | None) -> None:
+    """Apply a schema instance to this provider."""
+    super().apply_schema(schema_instance)
+    if isinstance(schema_instance, provider_schemas.OpenAISchema):
+      self.openai_schema = schema_instance
+    else:
+      self.openai_schema = None
 
   def __init__(
       self,
@@ -161,7 +181,16 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
       if temp is not None:
         api_params['temperature'] = temp
 
-      if self.format_type == data.FormatType.JSON:
+      if self.openai_schema is not None:
+        if self.format_type != data.FormatType.JSON:
+          raise exceptions.InferenceConfigError(
+              'OpenAI structured output only supports JSON format. '
+              'Set format_type=JSON or use_schema_constraints=False.'
+          )
+        api_params['response_format'] = self.openai_schema.to_provider_config()[
+            'response_format'
+        ]
+      elif self.format_type == data.FormatType.JSON:
         api_params.setdefault('response_format', {'type': 'json_object'})
 
       if (v := normalized_config.get('max_output_tokens')) is not None:

--- a/langextract/providers/schemas/__init__.py
+++ b/langextract/providers/schemas/__init__.py
@@ -16,7 +16,9 @@
 from __future__ import annotations
 
 from langextract.providers.schemas import gemini
+from langextract.providers.schemas import openai
 
 GeminiSchema = gemini.GeminiSchema  # Backward compat
+OpenAISchema = openai.OpenAISchema  # Backward compat
 
-__all__ = ["GeminiSchema"]
+__all__ = ["GeminiSchema", "OpenAISchema"]

--- a/langextract/providers/schemas/openai.py
+++ b/langextract/providers/schemas/openai.py
@@ -1,0 +1,177 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenAI provider schema implementation.
+
+This schema enables OpenAI "Structured Outputs" by providing a JSON Schema via
+the `response_format` parameter (type `json_schema`).
+
+Reference: https://platform.openai.com/docs/guides/structured-outputs
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import dataclasses
+from typing import Any
+import warnings
+
+from langextract.core import data
+from langextract.core import exceptions
+from langextract.core import format_handler as fh
+from langextract.core import schema
+
+
+_DEFAULT_SCHEMA_NAME = "langextract_extractions"
+
+
+@dataclasses.dataclass
+class OpenAISchema(schema.BaseSchema):
+  """Schema implementation for OpenAI Structured Outputs (JSON Schema)."""
+
+  _schema_dict: dict[str, Any]
+  _schema_name: str = _DEFAULT_SCHEMA_NAME
+  _strict: bool = True
+
+  @property
+  def schema_dict(self) -> dict[str, Any]:
+    """Returns the JSON schema dictionary."""
+    return self._schema_dict
+
+  def to_provider_config(self) -> dict[str, Any]:
+    """Convert schema to OpenAI Chat Completions configuration."""
+    return {
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": self._schema_name,
+                "schema": self._schema_dict,
+                "strict": self._strict,
+            },
+        }
+    }
+
+  @property
+  def requires_raw_output(self) -> bool:
+    """OpenAI structured outputs return raw JSON without fences."""
+    return True
+
+  def sync_with_provider_kwargs(self, kwargs: dict[str, Any]) -> None:
+    """Validate provider kwargs are compatible with OpenAI schema mode."""
+    fmt = kwargs.get("format_type", data.FormatType.JSON)
+    if fmt != data.FormatType.JSON:
+      raise exceptions.InferenceConfigError(
+          "OpenAI structured output only supports JSON format. "
+          "Set format_type=JSON or use_schema_constraints=False."
+      )
+
+  def validate_format(self, format_handler: fh.FormatHandler) -> None:
+    """Warn on format settings that conflict with OpenAI structured output."""
+    if format_handler.format_type != data.FormatType.JSON:
+      warnings.warn(
+          "OpenAI structured output only supports JSON format.",
+          UserWarning,
+          stacklevel=3,
+      )
+    if format_handler.use_fences:
+      warnings.warn(
+          "OpenAI structured output returns native JSON. Using fence_output=True"
+          " may cause parsing issues. Set fence_output=False.",
+          UserWarning,
+          stacklevel=3,
+      )
+    if (
+        not format_handler.use_wrapper
+        or format_handler.wrapper_key != data.EXTRACTIONS_KEY
+    ):
+      warnings.warn(
+          "OpenAI structured output schema expects wrapper_key="
+          f"'{data.EXTRACTIONS_KEY}'. Current settings: use_wrapper="
+          f"{format_handler.use_wrapper}, wrapper_key='{format_handler.wrapper_key}'",
+          UserWarning,
+          stacklevel=3,
+      )
+
+  @classmethod
+  def from_examples(
+      cls,
+      examples_data: Sequence[data.ExampleData],
+      attribute_suffix: str = data.ATTRIBUTE_SUFFIX,
+  ) -> OpenAISchema:
+    """Creates an OpenAISchema from example extractions.
+
+    Builds a JSON Schema with a top-level "extractions" array. Each element in
+    that array is an object containing the extraction class name and an
+    accompanying "<class>_attributes" object for its attributes.
+
+    Notes:
+      - OpenAI expects JSON Schema (not OpenAPI). Use `type: ["object", "null"]`
+        to represent nullable attribute objects.
+    """
+    # Track attribute types for each category
+    extraction_categories: dict[str, dict[str, set[type]]] = {}
+    for example in examples_data:
+      for extraction in example.extractions:
+        category = extraction.extraction_class
+        if category not in extraction_categories:
+          extraction_categories[category] = {}
+
+        if extraction.attributes:
+          for attr_name, attr_value in extraction.attributes.items():
+            if attr_name not in extraction_categories[category]:
+              extraction_categories[category][attr_name] = set()
+            extraction_categories[category][attr_name].add(type(attr_value))
+
+    extraction_properties: dict[str, dict[str, Any]] = {}
+
+    for category, attrs in extraction_categories.items():
+      extraction_properties[category] = {"type": "string"}
+
+      attributes_field = f"{category}{attribute_suffix}"
+      attr_properties: dict[str, Any] = {}
+
+      # Default property for categories without attributes
+      if not attrs:
+        attr_properties["_unused"] = {"type": "string"}
+      else:
+        for attr_name, attr_types in attrs.items():
+          # List attributes become arrays
+          if list in attr_types:
+            attr_properties[attr_name] = {
+                "type": "array",
+                "items": {"type": "string"},  # type: ignore[dict-item]
+            }
+          else:
+            attr_properties[attr_name] = {"type": "string"}
+
+      extraction_properties[attributes_field] = {
+          "type": ["object", "null"],
+          "properties": attr_properties,
+      }
+
+    extraction_schema = {
+        "type": "object",
+        "properties": extraction_properties,
+    }
+
+    schema_dict = {
+        "type": "object",
+        "properties": {
+            data.EXTRACTIONS_KEY: {"type": "array", "items": extraction_schema}
+        },
+        "required": [data.EXTRACTIONS_KEY],
+    }
+
+    return cls(_schema_dict=schema_dict)
+

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -32,6 +32,7 @@ from langextract.core import types
 from langextract.providers import gemini
 from langextract.providers import ollama
 from langextract.providers import openai
+from langextract.providers import schemas
 
 
 class TestBaseLanguageModel(absltest.TestCase):
@@ -670,6 +671,51 @@ class TestOpenAILanguageModel(absltest.TestCase):
     call_args = mock_client.chat.completions.create.call_args
     self.assertEqual(
         call_args.kwargs["response_format"], {"type": "json_object"}
+    )
+
+  @mock.patch("openai.OpenAI")
+  def test_openai_schema_constraints_use_json_schema_response_format(
+      self, mock_openai_class
+  ):
+    """Schema constraints should switch OpenAI to json_schema response_format."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"extractions": []}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai.OpenAILanguageModel(
+        api_key="test-key", format_type=data.FormatType.JSON
+    )
+
+    examples_data = [
+        data.ExampleData(
+            text="Patient has diabetes",
+            extractions=[
+                data.Extraction(
+                    extraction_class="condition",
+                    extraction_text="diabetes",
+                    attributes={"severity": "moderate"},
+                )
+            ],
+        )
+    ]
+    test_schema = schemas.openai.OpenAISchema.from_examples(examples_data)
+    model.apply_schema(test_schema)
+
+    list(model.infer(["test prompt"]))
+
+    call_args = mock_client.chat.completions.create.call_args
+    response_format = call_args.kwargs["response_format"]
+    self.assertEqual(response_format["type"], "json_schema")
+    self.assertIn("json_schema", response_format)
+    self.assertIn("schema", response_format["json_schema"])
+    self.assertIn(
+        data.EXTRACTIONS_KEY,
+        response_format["json_schema"]["schema"]["properties"],
     )
 
   @mock.patch("openai.OpenAI")

--- a/tests/provider_schema_test.py
+++ b/tests/provider_schema_test.py
@@ -51,12 +51,13 @@ class ProviderSchemaDiscoveryTest(absltest.TestCase):
     )
 
   def test_openai_returns_none(self):
-    """Test that OpenAILanguageModel returns None (no schema support yet)."""
+    """Test that OpenAILanguageModel returns OpenAISchema."""
     # OpenAI imports dependencies in __init__, not at module level
     schema_class = openai.OpenAILanguageModel.get_schema_class()
-    self.assertIsNone(
+    self.assertEqual(
         schema_class,
-        msg="OpenAILanguageModel should return None (no schema support)",
+        schemas.openai.OpenAISchema,
+        msg="OpenAILanguageModel should return OpenAISchema class",
     )
 
 
@@ -539,6 +540,43 @@ class GeminiSchemaProviderIntegrationTest(absltest.TestCase):
           call_kwargs["config"],
           msg="response_schema should be forwarded to genai API config",
       )
+
+
+class OpenAISchemaProviderIntegrationTest(absltest.TestCase):
+  """Tests for OpenAISchema provider integration."""
+
+  def test_openai_rejects_yaml_with_schema(self):
+    """OpenAI schema constraints should be JSON-only (no YAML)."""
+    examples_data = [
+        data.ExampleData(
+            text="Test",
+            extractions=[
+                data.Extraction(
+                    extraction_class="test",
+                    extraction_text="test text",
+                )
+            ],
+        )
+    ]
+
+    config = factory.ModelConfig(
+        model_id="gpt-4o-mini",
+        provider_kwargs={"api_key": "test_key", "format_type": data.FormatType.YAML},
+    )
+
+    with self.assertRaises(exceptions.InferenceConfigError) as cm:
+      _ = factory.create_model(
+          config=config,
+          examples=examples_data,
+          use_schema_constraints=True,
+          fence_output=None,
+      )
+
+    self.assertIn(
+        "only supports JSON format",
+        str(cm.exception),
+        msg="Error should mention JSON-only constraint",
+    )
 
 
 class SchemaShimTest(absltest.TestCase):


### PR DESCRIPTION
## Summary
- Add OpenAI schema support for `use_schema_constraints=True` by using Structured Outputs (`response_format: {type: \"json_schema\"}`) so JSON output can be returned without fences.
- Reject schema constraints for `FormatType.YAML` with a clear configuration error.
- Add tests covering schema discovery, YAML rejection, and request parameter wiring.

## Test plan
- [x] `python3 -m pytest -q`

Fixes #59

Made with [Cursor](https://cursor.com)