### PR TITLE
feat: add OpenAI Batch API support

### DIFF
--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -129,6 +129,8 @@ def extract(
         Default is True. 'suppress_parse_errors' (bool): Whether to suppress
         parsing errors and continue pipeline. Default is False.
       language_model_params: Additional parameters for the language model.
+        OpenAI supports the Batch API via a nested `batch` dict, e.g.
+        `language_model_params={"batch": {"enabled": True, "threshold": 50}}`.
       debug: Whether to enable debug logging. When True, enables detailed logging
         of function calls, arguments, return values, and timing for the langextract
         namespace. Note: Debug logging remains enabled for the process once activated.

--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -21,11 +21,14 @@ import concurrent.futures
 import dataclasses
 from typing import Any, Iterator, Sequence
 
+from absl import logging
+
 from langextract.core import base_model
 from langextract.core import data
 from langextract.core import exceptions
 from langextract.core import schema
 from langextract.core import types as core_types
+from langextract.providers import openai_batch
 from langextract.providers import patterns
 from langextract.providers import router
 
@@ -46,6 +49,9 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
   temperature: float | None = None
   max_workers: int = 10
   _client: Any = dataclasses.field(default=None, repr=False, compare=False)
+  _batch_cfg: openai_batch.BatchConfig = dataclasses.field(
+      default_factory=openai_batch.BatchConfig, repr=False, compare=False
+  )
   _extra_kwargs: dict[str, Any] = dataclasses.field(
       default_factory=dict, repr=False, compare=False
   )
@@ -99,6 +105,9 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
     self.temperature = temperature
     self.max_workers = max_workers
 
+    batch_cfg_dict = kwargs.pop("batch", None)
+    self._batch_cfg = openai_batch.BatchConfig.from_dict(batch_cfg_dict)
+
     if not self.api_key:
       raise exceptions.InferenceConfigError('API key not provided.')
 
@@ -130,56 +139,59 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
 
     return result
 
+  def _build_chat_completion_params(self, prompt: str, config: dict) -> dict:
+    """Build chat.completions parameters for a single prompt."""
+    normalized_config = self._normalize_reasoning_params(config)
+
+    system_message = ""
+    if self.format_type == data.FormatType.JSON:
+      system_message = "You are a helpful assistant that responds in JSON format."
+    elif self.format_type == data.FormatType.YAML:
+      system_message = "You are a helpful assistant that responds in YAML format."
+
+    messages = [{"role": "user", "content": prompt}]
+    if system_message:
+      messages.insert(0, {"role": "system", "content": system_message})
+
+    api_params = {
+        "model": self.model_id,
+        "messages": messages,
+        "n": 1,
+    }
+
+    temp = normalized_config.get("temperature", self.temperature)
+    if temp is not None:
+      api_params["temperature"] = temp
+
+    if self.format_type == data.FormatType.JSON:
+      api_params.setdefault("response_format", {"type": "json_object"})
+
+    if (v := normalized_config.get("max_output_tokens")) is not None:
+      api_params["max_tokens"] = v
+    if (v := normalized_config.get("top_p")) is not None:
+      api_params["top_p"] = v
+
+    for key in [
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "stop",
+        "logprobs",
+        "top_logprobs",
+        "reasoning",
+        "response_format",
+    ]:
+      if (v := normalized_config.get(key)) is not None:
+        api_params[key] = v
+
+    return api_params
+
   def _process_single_prompt(
       self, prompt: str, config: dict
   ) -> core_types.ScoredOutput:
     """Process a single prompt and return a ScoredOutput."""
     try:
-      normalized_config = self._normalize_reasoning_params(config)
-
-      system_message = ''
-      if self.format_type == data.FormatType.JSON:
-        system_message = (
-            'You are a helpful assistant that responds in JSON format.'
-        )
-      elif self.format_type == data.FormatType.YAML:
-        system_message = (
-            'You are a helpful assistant that responds in YAML format.'
-        )
-
-      messages = [{'role': 'user', 'content': prompt}]
-      if system_message:
-        messages.insert(0, {'role': 'system', 'content': system_message})
-
-      api_params = {
-          'model': self.model_id,
-          'messages': messages,
-          'n': 1,
-      }
-
-      temp = normalized_config.get('temperature', self.temperature)
-      if temp is not None:
-        api_params['temperature'] = temp
-
-      if self.format_type == data.FormatType.JSON:
-        api_params.setdefault('response_format', {'type': 'json_object'})
-
-      if (v := normalized_config.get('max_output_tokens')) is not None:
-        api_params['max_tokens'] = v
-      if (v := normalized_config.get('top_p')) is not None:
-        api_params['top_p'] = v
-      for key in [
-          'frequency_penalty',
-          'presence_penalty',
-          'seed',
-          'stop',
-          'logprobs',
-          'top_logprobs',
-          'reasoning',
-          'response_format',
-      ]:
-        if (v := normalized_config.get(key)) is not None:
-          api_params[key] = v
+      api_params = self._build_chat_completion_params(prompt, config)
 
       response = self._client.chat.completions.create(**api_params)
 
@@ -230,6 +242,38 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
     ]:
       if key in merged_kwargs:
         config[key] = merged_kwargs[key]
+
+    # Use OpenAI Batch API if enabled and threshold met
+    if self._batch_cfg and self._batch_cfg.enabled:
+      if len(batch_prompts) >= self._batch_cfg.threshold:
+        fallback = None
+        if self._batch_cfg.ignore_item_errors:
+          fallback = openai_batch.empty_extractions_output(
+              format_type=self.format_type,
+              use_fences=self.requires_fence_output,
+          )
+        bodies = [
+            self._build_chat_completion_params(prompt, config.copy())
+            for prompt in batch_prompts
+        ]
+        outputs = openai_batch.infer_batch(
+            client=self._client,
+            request_bodies=bodies,
+            cfg=self._batch_cfg,
+            fallback_output=fallback,
+        )
+        for text in outputs:
+          yield [core_types.ScoredOutput(score=1.0, output=text)]
+        return
+      else:
+        logging.info(
+            "OpenAI batch mode enabled but prompt count (%d) is below the"
+            " threshold (%d); using real-time API. Submit at least %d prompts"
+            " to trigger batch mode.",
+            len(batch_prompts),
+            self._batch_cfg.threshold,
+            self._batch_cfg.threshold,
+        )
 
     # Use parallel processing for batches larger than 1
     if len(batch_prompts) > 1 and self.max_workers > 1:

--- a/langextract/providers/openai_batch.py
+++ b/langextract/providers/openai_batch.py
@@ -1,0 +1,349 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenAI Batch API support.
+
+Implements file-based batch submission and result extraction for the
+`/v1/chat/completions` endpoint.
+
+The Batch API returns output lines in arbitrary order. We preserve the input
+ordering by assigning a stable `custom_id` per request.
+
+Reference: https://platform.openai.com/docs/guides/batch
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import io
+import json
+import time
+from typing import Any, Sequence
+
+from absl import logging
+
+from langextract.core import data
+from langextract.core import exceptions
+
+
+_ENDPOINT_CHAT_COMPLETIONS = "/v1/chat/completions"
+_COMPLETION_WINDOW = "24h"
+_CUSTOM_ID_PREFIX = "idx-"
+
+_TERMINAL_OK = frozenset({"completed"})
+_TERMINAL_FAIL = frozenset({"failed"})
+_TERMINAL_PARTIAL = frozenset({"expired", "cancelled"})
+_TERMINAL_ALL = _TERMINAL_OK | _TERMINAL_FAIL | _TERMINAL_PARTIAL
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class BatchConfig:
+  """Define and validate OpenAI Batch API configuration.
+
+  Attributes:
+    enabled: Whether batch mode is enabled.
+    threshold: Minimum prompts to trigger batch processing.
+    poll_interval: Seconds between status checks.
+    timeout: Maximum seconds to wait for completion.
+    max_prompts_per_job: Max prompts allowed in one batch job (OpenAI limit is
+      50,000 requests per batch file).
+    ignore_item_errors: If True, fill item failures with a fallback output.
+    metadata: Optional OpenAI metadata dict attached to the batch job.
+  """
+
+  enabled: bool = False
+  threshold: int = 50
+  poll_interval: int = 30
+  timeout: int = 3600
+  max_prompts_per_job: int = 50000
+  ignore_item_errors: bool = False
+  metadata: dict[str, str] | None = None
+
+  def __post_init__(self):
+    validations = [
+        (self.threshold >= 1, "batch.threshold must be >= 1"),
+        (self.poll_interval > 0, "batch.poll_interval must be > 0"),
+        (self.timeout > 0, "batch.timeout must be > 0"),
+        (self.max_prompts_per_job > 0, "batch.max_prompts_per_job must be > 0"),
+    ]
+    for is_valid, msg in validations:
+      if not is_valid:
+        raise ValueError(msg)
+    if self.max_prompts_per_job > 50000:
+      raise ValueError("batch.max_prompts_per_job must be <= 50000")
+
+  @classmethod
+  def from_dict(cls, d: dict | None) -> BatchConfig:
+    """Create BatchConfig from dictionary, using defaults for missing keys."""
+    if d is None:
+      return cls()
+    valid_keys = {f.name for f in dataclasses.fields(cls)}
+    filtered_dict = {k: v for k, v in d.items() if k in valid_keys}
+
+    unknown = sorted(set(d.keys()) - valid_keys)
+    if unknown:
+      logging.warning(
+          "Ignoring unknown batch config keys: %s", ", ".join(unknown)
+      )
+    return cls(**filtered_dict)
+
+
+def empty_extractions_output(
+    *, format_type: data.FormatType, use_fences: bool
+) -> str:
+  """Return a minimal valid empty extraction payload for the format."""
+  if format_type == data.FormatType.JSON:
+    content = '{"extractions": []}'
+    if not use_fences:
+      return content
+    return f"```json\n{content}\n```"
+
+  content = "extractions: []"
+  if not use_fences:
+    return content
+  return f"```yaml\n{content}\n```"
+
+
+def infer_batch(
+    *,
+    client: Any,
+    request_bodies: Sequence[dict[str, Any]],
+    cfg: BatchConfig,
+    endpoint: str = _ENDPOINT_CHAT_COMPLETIONS,
+    fallback_output: str | None = None,
+) -> list[str]:
+  """Execute OpenAI batch inference for many chat.completions requests.
+
+  Args:
+    client: `openai.OpenAI` client instance.
+    request_bodies: Per-request `body` payloads for `/v1/chat/completions`.
+    cfg: BatchConfig settings.
+    endpoint: Batch endpoint (defaults to chat completions).
+    fallback_output: Output to use for per-item errors when
+      cfg.ignore_item_errors=True.
+
+  Returns:
+    A list of output strings in the same order as request_bodies.
+  """
+  if cfg.ignore_item_errors and fallback_output is None:
+    raise ValueError(
+        "fallback_output must be provided when ignore_item_errors=True"
+    )
+
+  results: list[str] = []
+  for start in range(0, len(request_bodies), cfg.max_prompts_per_job):
+    chunk = request_bodies[start : start + cfg.max_prompts_per_job]
+    results.extend(
+        _infer_batch_single_job(
+            client=client,
+            request_bodies=chunk,
+            cfg=cfg,
+            endpoint=endpoint,
+            fallback_output=fallback_output,
+        )
+    )
+  return results
+
+
+def _infer_batch_single_job(
+    *,
+    client: Any,
+    request_bodies: Sequence[dict[str, Any]],
+    cfg: BatchConfig,
+    endpoint: str,
+    fallback_output: str | None,
+) -> list[str]:
+  """Submit one batch job and return outputs in request order."""
+  jsonl = io.BytesIO()
+  # The OpenAI SDK uses the file object's name for multipart uploads.
+  jsonl.name = "langextract_openai_batch.jsonl"  # type: ignore[attr-defined]
+
+  for idx, body in enumerate(request_bodies):
+    line = {
+        "custom_id": f"{_CUSTOM_ID_PREFIX}{idx}",
+        "method": "POST",
+        "url": endpoint,
+        "body": body,
+    }
+    jsonl.write(
+        (json.dumps(line, ensure_ascii=False, separators=(",", ":")) + "\n")
+        .encode("utf-8")
+    )
+
+  jsonl.seek(0)
+
+  try:
+    file_obj = client.files.create(file=jsonl, purpose="batch")
+    batch = client.batches.create(
+        input_file_id=file_obj.id,
+        endpoint=endpoint,
+        completion_window=_COMPLETION_WINDOW,
+        metadata=cfg.metadata,
+    )
+  except Exception as e:
+    raise exceptions.InferenceRuntimeError(
+        f"OpenAI Batch API submission error: {e}", original=e
+    ) from e
+
+  batch_id = batch.id
+
+  completed = _poll_batch(client=client, batch_id=batch_id, cfg=cfg)
+
+  output_file_id = getattr(completed, "output_file_id", None)
+  error_file_id = getattr(completed, "error_file_id", None)
+
+  outputs_by_idx: dict[int, str] = {}
+  errors_by_idx: dict[int, str] = {}
+
+  if output_file_id:
+    _parse_batch_file(
+        client=client,
+        file_id=output_file_id,
+        outputs_by_idx=outputs_by_idx,
+        errors_by_idx=errors_by_idx,
+    )
+
+  if error_file_id:
+    _parse_batch_file(
+        client=client,
+        file_id=error_file_id,
+        outputs_by_idx=outputs_by_idx,
+        errors_by_idx=errors_by_idx,
+    )
+
+  # Rebuild ordered outputs (and surface errors if configured).
+  ordered: list[str] = []
+  for idx in range(len(request_bodies)):
+    if idx in outputs_by_idx:
+      ordered.append(outputs_by_idx[idx])
+      continue
+    err = errors_by_idx.get(idx)
+    if err is None:
+      err = f"Missing batch output for custom_id={_CUSTOM_ID_PREFIX}{idx}"
+    if cfg.ignore_item_errors:
+      ordered.append(fallback_output or "")
+    else:
+      raise exceptions.InferenceRuntimeError(
+          f"OpenAI Batch item failed: custom_id={_CUSTOM_ID_PREFIX}{idx}: {err}"
+      )
+  return ordered
+
+
+def _poll_batch(*, client: Any, batch_id: str, cfg: BatchConfig) -> Any:
+  """Poll batch until terminal state or timeout."""
+  deadline = time.time() + cfg.timeout
+  last_status = None
+  while True:
+    try:
+      batch = client.batches.retrieve(batch_id)
+    except Exception as e:
+      raise exceptions.InferenceRuntimeError(
+          f"OpenAI Batch API retrieve error: {e}", original=e
+      ) from e
+
+    status = getattr(batch, "status", None)
+    if status != last_status:
+      logging.info("OpenAI batch %s status=%s", batch_id, status)
+      last_status = status
+
+    if status in _TERMINAL_ALL:
+      if status in _TERMINAL_FAIL:
+        raise exceptions.InferenceRuntimeError(
+            f"OpenAI batch failed: batch_id={batch_id}"
+        )
+      return batch
+
+    if time.time() > deadline:
+      try:
+        client.batches.cancel(batch_id)
+      except Exception as e:
+        logging.warning("Failed to cancel timed-out OpenAI batch %s: %s", batch_id, e)
+      raise exceptions.InferenceRuntimeError(
+          f"OpenAI batch timed out after {cfg.timeout}s: batch_id={batch_id}"
+      )
+
+    time.sleep(cfg.poll_interval)
+
+
+def _download_file_text(*, client: Any, file_id: str) -> str:
+  """Download a file as UTF-8 text from OpenAI."""
+  resp = client.files.content(file_id)
+  if hasattr(resp, "read"):
+    raw = resp.read()
+    if isinstance(raw, bytes):
+      return raw.decode("utf-8", errors="replace")
+    return str(raw)
+  # Fallback for alternate response shapes
+  return str(resp)
+
+
+def _parse_custom_id(custom_id: str) -> int:
+  if not isinstance(custom_id, str) or not custom_id.startswith(_CUSTOM_ID_PREFIX):
+    raise ValueError(f"Invalid custom_id: {custom_id!r}")
+  return int(custom_id[len(_CUSTOM_ID_PREFIX) :])
+
+
+def _parse_batch_file(
+    *,
+    client: Any,
+    file_id: str,
+    outputs_by_idx: dict[int, str],
+    errors_by_idx: dict[int, str],
+) -> None:
+  """Parse a batch output/error file and update output/error mappings."""
+  content = _download_file_text(client=client, file_id=file_id)
+  for raw in content.splitlines():
+    line = raw.strip()
+    if not line:
+      continue
+    try:
+      item = json.loads(line)
+      idx = _parse_custom_id(item.get("custom_id", ""))
+      if idx in outputs_by_idx or idx in errors_by_idx:
+        raise ValueError(f"Duplicate custom_id: {item.get('custom_id')}")
+
+      err = item.get("error")
+      if err:
+        errors_by_idx[idx] = err.get("message", str(err))
+        continue
+
+      resp = item.get("response")
+      if not resp:
+        errors_by_idx[idx] = "Missing response"
+        continue
+
+      status_code = resp.get("status_code")
+      if status_code != 200:
+        errors_by_idx[idx] = f"HTTP {status_code}"
+        continue
+
+      body = resp.get("body") or {}
+      # Chat Completions shape: body.choices[0].message.content
+      choices = body.get("choices") or []
+      if not choices:
+        errors_by_idx[idx] = "Missing choices in response body"
+        continue
+      message = (choices[0] or {}).get("message") or {}
+      content_text = message.get("content")
+      if not isinstance(content_text, str):
+        errors_by_idx[idx] = "Missing message.content in response body"
+        continue
+
+      outputs_by_idx[idx] = content_text
+
+    except Exception as e:
+      raise exceptions.InferenceRuntimeError(
+          f"Failed to parse OpenAI batch file line: {e}", original=e
+      ) from e
+

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -673,6 +673,35 @@ class TestOpenAILanguageModel(absltest.TestCase):
     )
 
   @mock.patch("openai.OpenAI")
+  @mock.patch("langextract.providers.openai.openai_batch.infer_batch")
+  def test_openai_uses_batch_api_when_enabled(
+      self, mock_infer_batch, mock_openai_class
+  ):
+    """When configured, OpenAI provider should route to Batch API."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_infer_batch.return_value = ['{"extractions": []}', '{"extractions": []}']
+
+    model = openai.OpenAILanguageModel(
+        api_key="test-key",
+        batch={"enabled": True, "threshold": 2},
+    )
+
+    results = list(model.infer(["p1", "p2"]))
+
+    self.assertEqual(
+        results,
+        [
+            [types.ScoredOutput(score=1.0, output='{"extractions": []}')],
+            [types.ScoredOutput(score=1.0, output='{"extractions": []}')],
+        ],
+    )
+
+    mock_infer_batch.assert_called_once()
+    mock_client.chat.completions.create.assert_not_called()
+
+  @mock.patch("openai.OpenAI")
   def test_openai_temperature_zero(self, mock_openai_class):
     """Verify temperature=0.0 is properly passed to the API."""
     mock_client = mock.Mock()

--- a/tests/openai_batch_test.py
+++ b/tests/openai_batch_test.py
@@ -1,0 +1,182 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for OpenAI Batch API support."""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+from absl.testing import absltest
+
+from langextract.core import exceptions
+from langextract.providers import openai_batch
+
+
+def _batch_line(*, custom_id: str, content: str | None, error: dict | None):
+  response = None
+  if content is not None:
+    response = {
+        "status_code": 200,
+        "request_id": "req_x",
+        "body": {
+            "choices": [{"message": {"role": "assistant", "content": content}}]
+        },
+    }
+  return {
+      "id": "batch_req_x",
+      "custom_id": custom_id,
+      "response": response,
+      "error": error,
+  }
+
+
+class OpenAIBatchTest(absltest.TestCase):
+
+  def test_infer_batch_preserves_order_with_out_of_order_output(self):
+    client = mock.Mock()
+    client.files.create.return_value = mock.Mock(id="file_1")
+    client.batches.create.return_value = mock.Mock(id="batch_1")
+    client.batches.retrieve.return_value = mock.Mock(
+        id="batch_1",
+        status="completed",
+        output_file_id="out_1",
+        error_file_id=None,
+    )
+
+    # Output lines are out of order: idx-1 arrives before idx-0
+    output_lines = "\n".join(
+        [
+            json.dumps(
+                _batch_line(custom_id="idx-1", content="out1", error=None)
+            ),
+            json.dumps(
+                _batch_line(custom_id="idx-0", content="out0", error=None)
+            ),
+            "",
+        ]
+    ).encode("utf-8")
+
+    client.files.content.return_value = mock.Mock(
+        read=mock.Mock(return_value=output_lines)
+    )
+
+    cfg = openai_batch.BatchConfig(enabled=True, threshold=2)
+    outputs = openai_batch.infer_batch(
+        client=client,
+        request_bodies=[{"model": "gpt"}, {"model": "gpt"}],
+        cfg=cfg,
+    )
+
+    self.assertEqual(outputs, ["out0", "out1"])
+    client.files.create.assert_called_once()
+    client.batches.create.assert_called_once()
+
+  def test_infer_batch_raises_on_item_error_by_default(self):
+    client = mock.Mock()
+    client.files.create.return_value = mock.Mock(id="file_1")
+    client.batches.create.return_value = mock.Mock(id="batch_1")
+    client.batches.retrieve.return_value = mock.Mock(
+        id="batch_1",
+        status="completed",
+        output_file_id="out_1",
+        error_file_id="err_1",
+    )
+
+    # Success for idx-0
+    output_lines = (
+        json.dumps(_batch_line(custom_id="idx-0", content="ok", error=None))
+        + "\n"
+    ).encode("utf-8")
+
+    # Error for idx-1
+    error_lines = (
+        json.dumps(
+            _batch_line(
+                custom_id="idx-1",
+                content=None,
+                error={"code": "bad_request", "message": "nope"},
+            )
+        )
+        + "\n"
+    ).encode("utf-8")
+
+    def _content(file_id: str):
+      if file_id == "out_1":
+        return mock.Mock(read=mock.Mock(return_value=output_lines))
+      return mock.Mock(read=mock.Mock(return_value=error_lines))
+
+    client.files.content.side_effect = _content
+
+    cfg = openai_batch.BatchConfig(enabled=True, threshold=2)
+    with self.assertRaises(exceptions.InferenceRuntimeError) as cm:
+      _ = openai_batch.infer_batch(
+          client=client,
+          request_bodies=[{"model": "gpt"}, {"model": "gpt"}],
+          cfg=cfg,
+      )
+
+    self.assertIn("custom_id=idx-1", str(cm.exception))
+    self.assertIn("nope", str(cm.exception))
+
+  def test_infer_batch_fills_fallback_on_item_error_when_configured(self):
+    client = mock.Mock()
+    client.files.create.return_value = mock.Mock(id="file_1")
+    client.batches.create.return_value = mock.Mock(id="batch_1")
+    client.batches.retrieve.return_value = mock.Mock(
+        id="batch_1",
+        status="completed",
+        output_file_id="out_1",
+        error_file_id="err_1",
+    )
+
+    output_lines = (
+        json.dumps(_batch_line(custom_id="idx-0", content="ok", error=None))
+        + "\n"
+    ).encode("utf-8")
+    error_lines = (
+        json.dumps(
+            _batch_line(
+                custom_id="idx-1",
+                content=None,
+                error={"code": "bad_request", "message": "nope"},
+            )
+        )
+        + "\n"
+    ).encode("utf-8")
+
+    def _content(file_id: str):
+      if file_id == "out_1":
+        return mock.Mock(read=mock.Mock(return_value=output_lines))
+      return mock.Mock(read=mock.Mock(return_value=error_lines))
+
+    client.files.content.side_effect = _content
+
+    cfg = openai_batch.BatchConfig(
+        enabled=True, threshold=2, ignore_item_errors=True
+    )
+    outputs = openai_batch.infer_batch(
+        client=client,
+        request_bodies=[{"model": "gpt"}, {"model": "gpt"}],
+        cfg=cfg,
+        fallback_output='{"extractions": []}',
+    )
+
+    self.assertEqual(outputs, ["ok", '{"extractions": []}'])
+
+
+if __name__ == "__main__":
+  absltest.main()
+


### PR DESCRIPTION
## Summary
- Add optional OpenAI Batch API routing for `/v1/chat/completions` via `language_model_params={"batch": {...}}`.
- Submit prompts as JSONL with stable `custom_id`s and reassemble outputs in original order.
- Support polling/timeout plus an opt-in `ignore_item_errors` mode that fills failures with an empty extraction payload.

## Test plan
- [x] `python3 -m pytest -q`

Fixes #309

Made with [Cursor](https://cursor.com)