### PR TITLE
feat: allow user-provided schema constraints

### DIFF
--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -58,6 +58,7 @@ def extract(
     model: typing.Any = None,
     *,
     fetch_urls: bool = True,
+    output_schema: typing.Any | None = None,
     prompt_validation_level: pv.PromptValidationLevel = pv.PromptValidationLevel.WARNING,
     prompt_validation_strict: bool = False,
     show_progress: bool = True,
@@ -154,6 +155,11 @@ def extract(
         URL string. When True (default), strings starting with http:// or
         https:// are fetched. When False, all strings are treated as literal
         text to analyze. This is a keyword-only parameter.
+      output_schema: Optional JSON schema to apply for structured output. When
+        provided, this overrides schema generation from examples for providers
+        that support strict schema constraints (e.g. Gemini). `output_schema`
+        may be a JSON-schema dict or a Pydantic model/class with a
+        `model_json_schema()` method.
       prompt_validation_level: Controls pre-flight alignment checks on few-shot
         examples. OFF skips validation, WARNING logs issues but continues, ERROR
         raises on failures. Defaults to WARNING.
@@ -172,6 +178,28 @@ def extract(
       requests.RequestException: If URL download fails.
       pv.PromptAlignmentError: If validation fails in ERROR mode.
   """
+  schema_dict: dict[str, typing.Any] | None = None
+  if output_schema is not None:
+    if isinstance(output_schema, dict):
+      schema_dict = output_schema
+    else:
+      schema_fn = getattr(output_schema, "model_json_schema", None)
+      if callable(schema_fn):
+        schema_dict = schema_fn()
+      else:
+        raise TypeError(
+            "'output_schema' must be a dict or a Pydantic model/class with"
+            " model_json_schema()."
+        )
+
+    if use_schema_constraints is False:
+      warnings.warn(
+          "'output_schema' provided; enabling use_schema_constraints.",
+          UserWarning,
+          stacklevel=2,
+      )
+      use_schema_constraints = True
+
   if not examples:
     raise ValueError(
         "Examples are required for reliable extraction. Please provide at least"
@@ -226,6 +254,13 @@ def extract(
     language_model = model
     if fence_output is not None:
       language_model.set_fence_output(fence_output)
+    if output_schema is not None:
+      warnings.warn(
+          "'output_schema' is ignored when 'model' is provided. Apply schema"
+          " constraints directly to the model instead.",
+          UserWarning,
+          stacklevel=2,
+      )
     if use_schema_constraints:
       warnings.warn(
           "'use_schema_constraints' is ignored when 'model' is provided. "
@@ -247,6 +282,7 @@ def extract(
         examples=prompt_template.examples if use_schema_constraints else None,
         use_schema_constraints=use_schema_constraints,
         fence_output=fence_output,
+        schema_dict=schema_dict,
     )
   else:
     if language_model_type is not None:
@@ -289,6 +325,7 @@ def extract(
         examples=prompt_template.examples if use_schema_constraints else None,
         use_schema_constraints=use_schema_constraints,
         fence_output=fence_output,
+        schema_dict=schema_dict,
     )
 
   format_handler, remaining_params = fh.FormatHandler.from_resolver_params(

--- a/langextract/factory.py
+++ b/langextract/factory.py
@@ -106,6 +106,7 @@ def create_model(
     use_schema_constraints: bool = False,
     fence_output: bool | None = None,
     return_fence_output: bool = False,
+    schema_dict: dict[str, typing.Any] | None = None,
 ) -> base_model.BaseLanguageModel | tuple[base_model.BaseLanguageModel, bool]:
   """Create a language model instance from configuration.
 
@@ -115,6 +116,9 @@ def create_model(
     use_schema_constraints: Whether to apply schema constraints from examples.
     fence_output: Explicit fence output preference. If None, computed from schema.
     return_fence_output: If True, also return computed fence_output value.
+    schema_dict: Optional user-provided JSON schema to use for structured output.
+      When provided, this overrides schema generation from examples for providers
+      that support strict schema constraints.
 
   Returns:
     An instantiated language model provider.
@@ -125,12 +129,13 @@ def create_model(
     ValueError: If no provider is registered for the model_id.
     InferenceConfigError: If provider instantiation fails.
   """
-  if use_schema_constraints or fence_output is not None:
+  if use_schema_constraints or fence_output is not None or schema_dict is not None:
     model = _create_model_with_schema(
         config=config,
         examples=examples,
         use_schema_constraints=use_schema_constraints,
         fence_output=fence_output,
+        schema_dict=schema_dict,
     )
     if return_fence_output:
       return model, model.requires_fence_output
@@ -202,6 +207,7 @@ def _create_model_with_schema(
     examples: typing.Sequence[typing.Any] | None = None,
     use_schema_constraints: bool = True,
     fence_output: bool | None = None,
+    schema_dict: dict[str, typing.Any] | None = None,
 ) -> base_model.BaseLanguageModel:
   """Internal helper to create a model with optional schema constraints.
 
@@ -215,6 +221,8 @@ def _create_model_with_schema(
     use_schema_constraints: Whether to generate and apply schema constraints.
     fence_output: Whether to wrap output in markdown fences. If None,
       will be computed based on schema's requires_raw_output.
+    schema_dict: Optional user-provided JSON schema to use for structured output.
+      When provided, this overrides schema generation from examples.
 
   Returns:
     A model instance with fence_output configured appropriately.
@@ -228,8 +236,19 @@ def _create_model_with_schema(
     provider_class = router.resolve(config.model_id)
 
   schema_instance = None
-  if use_schema_constraints and examples:
-    schema_class = provider_class.get_schema_class()
+  schema_class = provider_class.get_schema_class()
+  if schema_dict is not None:
+    if schema_class is None:
+      raise exceptions.InferenceConfigError(
+          f"Provider {provider_class.__name__} does not support schema constraints."
+      )
+    from_schema = getattr(schema_class, "from_schema_dict", None)
+    if not callable(from_schema):
+      raise exceptions.InferenceConfigError(
+          f"Provider {provider_class.__name__} does not support user-provided schemas."
+      )
+    schema_instance = from_schema(schema_dict)  # type: ignore[misc]
+  elif use_schema_constraints and examples:
     if schema_class is not None:
       schema_instance = schema_class.from_examples(examples)
 

--- a/langextract/providers/__init__.py
+++ b/langextract/providers/__init__.py
@@ -56,7 +56,9 @@ def load_builtins_once() -> None:
   """
   global _builtins_loaded  # pylint: disable=global-statement
 
-  if _builtins_loaded:
+  # If the router registry was cleared (common in tests), allow built-ins to be
+  # re-registered even if we've previously loaded them.
+  if _builtins_loaded and router.list_entries():
     return
 
   # Register built-ins lazily so they can be re-registered after a registry.clear()

--- a/langextract/providers/schemas/gemini.py
+++ b/langextract/providers/schemas/gemini.py
@@ -23,6 +23,7 @@ from typing import Any
 import warnings
 
 from langextract.core import data
+from langextract.core import exceptions
 from langextract.core import format_handler as fh
 from langextract.core import schema
 
@@ -93,6 +94,24 @@ class GeminiSchema(schema.BaseSchema):
           UserWarning,
           stacklevel=3,
       )
+
+  @classmethod
+  def from_schema_dict(cls, schema_dict: dict[str, Any]) -> GeminiSchema:
+    """Create a GeminiSchema from a user-provided JSON schema dict.
+
+    The schema must describe an object with an `extractions` array key, matching
+    LangExtract's resolver expectations.
+    """
+    if not isinstance(schema_dict, dict):
+      raise exceptions.InferenceConfigError("schema_dict must be a dict")
+
+    props = schema_dict.get("properties")
+    if not isinstance(props, dict) or data.EXTRACTIONS_KEY not in props:
+      raise exceptions.InferenceConfigError(
+          f"schema_dict must contain '{data.EXTRACTIONS_KEY}' in properties"
+      )
+
+    return cls(_schema_dict=schema_dict)
 
   @classmethod
   def from_examples(

--- a/tests/provider_schema_test.py
+++ b/tests/provider_schema_test.py
@@ -541,6 +541,87 @@ class GeminiSchemaProviderIntegrationTest(absltest.TestCase):
       )
 
 
+class UserSchemaOverrideTest(absltest.TestCase):
+  """Tests for user-provided schema dictionaries."""
+
+  @mock.patch("google.genai.Client", autospec=True)
+  def test_factory_uses_user_schema_dict_for_gemini(self, mock_client_class):
+    mock_client = mock.Mock()
+    mock_client_class.return_value = mock_client
+
+    examples_data = [
+        data.ExampleData(
+            text="Patient has diabetes",
+            extractions=[
+                data.Extraction(
+                    extraction_class="condition",
+                    extraction_text="diabetes",
+                    attributes={"severity": "mild"},
+                )
+            ],
+        )
+    ]
+
+    user_schema = {
+        "type": "object",
+        "properties": {
+            "extractions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "condition": {"type": "string"},
+                        "condition_attributes": {
+                            "type": "object",
+                            "properties": {
+                                "severity": {
+                                    "type": "string",
+                                    "enum": ["mild", "moderate", "severe"],
+                                }
+                            },
+                        },
+                    },
+                },
+            }
+        },
+        "required": ["extractions"],
+    }
+
+    config = factory.ModelConfig(
+        model_id="gemini-2.5-flash",
+        provider_kwargs={"api_key": "test_key"},
+    )
+    model = factory.create_model(
+        config=config,
+        examples=examples_data,
+        use_schema_constraints=True,
+        fence_output=None,
+        schema_dict=user_schema,
+    )
+
+    self.assertIsInstance(model, gemini.GeminiLanguageModel)
+    self.assertIsNotNone(model.gemini_schema)
+    self.assertEqual(model.gemini_schema.schema_dict, user_schema)
+
+  @mock.patch("google.genai.Client", autospec=True)
+  def test_factory_rejects_invalid_user_schema_dict(self, mock_client_class):
+    mock_client = mock.Mock()
+    mock_client_class.return_value = mock_client
+
+    config = factory.ModelConfig(
+        model_id="gemini-2.5-flash",
+        provider_kwargs={"api_key": "test_key"},
+    )
+    with self.assertRaises(exceptions.InferenceConfigError):
+      _ = factory.create_model(
+          config=config,
+          examples=[],
+          use_schema_constraints=True,
+          fence_output=None,
+          schema_dict={"type": "object", "properties": {}},
+      )
+
+
 class SchemaShimTest(absltest.TestCase):
   """Tests for backward compatibility shims in schema module."""
 


### PR DESCRIPTION
## Summary
- Add `output_schema` to `extract()` to override schema generation from examples with a user-supplied JSON schema (or Pydantic model/class).
- Plumb the schema override through `factory.create_model()` so supported providers can apply strict structured output constraints.
- Add Gemini support for `GeminiSchema.from_schema_dict()` plus tests for valid/invalid user schemas.

## Test plan
- [x] `python3 -m pytest -q`

Fixes #128

Made with [Cursor](https://cursor.com)