### PR TITLE
fix: retry transient provider overload errors

### DIFF
--- a/langextract/core/__init__.py
+++ b/langextract/core/__init__.py
@@ -28,4 +28,5 @@ __all__ = [
     "schema",
     "data",
     "tokenizer",
+    "retry_utils",
 ]

--- a/langextract/core/retry_utils.py
+++ b/langextract/core/retry_utils.py
@@ -1,0 +1,162 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Retry helpers for transient inference failures."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import dataclasses
+import random
+import time
+from typing import Any, TypeVar
+
+from langextract.core import exceptions
+
+T = TypeVar("T")
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class RetryConfig:
+  """Retry configuration for transient provider failures."""
+
+  enabled: bool = True
+  max_attempts: int = 5
+  initial_delay_s: float = 1.0
+  max_delay_s: float = 30.0
+  backoff_multiplier: float = 2.0
+  jitter_ratio: float = 0.1
+
+  retryable_status_codes: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+  retryable_message_substrings: tuple[str, ...] = (
+      "model is overloaded",
+      "overloaded",
+      "service unavailable",
+      "temporarily unavailable",
+      "rate limit",
+      "too many requests",
+      "timeout",
+      "timed out",
+      "connection reset",
+      "connection aborted",
+      "connection error",
+  )
+
+  def __post_init__(self) -> None:
+    if self.max_attempts < 1:
+      raise ValueError("retry.max_attempts must be >= 1")
+    if self.initial_delay_s < 0:
+      raise ValueError("retry.initial_delay_s must be >= 0")
+    if self.max_delay_s < 0:
+      raise ValueError("retry.max_delay_s must be >= 0")
+    if self.backoff_multiplier < 1:
+      raise ValueError("retry.backoff_multiplier must be >= 1")
+    if not (0.0 <= self.jitter_ratio <= 1.0):
+      raise ValueError("retry.jitter_ratio must be in [0, 1]")
+
+  @classmethod
+  def from_dict(cls, d: dict[str, Any] | None) -> RetryConfig:
+    if d is None:
+      return cls()
+    valid_keys = {f.name for f in dataclasses.fields(cls)}
+    filtered = {k: v for k, v in d.items() if k in valid_keys}
+    return cls(**filtered)
+
+  def delay_s(self, attempt: int) -> float:
+    """Compute delay for a 1-based attempt number."""
+    if attempt <= 1 or self.initial_delay_s <= 0:
+      return 0.0
+    base = self.initial_delay_s * (self.backoff_multiplier ** (attempt - 2))
+    base = min(base, self.max_delay_s) if self.max_delay_s > 0 else base
+    if self.jitter_ratio <= 0:
+      return base
+    jitter = random.uniform(1.0 - self.jitter_ratio, 1.0 + self.jitter_ratio)
+    return max(0.0, base * jitter)
+
+
+def call_with_retry(
+    fn: Callable[[], T],
+    *,
+    cfg: RetryConfig,
+    is_retryable: Callable[[BaseException], bool] | None = None,
+    on_retry: Callable[[int, BaseException, float], None] | None = None,
+    sleep_fn: Callable[[float], None] | None = None,
+) -> T:
+  """Call `fn`, retrying on transient failures."""
+  if sleep_fn is None:
+    sleep_fn = time.sleep
+  last_exc: BaseException | None = None
+  for attempt in range(1, cfg.max_attempts + 1):
+    try:
+      return fn()
+    except BaseException as e:  # pylint: disable=broad-exception-caught
+      last_exc = e
+      if not cfg.enabled or attempt >= cfg.max_attempts:
+        raise
+      retryable = (
+          is_retryable(e)
+          if is_retryable is not None
+          else is_retryable_error(e, cfg=cfg)
+      )
+      if not retryable:
+        raise
+      delay = cfg.delay_s(attempt + 1)
+      if on_retry is not None:
+        on_retry(attempt, e, delay)
+      if delay > 0:
+        sleep_fn(delay)
+  assert last_exc is not None
+  raise last_exc
+
+
+def is_retryable_error(exc: BaseException, *, cfg: RetryConfig) -> bool:
+  """Heuristic retryability check for common provider exceptions."""
+  unwrapped = _unwrap_inference_error(exc)
+  code = _status_code(unwrapped)
+  if code is not None and code in cfg.retryable_status_codes:
+    return True
+  msg = str(unwrapped).lower()
+  return any(substr in msg for substr in cfg.retryable_message_substrings)
+
+
+def _unwrap_inference_error(exc: BaseException) -> BaseException:
+  if isinstance(exc, exceptions.InferenceRuntimeError) and exc.original is not None:
+    return exc.original
+  return exc
+
+
+def _status_code(exc: BaseException) -> int | None:
+  """Best-effort extraction of an HTTP-like status code from an exception."""
+  # Common shapes:
+  # - requests.HTTPError: .response.status_code
+  # - openai errors: .status_code
+  # - google api_core exceptions: .code() -> int
+  for attr in ("status_code", "status", "code"):
+    val = getattr(exc, attr, None)
+    if val is None:
+      continue
+    try:
+      candidate = val() if callable(val) else val
+    except TypeError:
+      continue
+    if isinstance(candidate, int):
+      return candidate
+
+  response = getattr(exc, "response", None)
+  if response is not None:
+    status = getattr(response, "status_code", None)
+    if isinstance(status, int):
+      return status
+  return None
+

--- a/langextract/providers/gemini.py
+++ b/langextract/providers/gemini.py
@@ -26,6 +26,7 @@ from absl import logging
 from langextract.core import base_model
 from langextract.core import data
 from langextract.core import exceptions
+from langextract.core import retry_utils
 from langextract.core import schema
 from langextract.core import types as core_types
 from langextract.providers import gemini_batch
@@ -150,6 +151,9 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
     self.max_workers = max_workers
     self.fence_output = fence_output
 
+    retry_cfg_dict = kwargs.pop('retry', None)
+    self._retry_cfg = retry_utils.RetryConfig.from_dict(retry_cfg_dict)
+
     # Extract batch config before we filter kwargs into _extra_kwargs
     batch_cfg_dict = kwargs.pop('batch', None)
     self._batch_cfg = gemini_batch.BatchConfig.from_dict(batch_cfg_dict)
@@ -214,8 +218,22 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
         config.setdefault('response_mime_type', 'application/json')
         config.setdefault('response_schema', self.gemini_schema.schema_dict)
 
-      response = self._client.models.generate_content(
-          model=self.model_id, contents=prompt, config=config
+      def _call():
+        return self._client.models.generate_content(
+            model=self.model_id, contents=prompt, config=config
+        )
+
+      def _on_retry(attempt: int, err: BaseException, delay_s: float) -> None:
+        logging.warning(
+            "Gemini API transient error (attempt %d/%d): %s. Retrying in %.2fs",
+            attempt,
+            self._retry_cfg.max_attempts,
+            err,
+            delay_s,
+        )
+
+      response = retry_utils.call_with_retry(
+          _call, cfg=self._retry_cfg, on_retry=_on_retry
       )
 
       return core_types.ScoredOutput(score=1.0, output=response.text)

--- a/langextract/providers/ollama.py
+++ b/langextract/providers/ollama.py
@@ -89,6 +89,7 @@ from urllib.parse import urljoin
 from urllib.parse import urlparse
 import warnings
 
+from absl import logging
 import requests
 
 # Import from core modules directly
@@ -96,6 +97,7 @@ from langextract.core import base_model
 from langextract.core import data
 from langextract.core import exceptions
 from langextract.core import format_handler as fh
+from langextract.core import retry_utils
 from langextract.core import schema
 from langextract.core import types as core_types
 from langextract.providers import patterns
@@ -228,6 +230,8 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
     self._api_key = kwargs.pop('api_key', None)
     self._auth_scheme = kwargs.pop('auth_scheme', 'Bearer')
     self._auth_header = kwargs.pop('auth_header', 'Authorization')
+    retry_cfg_dict = kwargs.pop('retry', None)
+    self._retry_cfg = retry_utils.RetryConfig.from_dict(retry_cfg_dict)
 
     if self._api_key:
       host = urlparse(self._model_url).hostname
@@ -270,6 +274,8 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
             **combined_kwargs,
         )
         yield [core_types.ScoredOutput(score=1.0, output=response['response'])]
+      except exceptions.InferenceError:
+        raise
       except Exception as e:
         raise exceptions.InferenceRuntimeError(
             f'Ollama API error: {str(e)}', original=e
@@ -422,33 +428,56 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
       else:
         headers[self._auth_header] = self._api_key
 
-    try:
-      response = self._requests.post(
-          api_url,
-          headers=headers,
-          json=payload,
-          timeout=request_timeout,
-      )
-    except self._requests.exceptions.RequestException as e:
-      if isinstance(e, self._requests.exceptions.ReadTimeout):
-        msg = (
-            f'Ollama Model timed out (timeout={request_timeout},'
-            f' num_threads={num_threads})'
+    def _call() -> Mapping[str, Any]:
+      try:
+        response = self._requests.post(
+            api_url,
+            headers=headers,
+            json=payload,
+            timeout=request_timeout,
         )
+      except self._requests.exceptions.RequestException as e:
+        if isinstance(e, self._requests.exceptions.ReadTimeout):
+          msg = (
+              f'Ollama Model timed out (timeout={request_timeout},'
+              f' num_threads={num_threads})'
+          )
+          raise exceptions.InferenceRuntimeError(
+              msg, original=e, provider='Ollama'
+          ) from e
         raise exceptions.InferenceRuntimeError(
-            msg, original=e, provider='Ollama'
+            f'Ollama request failed: {str(e)}', original=e, provider='Ollama'
         ) from e
-      raise exceptions.InferenceRuntimeError(
-          f'Ollama request failed: {str(e)}', original=e, provider='Ollama'
-      ) from e
 
-    response.encoding = 'utf-8'
-    if response.status_code == 200:
-      return response.json()
-    if response.status_code == 404:
-      raise exceptions.InferenceConfigError(
-          f"Can't find Ollama {model}. Try: ollama run {model}"
-      )
-    else:
+      response.encoding = 'utf-8'
+      if response.status_code == 200:
+        return response.json()
+      if response.status_code == 404:
+        raise exceptions.InferenceConfigError(
+            f"Can't find Ollama {model}. Try: ollama run {model}"
+        )
+
+      try:
+        response.raise_for_status()
+      except self._requests.exceptions.HTTPError as e:
+        raise exceptions.InferenceRuntimeError(
+            f'Bad status code from Ollama: {response.status_code}',
+            original=e,
+            provider='Ollama',
+        ) from e
+
       msg = f'Bad status code from Ollama: {response.status_code}'
       raise exceptions.InferenceRuntimeError(msg, provider='Ollama')
+
+    def _on_retry(attempt: int, err: BaseException, delay_s: float) -> None:
+      logging.warning(
+          "Ollama transient error (attempt %d/%d): %s. Retrying in %.2fs",
+          attempt,
+          self._retry_cfg.max_attempts,
+          err,
+          delay_s,
+      )
+
+    return retry_utils.call_with_retry(
+        _call, cfg=self._retry_cfg, on_retry=_on_retry
+    )

--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -21,9 +21,12 @@ import concurrent.futures
 import dataclasses
 from typing import Any, Iterator, Sequence
 
+from absl import logging
+
 from langextract.core import base_model
 from langextract.core import data
 from langextract.core import exceptions
+from langextract.core import retry_utils
 from langextract.core import schema
 from langextract.core import types as core_types
 from langextract.providers import patterns
@@ -98,6 +101,8 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
     self.format_type = format_type
     self.temperature = temperature
     self.max_workers = max_workers
+    retry_cfg_dict = kwargs.pop("retry", None)
+    self._retry_cfg = retry_utils.RetryConfig.from_dict(retry_cfg_dict)
 
     if not self.api_key:
       raise exceptions.InferenceConfigError('API key not provided.')
@@ -181,7 +186,21 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
         if (v := normalized_config.get(key)) is not None:
           api_params[key] = v
 
-      response = self._client.chat.completions.create(**api_params)
+      def _call():
+        return self._client.chat.completions.create(**api_params)
+
+      def _on_retry(attempt: int, err: BaseException, delay_s: float) -> None:
+        logging.warning(
+            "OpenAI API transient error (attempt %d/%d): %s. Retrying in %.2fs",
+            attempt,
+            self._retry_cfg.max_attempts,
+            err,
+            delay_s,
+        )
+
+      response = retry_utils.call_with_retry(
+          _call, cfg=self._retry_cfg, on_retry=_on_retry
+      )
 
       # Extract the response text using the v1.x response format
       output_text = response.choices[0].message.content

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -22,12 +22,15 @@ pylint warnings are expected for test fixtures.
 
 from unittest import mock
 
+import requests
+
 from absl.testing import absltest
 from absl.testing import parameterized
 
 from langextract import exceptions
 from langextract.core import base_model
 from langextract.core import data
+from langextract.core import retry_utils
 from langextract.core import types
 from langextract.providers import gemini
 from langextract.providers import ollama
@@ -85,6 +88,37 @@ class TestBaseLanguageModel(absltest.TestCase):
         result,
         "merge_kwargs should work even without _extra_kwargs attribute",
     )
+
+
+class TestRetryUtils(absltest.TestCase):
+
+  def test_is_retryable_error_detects_status_code_attribute(self):
+    cfg = retry_utils.RetryConfig()
+    err = Exception("nope")
+    err.status_code = 503  # type: ignore[attr-defined]
+    self.assertTrue(retry_utils.is_retryable_error(err, cfg=cfg))
+
+  def test_is_retryable_error_detects_code_method(self):
+    class _E(Exception):
+
+      def code(self):
+        return 503
+
+    cfg = retry_utils.RetryConfig()
+    self.assertTrue(retry_utils.is_retryable_error(_E("x"), cfg=cfg))
+
+  def test_is_retryable_error_detects_http_error_response(self):
+    cfg = retry_utils.RetryConfig()
+    resp = mock.Mock()
+    resp.status_code = 503
+    http_err = requests.exceptions.HTTPError("fail")
+    http_err.response = resp  # type: ignore[attr-defined]
+    self.assertTrue(retry_utils.is_retryable_error(http_err, cfg=cfg))
+
+  def test_is_retryable_error_detects_message_substring(self):
+    cfg = retry_utils.RetryConfig()
+    err = Exception("503 The model is overloaded")
+    self.assertTrue(retry_utils.is_retryable_error(err, cfg=cfg))
 
 
 class TestOllamaLanguageModel(absltest.TestCase):
@@ -343,6 +377,30 @@ class TestOllamaLanguageModel(absltest.TestCase):
           "Timeout from constructor should flow through infer()",
       )
 
+  @mock.patch("requests.post")
+  def test_ollama_retries_on_retryable_status_codes(self, mock_post):
+    """503 responses should be retried when configured."""
+    resp_503 = mock.Mock()
+    resp_503.status_code = 503
+    http_err = requests.exceptions.HTTPError("service unavailable")
+    http_err.response = resp_503  # type: ignore[attr-defined]
+    resp_503.raise_for_status.side_effect = http_err
+
+    resp_200 = mock.Mock()
+    resp_200.status_code = 200
+    resp_200.json.return_value = {"response": '{"ok": 1}', "done": True}
+
+    mock_post.side_effect = [resp_503, resp_200]
+
+    model = ollama.OllamaLanguageModel(
+        model_id="test-model",
+        retry={"max_attempts": 2, "initial_delay_s": 0.0, "jitter_ratio": 0.0},
+    )
+
+    results = list(model.infer(["prompt"]))
+    self.assertEqual(results[0][0].output, '{"ok": 1}')
+    self.assertEqual(mock_post.call_count, 2)
+
 
 class TestGeminiLanguageModel(absltest.TestCase):
 
@@ -520,6 +578,51 @@ class TestGeminiLanguageModel(absltest.TestCase):
         http_options=http_options,
     )
 
+  @mock.patch("google.genai.Client")
+  def test_gemini_retries_on_overloaded_errors(self, mock_client_class):
+    """503 overload errors should be retried when configured."""
+    mock_client = mock.Mock()
+    mock_client_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.text = '{"ok": 1}'
+    mock_client.models.generate_content.side_effect = [
+        Exception("503 The model is overloaded"),
+        mock_response,
+    ]
+
+    model = gemini.GeminiLanguageModel(
+        api_key="test-key",
+        retry={"max_attempts": 2, "initial_delay_s": 0.0, "jitter_ratio": 0.0},
+    )
+
+    results = list(model.infer(["prompt"]))
+    self.assertEqual(results[0][0].output, '{"ok": 1}')
+    self.assertEqual(mock_client.models.generate_content.call_count, 2)
+
+  @mock.patch("google.genai.Client")
+  def test_gemini_retry_disabled_does_not_retry(self, mock_client_class):
+    mock_client = mock.Mock()
+    mock_client_class.return_value = mock_client
+    mock_client.models.generate_content.side_effect = Exception(
+        "503 The model is overloaded"
+    )
+
+    model = gemini.GeminiLanguageModel(
+        api_key="test-key",
+        retry={
+            "enabled": False,
+            "max_attempts": 2,
+            "initial_delay_s": 0.0,
+            "jitter_ratio": 0.0,
+        },
+    )
+
+    with self.assertRaises(exceptions.InferenceRuntimeError):
+      list(model.infer(["prompt"]))
+
+    self.assertEqual(mock_client.models.generate_content.call_count, 1)
+
 
 class TestOpenAILanguageModelInference(parameterized.TestCase):
 
@@ -564,6 +667,29 @@ class TestOpenAILanguageModelInference(parameterized.TestCase):
         [types.ScoredOutput(score=1.0, output='{"name": "John", "age": 30}')]
     ]
     self.assertEqual(results, expected_results)
+
+  @mock.patch("openai.OpenAI")
+  def test_openai_retries_on_retryable_errors(self, mock_openai_class):
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    retryable = Exception("service unavailable")
+    retryable.status_code = 503  # type: ignore[attr-defined]
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"ok": 1}'))
+    ]
+    mock_client.chat.completions.create.side_effect = [retryable, mock_response]
+
+    model = openai.OpenAILanguageModel(
+        api_key="test-api-key",
+        retry={"max_attempts": 2, "initial_delay_s": 0.0, "jitter_ratio": 0.0},
+    )
+
+    results = list(model.infer(["prompt"]))
+    self.assertEqual(results[0][0].output, '{"ok": 1}')
+    self.assertEqual(mock_client.chat.completions.create.call_count, 2)
 
 
 class TestOpenAILanguageModel(absltest.TestCase):


### PR DESCRIPTION
## Summary
- Add shared retry utilities for transient inference failures (503 overload, timeouts).
- Retry per-prompt calls in Gemini/OpenAI/Ollama so chunked extraction can continue through temporary overloads.

## Test plan
- [x] `python3 -m pytest -q`

Fixes #240