### PR TITLE
fix: prefer final output and drop unaligned extractions

### DIFF
--- a/langextract/core/__init__.py
+++ b/langextract/core/__init__.py
@@ -28,4 +28,5 @@ __all__ = [
     "schema",
     "data",
     "tokenizer",
+    "json_parsing",
 ]

--- a/langextract/core/format_handler.py
+++ b/langextract/core/format_handler.py
@@ -25,6 +25,7 @@ import yaml
 
 from langextract.core import data
 from langextract.core import exceptions
+from langextract.core import json_parsing
 
 ExtractionValueType = str | int | float | dict | list | None
 
@@ -268,12 +269,41 @@ class FormatHandler:
       if strict:
         raise
       # Reasoning models (DeepSeek-R1, QwQ) emit <think> tags before JSON.
-      if _THINK_TAG_RE.search(content):
-        stripped = _THINK_TAG_RE.sub("", content).strip()
-        if self.format_type == data.FormatType.YAML:
+      stripped = (
+          _THINK_TAG_RE.sub("", content).strip()
+          if _THINK_TAG_RE.search(content)
+          else content
+      )
+
+      if self.format_type == data.FormatType.YAML:
+        try:
           return yaml.safe_load(stripped)
+        except yaml.YAMLError:
+          # Some models emit multiple YAML documents; use the last one.
+          docs = [d for d in yaml.safe_load_all(stripped) if d is not None]
+          if docs:
+            return docs[-1]
+          raise
+
+      # JSON
+      try:
         return json.loads(stripped)
-      raise
+      except json.JSONDecodeError:
+        # Models may echo example payloads before the final answer. Prefer the
+        # last parseable JSON object/array in the output.
+        require_wrapper = self.wrapper_key is not None and (
+            self.use_wrapper or bool(strict)
+        )
+
+        def _accept(obj) -> bool:
+          if require_wrapper:
+            return isinstance(obj, dict) and (
+                (self.wrapper_key in obj if self.wrapper_key else False)
+                or data.EXTRACTIONS_KEY in obj
+            )
+          return isinstance(obj, (dict, list))
+
+        return json_parsing.parse_last_json(stripped, accept=_accept)
 
   def _extract_content(self, text: str) -> str:
     """Extract content from text, handling fences if configured.
@@ -319,13 +349,15 @@ class FormatHandler:
     if len(candidates) == 1:
       return candidates[0].group("body").strip()
     elif len(candidates) > 1:
-      raise exceptions.FormatParseError(
-          "Multiple fenced blocks found. Expected exactly one."
-      )
+      # In non-strict mode, prefer the last candidate. This is particularly
+      # useful when a model echoes few-shot examples before the actual answer.
+      return candidates[-1].group("body").strip()
 
     if matches:
-      if not self.strict_fences and len(matches) == 1:
-        return matches[0].group("body").strip()
+      if not self.strict_fences:
+        # If there are fenced blocks but no valid language tags, use the last
+        # fenced block as a best-effort fallback.
+        return matches[-1].group("body").strip()
       raise exceptions.FormatParseError(
           f"No {self.format_type.value} code block found."
       )

--- a/langextract/core/json_parsing.py
+++ b/langextract/core/json_parsing.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for lenient JSON extraction from mixed model outputs."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import json
+from typing import Any
+
+
+def parse_last_json(
+    text: str, *, accept: Callable[[Any], bool] | None = None
+) -> Any:
+  """Parse the last JSON object/array found in `text`.
+
+  This is useful when a model echoes few-shot examples before emitting the
+  actual answer; selecting the last JSON payload avoids parsing the example.
+
+  Args:
+    text: Model output that may contain leading/trailing non-JSON text or
+      multiple JSON objects/arrays.
+
+  Returns:
+    Parsed Python object (dict/list/etc.).
+
+  Raises:
+    json.JSONDecodeError: If no parseable JSON object/array is found.
+  """
+  decoder = json.JSONDecoder()
+  starts = [i for i, c in enumerate(text) if c in "{["]
+  last_err: json.JSONDecodeError | None = None
+  for start in reversed(starts):
+    try:
+      obj, _ = decoder.raw_decode(text, start)
+      if accept is not None and not accept(obj):
+        continue
+      return obj
+    except json.JSONDecodeError as e:
+      last_err = e
+      continue
+  if last_err is not None:
+    raise last_err
+  raise json.JSONDecodeError("No JSON object found", text, 0)
+

--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -126,7 +126,10 @@ def extract(
         reduce recall. Default is True. 'fuzzy_alignment_threshold' (float):
         Minimum token overlap ratio for fuzzy match (0.0-1.0). Default is 0.75.
         'accept_match_lesser' (bool): Whether to accept partial exact matches.
-        Default is True. 'suppress_parse_errors' (bool): Whether to suppress
+        Default is True. 'drop_unaligned_extractions' (bool): Whether to discard
+        extractions that could not be aligned to the source text (char_interval
+        is None). Useful when models echo few-shot examples. Default is False.
+        'suppress_parse_errors' (bool): Whether to suppress
         parsing errors and continue pipeline. Default is False.
       language_model_params: Additional parameters for the language model.
       debug: Whether to enable debug logging. When True, enables detailed logging

--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -47,6 +47,7 @@ ALIGNMENT_PARAM_KEYS: Final[frozenset[str]] = frozenset({
     "fuzzy_alignment_threshold",
     "accept_match_lesser",
     "suppress_parse_errors",
+    "drop_unaligned_extractions",
 })
 
 
@@ -314,6 +315,10 @@ class Resolver(AbstractResolver):
     """
     logging.debug("Starting alignment process for provided chunk text.")
 
+    drop_unaligned_extractions = bool(
+        kwargs.pop("drop_unaligned_extractions", False)
+    )
+
     if not extractions:
       logging.debug(
           "No extractions found in the annotated text; exiting alignment"
@@ -340,6 +345,8 @@ class Resolver(AbstractResolver):
     )
 
     for extraction in itertools.chain(*aligned_yaml_extractions):
+      if drop_unaligned_extractions and extraction.char_interval is None:
+        continue
       logging.debug("Yielding aligned extraction: %s", extraction)
       yield extraction
 

--- a/tests/format_handler_test.py
+++ b/tests/format_handler_test.py
@@ -305,6 +305,41 @@ class NonGeminiModelParsingTest(parameterized.TestCase):
     self.assertLen(parsed, 1)
     self.assertEqual(parsed[0]["person"], "John Smith")
 
+  def test_lenient_json_prefers_last_payload_when_multiple_present(self):
+    handler = format_handler.FormatHandler(
+        format_type=data.FormatType.JSON,
+        use_wrapper=True,
+        wrapper_key="extractions",
+        use_fences=False,
+    )
+    output = textwrap.dedent("""\
+        Example:
+        {"extractions": [{"person": "Alice"}]}
+        Answer:
+        {"extractions": [{"person": "Bob"}]}""")
+    parsed = handler.parse_output(output)
+    self.assertLen(parsed, 1)
+    self.assertEqual(parsed[0]["person"], "Bob")
+
+  def test_lenient_fences_prefers_last_block_when_multiple_present(self):
+    handler = format_handler.FormatHandler(
+        format_type=data.FormatType.JSON,
+        use_wrapper=True,
+        wrapper_key="extractions",
+        use_fences=True,
+        strict_fences=False,
+    )
+    output = textwrap.dedent("""\
+        ```json
+        {"extractions": [{"person": "Alice"}]}
+        ```
+        ```json
+        {"extractions": [{"person": "Bob"}]}
+        ```""")
+    parsed = handler.parse_output(output)
+    self.assertLen(parsed, 1)
+    self.assertEqual(parsed[0]["person"], "Bob")
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tests/resolver_test.py
+++ b/tests/resolver_test.py
@@ -1989,6 +1989,36 @@ class ResolverTest(parameterized.TestCase):
 
     self.assertEmpty(aligned_extractions)
 
+  def test_align_can_drop_unaligned_extractions(self):
+    text = "This is a sample text with some extractions."
+    annotated_extractions = [
+        data.Extraction(extraction_class="medication", extraction_text="Aspirin")
+    ]
+
+    aligned_default = list(
+        self.default_resolver.align(
+            extractions=annotated_extractions,
+            source_text=text,
+            token_offset=0,
+            char_offset=0,
+            enable_fuzzy_alignment=False,
+        )
+    )
+    self.assertLen(aligned_default, 1)
+    self.assertIsNone(aligned_default[0].char_interval)
+
+    aligned_dropped = list(
+        self.default_resolver.align(
+            extractions=annotated_extractions,
+            source_text=text,
+            token_offset=0,
+            char_offset=0,
+            enable_fuzzy_alignment=False,
+            drop_unaligned_extractions=True,
+        )
+    )
+    self.assertEmpty(aligned_dropped)
+
   def test_align_successful(self):
     tokenized_text = tokenizer.TokenizedText(
         text="zero one two",
@@ -2299,7 +2329,7 @@ class FenceFallbackTest(parameterized.TestCase):
     self.assertLen(result, 1)
     self.assertEqual(result[0]["person"], "Default Test")
 
-  def test_rejects_multiple_fenced_blocks(self):
+  def test_lenient_prefers_last_fenced_block_when_multiple_present(self):
     test_input = textwrap.dedent("""\
         preamble
         ```json
@@ -2314,10 +2344,9 @@ class FenceFallbackTest(parameterized.TestCase):
         format_type=data.FormatType.JSON,
         strict_fences=False,
     )
-    with self.assertRaisesRegex(
-        resolver_lib.ResolverParsingError, "Multiple fenced blocks found"
-    ):
-      resolver.string_to_extraction_data(test_input)
+    result = resolver.string_to_extraction_data(test_input)
+    self.assertLen(result, 1)
+    self.assertEqual(result[0]["item"], "second")
 
 
 class FlexibleSchemaTest(parameterized.TestCase):


### PR DESCRIPTION
## Summary
- Make lenient parsing prefer the final fenced block / final JSON payload (helps when models echo few-shot examples).
- Add an opt-in `drop_unaligned_extractions` alignment flag to discard extractions that don’t align to the source chunk.

## Test plan
- [x] `python3 -m pytest -q`

Fixes #209