### PR TITLE
Fix: make IssueKind public and add to __all__ (closes #389)

### DIFF
--- a/langextract/prompt_validation.py
+++ b/langextract/prompt_validation.py
@@ -28,6 +28,7 @@ from langextract.core import data
 from langextract.core import tokenizer as tokenizer_lib
 
 __all__ = [
+    "IssueKind",
     "PromptValidationLevel",
     "ValidationIssue",
     "ValidationReport",
@@ -49,8 +50,19 @@ class PromptValidationLevel(enum.Enum):
   ERROR = "error"
 
 
-class _IssueKind(enum.Enum):
-  """Internal categorization of alignment issues."""
+class IssueKind(enum.Enum):
+  """Categorization of alignment issues found during prompt validation.
+
+  Use this to filter or inspect individual :class:`ValidationIssue` objects
+  returned in a :class:`ValidationReport`.
+
+  Example::
+
+      from langextract.prompt_validation import IssueKind, validate_prompt_alignment
+
+      report = validate_prompt_alignment(examples)
+      failed = [i for i in report.issues if i.issue_kind == IssueKind.FAILED]
+  """
 
   FAILED = "failed"  # alignment_status is None
   NON_EXACT = "non_exact"  # MATCH_FUZZY or MATCH_LESSER
@@ -65,7 +77,7 @@ class ValidationIssue:
   extraction_class: str
   extraction_text_preview: str
   alignment_status: data.AlignmentStatus | None
-  issue_kind: _IssueKind
+  issue_kind: IssueKind
   char_interval: tuple[int, int] | None = None
   token_interval: tuple[int, int] | None = None
 
@@ -92,12 +104,12 @@ class ValidationReport:
   @property
   def has_failed(self) -> bool:
     """Returns True if any extraction failed to align."""
-    return any(i.issue_kind is _IssueKind.FAILED for i in self.issues)
+    return any(i.issue_kind is IssueKind.FAILED for i in self.issues)
 
   @property
   def has_non_exact(self) -> bool:
     """Returns True if any extraction has non-exact alignment."""
-    return any(i.issue_kind is _IssueKind.NON_EXACT for i in self.issues)
+    return any(i.issue_kind is IssueKind.NON_EXACT for i in self.issues)
 
 
 class PromptAlignmentError(RuntimeError):
@@ -174,7 +186,7 @@ def validate_prompt_alignment(
                 extraction_class=klass,
                 extraction_text_preview=_preview(text),
                 alignment_status=None,
-                issue_kind=_IssueKind.FAILED,
+                issue_kind=IssueKind.FAILED,
                 char_interval=None,
                 token_interval=None,
             )
@@ -200,7 +212,7 @@ def validate_prompt_alignment(
                 extraction_class=klass,
                 extraction_text_preview=_preview(text),
                 alignment_status=status,
-                issue_kind=_IssueKind.NON_EXACT,
+                issue_kind=IssueKind.NON_EXACT,
                 char_interval=char_interval_tuple,
                 token_interval=token_interval_tuple,
             )
@@ -229,7 +241,7 @@ def handle_alignment_report(
     return
 
   for issue in report.issues:
-    if issue.issue_kind is _IssueKind.NON_EXACT:
+    if issue.issue_kind is IssueKind.NON_EXACT:
       logging.warning(
           "Prompt alignment: non-exact match: %s", issue.short_msg()
       )
@@ -239,9 +251,9 @@ def handle_alignment_report(
       )
 
   if level is PromptValidationLevel.ERROR:
-    failed = [i for i in report.issues if i.issue_kind is _IssueKind.FAILED]
+    failed = [i for i in report.issues if i.issue_kind is IssueKind.FAILED]
     non_exact = [
-        i for i in report.issues if i.issue_kind is _IssueKind.NON_EXACT
+        i for i in report.issues if i.issue_kind is IssueKind.NON_EXACT
     ]
 
     if failed:

--- a/tests/prompt_validation_test.py
+++ b/tests/prompt_validation_test.py
@@ -391,6 +391,56 @@ class PromptAlignmentValidationTest(parameterized.TestCase):
     self.assertEqual(report.has_non_exact, expected_has_non_exact)
 
 
+class IssueKindPublicApiTest(absltest.TestCase):
+  """Tests verifying IssueKind is exported and usable as public API."""
+
+  def test_issuekind_is_importable(self):
+    """IssueKind should be importable from the public module."""
+    from langextract.prompt_validation import IssueKind  # pylint: disable=g-import-not-at-top
+    self.assertIsNotNone(IssueKind)
+
+  def test_issuekind_in_all(self):
+    """IssueKind should be listed in __all__."""
+    from langextract import prompt_validation  # pylint: disable=g-import-not-at-top
+    self.assertIn("IssueKind", prompt_validation.__all__)
+
+  def test_filter_failed_issues_via_public_issuekind(self):
+    """Users can filter individual failed issues without accessing private API."""
+    from langextract.prompt_validation import IssueKind  # pylint: disable=g-import-not-at-top
+
+    examples = [
+        data.ExampleData(
+            text="Patient takes aspirin.",
+            extractions=[
+                data.Extraction(
+                    extraction_class="Medication",
+                    extraction_text="metformin",  # not in text → FAILED
+                    attributes={},
+                ),
+            ],
+        ),
+        data.ExampleData(
+            text="Type 2 diabetes.",
+            extractions=[
+                data.Extraction(
+                    extraction_class="Diagnosis",
+                    extraction_text="type-2 diabetes",  # fuzzy → NON_EXACT
+                    attributes={},
+                ),
+            ],
+        ),
+    ]
+
+    report = prompt_validation.validate_prompt_alignment(examples)
+
+    failed = [i for i in report.issues if i.issue_kind == IssueKind.FAILED]
+    non_exact = [i for i in report.issues if i.issue_kind == IssueKind.NON_EXACT]
+
+    self.assertLen(failed, 1)
+    self.assertLen(non_exact, 1)
+    self.assertEqual(failed[0].extraction_text_preview, "metformin")
+
+
 class ExtractIntegrationTest(absltest.TestCase):
   """Minimal integration test for extract() entry point validation."""
 


### PR DESCRIPTION
## Summary

- `ValidationIssue.issue_kind` was typed as `_IssueKind`, a **private enum** not present in `__all__`
- Users who needed to filter individual issues by kind had no choice but to import a private symbol:

  ```python
  from langextract.prompt_validation import _IssueKind  # ← private!
  failed = [i for i in report.issues if i.issue_kind == _IssueKind.FAILED]
  ```

- This PR renames `_IssueKind` → `IssueKind`, adds it to `__all__`, and updates all internal references

## Changes

- `langextract/prompt_validation.py`: rename `_IssueKind` → `IssueKind`, expand docstring, add to `__all__`
- `tests/prompt_validation_test.py`: add `IssueKindPublicApiTest` to verify public accessibility and filtering

## After this fix

```python
from langextract.prompt_validation import IssueKind

report = validate_prompt_alignment(examples)
failed = [i for i in report.issues if i.issue_kind == IssueKind.FAILED]
```

## Test plan

- [x] `IssueKind` is importable from `langextract.prompt_validation`
- [x] `IssueKind` is present in `__all__`
- [x] Individual issues can be filtered by `IssueKind` without accessing private API
- [x] All existing `prompt_validation_test.py` tests still pass

Closes #389