### PR TITLE
fix: stabilize Gemini batch cache hashing

### DIFF
--- a/langextract/core/__init__.py
+++ b/langextract/core/__init__.py
@@ -28,4 +28,5 @@ __all__ = [
     "schema",
     "data",
     "tokenizer",
+    "json_utils",
 ]

--- a/langextract/core/json_utils.py
+++ b/langextract/core/json_utils.py
@@ -1,0 +1,148 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JSON serialization helpers.
+
+These helpers provide a *stable*, best-effort conversion of common Python
+objects (dataclasses, enums, pydantic models, sets, etc.) into JSON-serializable
+structures.
+
+Primary use case: building deterministic cache keys (hashing request payloads)
+without crashing on non-JSON-native types.
+"""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import datetime
+import enum
+import json
+import pathlib
+import re
+from typing import Any
+
+_MEMORY_ADDRESS_RE = re.compile(r"0x[0-9a-fA-F]+")
+
+
+def dumps_canonical(obj: Any) -> str:
+  """Serialize `obj` to a canonical JSON string.
+
+  The output is deterministic across runs for supported types:
+  - Dict keys are sorted
+  - Sets are converted to sorted lists (by canonical JSON of elements)
+  - Dataclasses and enums are converted into JSON-serializable forms
+
+  Args:
+    obj: Any Python object.
+
+  Returns:
+    Canonical JSON string (UTF-8 safe, no ASCII escaping).
+  """
+  return json.dumps(
+      to_jsonable(obj),
+      sort_keys=True,
+      ensure_ascii=False,
+      separators=(",", ":"),
+      allow_nan=False,
+  )
+
+
+def to_jsonable(obj: Any) -> Any:
+  """Convert `obj` into a JSON-serializable structure."""
+  if obj is None or isinstance(obj, (bool, int, float, str)):
+    return obj
+
+  # Dataclasses
+  if dataclasses.is_dataclass(obj):
+    return to_jsonable(dataclasses.asdict(obj))
+
+  # Enums
+  if isinstance(obj, enum.Enum):
+    return {
+        "__enum__": f"{obj.__class__.__module__}.{obj.__class__.__qualname__}",
+        "name": obj.name,
+    }
+
+  # Paths
+  if isinstance(obj, pathlib.Path):
+    return str(obj)
+
+  # Bytes-like
+  if isinstance(obj, (bytes, bytearray, memoryview)):
+    return {"__bytes__": base64.b64encode(bytes(obj)).decode("ascii")}
+
+  # Datetime-like
+  if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
+    return obj.isoformat()
+
+  # Sequences
+  if isinstance(obj, (list, tuple)):
+    return [to_jsonable(v) for v in obj]
+
+  # Sets (order-independent)
+  if isinstance(obj, (set, frozenset)):
+    items = [to_jsonable(v) for v in obj]
+    items.sort(key=_canonical_sort_key)
+    return items
+
+  # Mappings
+  if isinstance(obj, dict):
+    # JSON requires string keys. For non-strings, use canonical JSON of the key.
+    out: dict[str, Any] = {}
+    for k, v in obj.items():
+      if isinstance(k, str):
+        key = k
+      else:
+        key = dumps_canonical(k)
+      out[key] = to_jsonable(v)
+    return out
+
+  # Pydantic v2 models (and similarly shaped objects).
+  model_dump = getattr(obj, "model_dump", None)
+  if callable(model_dump):
+    try:
+      return to_jsonable(model_dump(mode="json"))
+    except TypeError:
+      return to_jsonable(model_dump())
+
+  # Pydantic v1 models / other libs.
+  to_dict = getattr(obj, "to_dict", None)
+  if callable(to_dict):
+    return to_jsonable(to_dict())
+
+  dict_method = getattr(obj, "dict", None)
+  if callable(dict_method):
+    return to_jsonable(dict_method())
+
+  # Fall back to a stable-ish repr (strip memory addresses).
+  return _stable_repr(obj)
+
+
+def _canonical_sort_key(obj: Any) -> str:
+  """Key function for deterministic sorting of set elements."""
+  return json.dumps(
+      obj,
+      sort_keys=True,
+      ensure_ascii=False,
+      separators=(",", ":"),
+      default=_stable_repr,
+      allow_nan=False,
+  )
+
+
+def _stable_repr(obj: Any) -> str:
+  """Return a representation that avoids non-deterministic memory addresses."""
+  return _MEMORY_ADDRESS_RE.sub("0x...", repr(obj))
+

--- a/langextract/providers/gemini_batch.py
+++ b/langextract/providers/gemini_batch.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 from collections.abc import Iterator, Sequence
 import concurrent.futures
 import dataclasses
-import enum
 import hashlib
 import json
 import logging as std_logging
@@ -44,6 +43,7 @@ from google.api_core import exceptions as google_exceptions
 from google.cloud import storage
 
 from langextract.core import exceptions
+from langextract.core import json_utils
 
 _MIME_TYPE_JSON = "application/json"
 _DEFAULT_LOCATION = "us-central1"
@@ -386,7 +386,7 @@ class GCSBatchCache:
 
   def _compute_hash(self, key_data: dict) -> str:
     """Compute SHA256 hash of the canonicalized request data."""
-    canonical_json = json.dumps(key_data, sort_keys=True, ensure_ascii=False)
+    canonical_json = json_utils.dumps_canonical(key_data)
     return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
 
   def _get_single(self, key_hash: str) -> str | None:
@@ -443,19 +443,12 @@ class GCSBatchCache:
             "Cache write error for %s: %s", key_hash, e, exc_info=True
         )
 
-    def _json_default(obj):
-      if dataclasses.is_dataclass(obj):
-        return dataclasses.asdict(obj)
-      if isinstance(obj, enum.Enum):
-        return obj.value
-      raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
-
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
       for key_data, text in items:
         # If text is not a string, try to serialize it
         if not isinstance(text, str):
           try:
-            text = json.dumps(text, default=_json_default, ensure_ascii=False)
+            text = json_utils.dumps_canonical(text)
           except Exception as e:
             logging.warning("Serialization error: %s", e)
             continue

--- a/tests/test_gemini_batch_api.py
+++ b/tests/test_gemini_batch_api.py
@@ -14,6 +14,9 @@
 
 """Tests for Gemini Batch API functionality."""
 
+import dataclasses
+import enum
+import hashlib
 import io
 import json
 from unittest import mock
@@ -26,6 +29,7 @@ from google.api_core import exceptions
 from langextract.providers import gemini
 from langextract.providers import gemini_batch as gb
 from langextract.providers import schemas
+from langextract.core import json_utils
 
 
 def create_mock_batch_job(
@@ -678,6 +682,60 @@ class GCSBatchCachingTest(absltest.TestCase):
     data1 = {"a": 1, "b": 2}
     data2 = {"b": 2, "a": 1}
     self.assertEqual(cache._compute_hash(data1), cache._compute_hash(data2))
+
+
+class TestGCSBatchCache(absltest.TestCase):
+  """Unit tests for GCSBatchCache hashing/canonicalization."""
+
+  def setUp(self):
+    super().setUp()
+    self.enter_context(mock.patch.object(gb.storage, "Client", autospec=True))
+
+  def test_compute_hash_serializes_enums_dataclasses_and_sets(self):
+    class _Safety(enum.Enum):
+      ALLOW = "allow"
+      BLOCK = "block"
+
+    @dataclasses.dataclass(frozen=True)
+    class _Cfg:
+      threshold: int
+      mode: _Safety
+
+    class _ModelLike:
+      def __init__(self, v):
+        self._v = v
+
+      def model_dump(self, mode="python"):
+        del mode  # unused
+        return {"v": self._v}
+
+    cache = gb.GCSBatchCache(bucket_name="bucket", project="project")
+    key_data = {
+        "cfg": _Cfg(threshold=3, mode=_Safety.ALLOW),
+        "safety_settings": {_Safety.BLOCK, _Safety.ALLOW},
+        "model_like": _ModelLike(_Safety.BLOCK),
+        # Non-string dict keys should be supported (canonicalized to strings).
+        _Safety.BLOCK: {"nested": _Cfg(threshold=1, mode=_Safety.BLOCK)},
+    }
+
+    # Should not crash on non-JSON-native types.
+    key_hash = cache._compute_hash(key_data)
+    self.assertIsInstance(key_hash, str)
+    self.assertLen(key_hash, 64)  # sha256 hex
+
+    # Deterministic across key orderings.
+    key_data_reordered = {
+        _Safety.BLOCK: {"nested": _Cfg(threshold=1, mode=_Safety.BLOCK)},
+        "model_like": _ModelLike(_Safety.BLOCK),
+        "safety_settings": {_Safety.ALLOW, _Safety.BLOCK},
+        "cfg": _Cfg(threshold=3, mode=_Safety.ALLOW),
+    }
+    self.assertEqual(cache._compute_hash(key_data_reordered), key_hash)
+
+    # Matches the canonical JSON + sha256 contract.
+    canonical = json_utils.dumps_canonical(key_data)
+    expected = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    self.assertEqual(key_hash, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Make Gemini Batch API cache-key hashing robust to enums, dataclasses, sets, and model-dumpable objects.
- Introduce shared canonical JSON serialization helpers for deterministic cache keys.

## Test plan
- [x] `python3 -m pytest tests/test_gemini_batch_api.py -q`

Fixes #353

Made with [Cursor](https://cursor.com)