### PR TITLE
fix: extend long lesser-match spans for accurate char_interval

### DIFF
--- a/langextract/core/__init__.py
+++ b/langextract/core/__init__.py
@@ -28,4 +28,5 @@ __all__ = [
     "schema",
     "data",
     "tokenizer",
+    "alignment_utils",
 ]

--- a/langextract/core/alignment_utils.py
+++ b/langextract/core/alignment_utils.py
@@ -1,0 +1,117 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Alignment helpers used by `resolver.WordAligner`.
+
+These utilities are intentionally conservative: they only adjust alignment
+spans when a "lesser" match would otherwise produce an unhelpfully short
+character interval for a long extraction (common when models paraphrase or
+omit words in long, non-English extractions).
+"""
+
+from __future__ import annotations
+
+from langextract.core import tokenizer as tokenizer_lib
+
+# Heuristics for when a MATCH_LESSER span is too small to be useful.
+_MIN_EXTRACTION_TOKENS_FOR_EXTENSION = 12
+_MIN_UNMATCHED_TOKENS_FOR_EXTENSION = 10
+_SENTENCE_TERMINATORS = frozenset({".", "?", "!", "。", "？", "！", "\u0964"})
+
+
+def maybe_extend_lesser_match_end(
+    *,
+    tokenized_text: tokenizer_lib.TokenizedText,
+    start_index: int,
+    matched_tokens: int,
+    extraction_tokens: int,
+) -> int | None:
+  """Return an extended end_index (exclusive) for a lesser match.
+
+  Only extends when:
+  - the extraction is long, and
+  - the exact prefix match accounts for only a small portion of it.
+
+  The extension prefers a sentence boundary when available. If no boundary is
+  found, it caps the span using the extraction length to avoid returning an
+  entire chunk.
+
+  Args:
+    tokenized_text: Tokenized source text (indices must match original text).
+    start_index: Start token index (inclusive) of the match in source tokens.
+    matched_tokens: Number of source tokens that matched exactly.
+    extraction_tokens: Total number of tokens in the extraction text.
+
+  Returns:
+    The extended end token index (exclusive), or None if no extension should
+    be applied.
+  """
+  if extraction_tokens < _MIN_EXTRACTION_TOKENS_FOR_EXTENSION:
+    return None
+  if extraction_tokens - matched_tokens < _MIN_UNMATCHED_TOKENS_FOR_EXTENSION:
+    return None
+
+  tokens = tokenized_text.tokens
+  if not tokens:
+    return None
+  if start_index < 0 or start_index >= len(tokens):
+    return None
+
+  # Find a conservative "sentence" end for the span.
+  try:
+    sentence = tokenizer_lib.find_sentence_range(
+        tokenized_text.text, tokens, start_index
+    )
+  except tokenizer_lib.SentenceRangeError:
+    return None
+
+  end_index = sentence.end_index
+  if end_index == len(tokens):
+    # Only cap to extraction length if there is no terminator at all in the
+    # remainder of the text (i.e., we truly hit end-of-chunk without finding
+    # a sentence boundary).
+    if not _contains_sentence_terminator(tokenized_text, start_index):
+      end_index = min(end_index, start_index + extraction_tokens)
+
+  min_end = start_index + matched_tokens
+  if end_index <= min_end:
+    return None
+  return end_index
+
+
+def _contains_sentence_terminator(
+    tokenized_text: tokenizer_lib.TokenizedText, start_index: int
+) -> bool:
+  """Return True if any sentence terminator appears at/after start_index."""
+  text = tokenized_text.text
+  tokens = tokenized_text.tokens
+  for idx in range(max(0, start_index), len(tokens)):
+    tok = tokens[idx]
+    if tok.token_type != tokenizer_lib.TokenType.PUNCTUATION:
+      continue
+    token_text = text[tok.char_interval.start_pos : tok.char_interval.end_pos]
+    if token_text not in _SENTENCE_TERMINATORS:
+      continue
+    # Ignore decimal points like "21.56".
+    if (
+        token_text == "."
+        and idx > 0
+        and idx + 1 < len(tokens)
+        and tokens[idx - 1].token_type == tokenizer_lib.TokenType.NUMBER
+        and tokens[idx + 1].token_type == tokenizer_lib.TokenType.NUMBER
+    ):
+      continue
+    return True
+  return False
+

--- a/langextract/core/tokenizer.py
+++ b/langextract/core/tokenizer.py
@@ -534,6 +534,16 @@ def _is_end_of_sentence_token(
       .char_interval.end_pos
   ]
   if _END_OF_SENTENCE_PATTERN.search(current_token_text):
+    # Decimal points (e.g., "21.56") should not terminate a sentence.
+    if (
+        current_token_text == "."
+        and current_idx > 0
+        and current_idx + 1 < len(tokens)
+        and tokens[current_idx - 1].token_type == TokenType.NUMBER
+        and tokens[current_idx + 1].token_type == TokenType.NUMBER
+    ):
+      return False
+
     if current_idx > 0:
       prev_token_text = text[
           tokens[current_idx - 1]

--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -31,6 +31,7 @@ from typing import Final
 
 from absl import logging
 
+from langextract.core import alignment_utils
 from langextract.core import data
 from langextract.core import exceptions
 from langextract.core import format_handler as fh
@@ -786,25 +787,6 @@ class WordAligner:
         )
         continue
 
-      extraction.token_interval = tokenizer_lib.TokenInterval(
-          start_index=i + token_offset,
-          end_index=i + n + token_offset,
-      )
-
-      try:
-        start_token = tokenized_text.tokens[i]
-        end_token = tokenized_text.tokens[i + n - 1]
-        extraction.char_interval = data.CharInterval(
-            start_pos=char_offset + start_token.char_interval.start_pos,
-            end_pos=char_offset + end_token.char_interval.end_pos,
-        )
-      except IndexError as e:
-        raise IndexError(
-            "Failed to align extraction with source text. Extraction token"
-            f" interval {extraction.token_interval} does not match source text"
-            f" tokens {tokenized_text.tokens}."
-        ) from e
-
       extraction_text_len = len(
           list(
               _tokenize_with_lowercase(
@@ -817,6 +799,37 @@ class WordAligner:
             "Delimiter prevents blocks greater than extraction length: "
             f"extraction_text_len={extraction_text_len}, block_size={n}"
         )
+
+      end_idx = i + n
+      if extraction_text_len > n and accept_match_lesser:
+        extended_end = alignment_utils.maybe_extend_lesser_match_end(
+            tokenized_text=tokenized_text,
+            start_index=i,
+            matched_tokens=n,
+            extraction_tokens=extraction_text_len,
+        )
+        if extended_end is not None:
+          end_idx = extended_end
+
+      extraction.token_interval = tokenizer_lib.TokenInterval(
+          start_index=i + token_offset,
+          end_index=end_idx + token_offset,
+      )
+
+      try:
+        start_token = tokenized_text.tokens[i]
+        end_token = tokenized_text.tokens[end_idx - 1]
+        extraction.char_interval = data.CharInterval(
+            start_pos=char_offset + start_token.char_interval.start_pos,
+            end_pos=char_offset + end_token.char_interval.end_pos,
+        )
+      except IndexError as e:
+        raise IndexError(
+            "Failed to align extraction with source text. Extraction token"
+            f" interval {extraction.token_interval} does not match source text"
+            f" tokens {tokenized_text.tokens}."
+        ) from e
+
       if extraction_text_len == n:
         extraction.alignment_status = data.AlignmentStatus.MATCH_EXACT
         exact_matches += 1

--- a/tests/resolver_test.py
+++ b/tests/resolver_test.py
@@ -583,6 +583,53 @@ class AlignEntitiesTest(parameterized.TestCase):
     self.aligner = resolver_lib.WordAligner()
     self.maxDiff = 10000
 
+  def test_match_lesser_long_extraction_extends_char_interval(self):
+    """MATCH_LESSER spans for long extractions should be informative.
+
+    For long, paraphrased extractions (common in Chinese), difflib may only
+    exactly match a small prefix. We extend the span to a conservative sentence
+    boundary so `char_interval` is not reduced to just the matched prefix.
+    """
+    source_text = (
+        "营养成分：每份汉堡约200克，含548大卡热量，其中蛋白质21.56克、"
+        "脂肪18.12克、碳水化合物75.7克，能提供充足能量，但作为快餐食品，"
+        "营养均衡方面有所欠缺。"
+    )
+    extraction = data.Extraction(
+        extraction_class="营养成分",
+        extraction_text=(
+            "每份约200克，含548大卡热量，蛋白质21.56克，脂肪18.12克，"
+            "碳水化合物75.7克，能提供充足能量，但营养均衡有所欠缺"
+        ),
+    )
+
+    aligned = self.aligner.align_extractions(
+        [[extraction]],
+        source_text,
+        enable_fuzzy_alignment=False,
+        accept_match_lesser=True,
+        tokenizer_impl=tokenizer.UnicodeTokenizer(),
+    )
+
+    self.assertLen(aligned, 1)
+    self.assertLen(aligned[0], 1)
+    aligned_extraction = aligned[0][0]
+    self.assertEqual(
+        aligned_extraction.alignment_status, data.AlignmentStatus.MATCH_LESSER
+    )
+    self.assertIsNotNone(aligned_extraction.char_interval)
+
+    expected_start = source_text.index("每份汉堡")
+    expected_end = source_text.rindex("。") + 1
+    self.assertEqual(aligned_extraction.char_interval.start_pos, expected_start)
+    self.assertEqual(aligned_extraction.char_interval.end_pos, expected_end)
+    self.assertIn(
+        "有所欠缺",
+        source_text[
+            aligned_extraction.char_interval.start_pos : aligned_extraction.char_interval.end_pos
+        ],
+    )
+
   @parameterized.named_parameters(
       (
           "basic_alignment",

--- a/tests/tokenizer_test.py
+++ b/tests/tokenizer_test.py
@@ -966,6 +966,13 @@ class SentenceRangeTest(parameterized.TestCase):
     interval = tokenizer.find_sentence_range(text_cr, tokens, 0)
     self.assertEqual(interval.end_index, 3)
 
+  def test_decimal_points_do_not_terminate_sentences(self):
+    text = "Value is 21.56. Next."
+    tokenized = tokenizer.tokenize(text)
+    interval = tokenizer.find_sentence_range(text, tokenized.tokens, 0)
+    self.assertEqual(interval.end_index, 6)
+    self.assertEqual(tokenizer.tokens_text(tokenized, interval), "Value is 21.56.")
+
   def test_unicode_sentence_boundaries(self):
     """Verify that Unicode sentence terminators are respected."""
     # Japanese full stop


### PR DESCRIPTION
## Summary
- Improve `char_interval` for long `MATCH_LESSER` extractions by extending the aligned span to a conservative sentence boundary.
- Avoid treating decimal points (e.g. `21.56`) as sentence terminators during sentence range detection.

## Test plan
- [x] `python3 -m pytest tests/tokenizer_test.py tests/resolver_test.py -q`

Fixes #289

Made with [Cursor](https://cursor.com)