### PR TITLE
feat: add multimodal image inputs

### DIFF
--- a/langextract/annotation.py
+++ b/langextract/annotation.py
@@ -308,6 +308,7 @@ class Annotator:
         list
     )
     next_emit_idx = 0
+    global_images = kwargs.pop("images", None)
 
     def _capture_docs(src: Iterable[data.Document]) -> Iterator[data.Document]:
       """Captures document order and text lazily as chunks are produced."""
@@ -387,7 +388,31 @@ class Annotator:
           except AttributeError:
             pass
 
-        outputs = self._language_model.infer(batch_prompts=prompts, **kwargs)
+        prompt_images: list[list[data.Image] | None] = []
+        for chunk in batch:
+          doc_images = (
+              chunk.document.images if chunk.document is not None else None
+          )
+          if doc_images and global_images:
+            prompt_images.append([*doc_images, *global_images])
+          elif doc_images:
+            prompt_images.append(doc_images)
+          elif global_images:
+            prompt_images.append(global_images)
+          else:
+            prompt_images.append(None)
+
+        if any(prompt_images):
+          if not getattr(self._language_model, "supports_images", False):
+            raise exceptions.InferenceConfigError(
+                "Image inputs were provided, but the selected provider does not"
+                " support multimodal extraction."
+            )
+          outputs = self._language_model.infer(
+              batch_prompts=prompts, images=prompt_images, **kwargs
+          )
+        else:
+          outputs = self._language_model.infer(batch_prompts=prompts, **kwargs)
         if not isinstance(outputs, list):
           outputs = list(outputs)
 

--- a/langextract/core/base_model.py
+++ b/langextract/core/base_model.py
@@ -101,6 +101,11 @@ class BaseLanguageModel(abc.ABC):
       return True
     return not schema_obj.requires_raw_output
 
+  @property
+  def supports_images(self) -> bool:
+    """Whether this provider supports image inputs."""
+    return False
+
   def merge_kwargs(
       self, runtime_kwargs: Mapping[str, Any] | None = None
   ) -> dict[str, Any]:

--- a/langextract/core/data.py
+++ b/langextract/core/data.py
@@ -30,6 +30,7 @@ ATTRIBUTE_SUFFIX = "_attributes"
 __all__ = [
     "AlignmentStatus",
     "CharInterval",
+    "Image",
     "Extraction",
     "Document",
     "AnnotatedDocument",
@@ -58,6 +59,14 @@ class CharInterval:
 
   start_pos: int | None = None
   end_pos: int | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class Image:
+  """Binary image input for multimodal extraction."""
+
+  data: bytes
+  mime_type: str = "image/png"
 
 
 @dataclasses.dataclass(init=False)
@@ -139,6 +148,7 @@ class Document:
 
   text: str
   additional_context: str | None = None
+  images: list[Image] | None = None
   _document_id: str | None = dataclasses.field(
       default=None, init=False, repr=False, compare=False
   )
@@ -152,9 +162,11 @@ class Document:
       *,
       document_id: str | None = None,
       additional_context: str | None = None,
+      images: list[Image] | None = None,
   ):
     self.text = text
     self.additional_context = additional_context
+    self.images = images
     self._document_id = document_id
 
   @property

--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+import mimetypes
+import pathlib
 import typing
 from typing import cast
 import warnings
@@ -31,6 +33,52 @@ from langextract.core import base_model
 from langextract.core import data
 from langextract.core import format_handler as fh
 from langextract.core import tokenizer as tokenizer_lib
+
+
+_DEFAULT_IMAGE_MIME_TYPE = "image/png"
+
+
+def _normalize_images(
+    images: typing.Sequence[typing.Any] | None,
+) -> list[data.Image] | None:
+  """Normalize supported image inputs into `data.Image`."""
+  if not images:
+    return None
+
+  out: list[data.Image] = []
+  for item in images:
+    if isinstance(item, data.Image):
+      out.append(item)
+      continue
+
+    if isinstance(item, (bytes, bytearray, memoryview)):
+      out.append(data.Image(data=bytes(item), mime_type=_DEFAULT_IMAGE_MIME_TYPE))
+      continue
+
+    if (
+        isinstance(item, tuple)
+        and len(item) == 2
+        and isinstance(item[0], str)
+        and isinstance(item[1], (bytes, bytearray, memoryview))
+    ):
+      out.append(data.Image(data=bytes(item[1]), mime_type=item[0]))
+      continue
+
+    if isinstance(item, (str, pathlib.Path)):
+      path = pathlib.Path(item)
+      raw = path.read_bytes()
+      mime, _ = mimetypes.guess_type(str(path))
+      if mime is None:
+        mime = _DEFAULT_IMAGE_MIME_TYPE
+      out.append(data.Image(data=raw, mime_type=mime))
+      continue
+
+    raise TypeError(
+        "Unsupported image input type. Expected data.Image, bytes, "
+        "(mime_type, bytes), or a filesystem path."
+    )
+
+  return out
 
 
 def extract(
@@ -58,6 +106,7 @@ def extract(
     model: typing.Any = None,
     *,
     fetch_urls: bool = True,
+    images: typing.Sequence[typing.Any] | None = None,
     prompt_validation_level: pv.PromptValidationLevel = pv.PromptValidationLevel.WARNING,
     prompt_validation_strict: bool = False,
     show_progress: bool = True,
@@ -154,6 +203,9 @@ def extract(
         URL string. When True (default), strings starting with http:// or
         https:// are fetched. When False, all strings are treated as literal
         text to analyze. This is a keyword-only parameter.
+      images: Optional images to attach to each prompt for multimodal-capable
+        models. Items may be `data.Image`, raw bytes (assumed PNG),
+        `(mime_type, bytes)`, or filesystem paths.
       prompt_validation_level: Controls pre-flight alignment checks on few-shot
         examples. OFF skips validation, WARNING logs issues but continues, ERROR
         raises on failures. Defaults to WARNING.
@@ -214,6 +266,8 @@ def extract(
       and io.is_url(text_or_documents)
   ):
     text_or_documents = io.download_text_from_url(text_or_documents)
+
+  normalized_images = _normalize_images(images)
 
   prompt_template = prompting.PromptTemplateStructured(
       description=prompt_description
@@ -344,6 +398,7 @@ def extract(
         show_progress=show_progress,
         max_workers=max_workers,
         tokenizer=tokenizer,
+        images=normalized_images,
         **alignment_kwargs,
     )
     return result
@@ -360,6 +415,7 @@ def extract(
         show_progress=show_progress,
         max_workers=max_workers,
         tokenizer=tokenizer,
+        images=normalized_images,
         **alignment_kwargs,
     )
     return list(result)

--- a/langextract/providers/gemini.py
+++ b/langextract/providers/gemini.py
@@ -91,6 +91,10 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
     if isinstance(schema_instance, schemas.gemini.GeminiSchema):
       self.gemini_schema = schema_instance
 
+  @property
+  def supports_images(self) -> bool:
+    return True
+
   def __init__(
       self,
       model_id: str = _DEFAULT_MODEL_ID,
@@ -200,7 +204,10 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
       )
 
   def _process_single_prompt(
-      self, prompt: str, config: dict
+      self,
+      prompt: str,
+      config: dict,
+      images: Sequence[data.Image] | None = None,
   ) -> core_types.ScoredOutput:
     """Process a single prompt and return a ScoredOutput."""
     try:
@@ -214,8 +221,22 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
         config.setdefault('response_mime_type', 'application/json')
         config.setdefault('response_schema', self.gemini_schema.schema_dict)
 
+      contents: Any = prompt
+      if images:
+        # pylint: disable=import-outside-toplevel
+        from google import genai
+
+        parts = [genai.types.Part.from_text(prompt)]
+        for img in images:
+          parts.append(
+              genai.types.Part.from_bytes(
+                  data=img.data, mime_type=img.mime_type
+              )
+          )
+        contents = parts
+
       response = self._client.models.generate_content(
-          model=self.model_id, contents=prompt, config=config
+          model=self.model_id, contents=contents, config=config
       )
 
       return core_types.ScoredOutput(score=1.0, output=response.text)
@@ -239,6 +260,27 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
     """
     merged_kwargs = self.merge_kwargs(kwargs)
 
+    images_arg = merged_kwargs.get("images")
+    prompt_images: list[list[data.Image] | None] = [None] * len(batch_prompts)
+    if images_arg:
+      if (
+          isinstance(images_arg, list)
+          and images_arg
+          and isinstance(images_arg[0], data.Image)
+      ):
+        prompt_images = [images_arg] * len(batch_prompts)
+      elif (
+          isinstance(images_arg, list)
+          and len(images_arg) == len(batch_prompts)
+          and all(x is None or isinstance(x, list) for x in images_arg)
+      ):
+        prompt_images = images_arg
+      else:
+        raise TypeError(
+            "images must be a list[data.Image] (applied to all prompts) or "
+            "a list[list[data.Image] | None] aligned with batch_prompts."
+        )
+
     config = {
         'temperature': merged_kwargs.get('temperature', self.temperature),
     }
@@ -255,8 +297,9 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
       ):
         config[key] = value
 
-    # Use batch API if threshold met
-    if self._batch_cfg and self._batch_cfg.enabled:
+    # Use batch API if threshold met. Multimodal inputs are not currently
+    # supported by the batch API path.
+    if self._batch_cfg and self._batch_cfg.enabled and not any(prompt_images):
       if len(batch_prompts) >= self._batch_cfg.threshold:
         try:
           if self.gemini_schema:
@@ -310,7 +353,10 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
       ) as executor:
         future_to_index = {
             executor.submit(
-                self._process_single_prompt, prompt, config.copy()
+                self._process_single_prompt,
+                prompt,
+                config.copy(),
+                prompt_images[i],
             ): i
             for i, prompt in enumerate(batch_prompts)
         }
@@ -335,6 +381,6 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
           yield [result]
     else:
       # Sequential processing for single prompt or worker
-      for prompt in batch_prompts:
-        result = self._process_single_prompt(prompt, config.copy())
+      for i, prompt in enumerate(batch_prompts):
+        result = self._process_single_prompt(prompt, config.copy(), prompt_images[i])
         yield [result]  # pylint: disable=duplicate-code

--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import base64
 import concurrent.futures
 import dataclasses
 from typing import Any, Iterator, Sequence
@@ -56,6 +57,10 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
     if self.format_type == data.FormatType.JSON:
       return False
     return super().requires_fence_output
+
+  @property
+  def supports_images(self) -> bool:
+    return True
 
   def __init__(
       self,
@@ -131,7 +136,10 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
     return result
 
   def _process_single_prompt(
-      self, prompt: str, config: dict
+      self,
+      prompt: str,
+      config: dict,
+      images: Sequence[data.Image] | None = None,
   ) -> core_types.ScoredOutput:
     """Process a single prompt and return a ScoredOutput."""
     try:
@@ -147,7 +155,22 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
             'You are a helpful assistant that responds in YAML format.'
         )
 
-      messages = [{'role': 'user', 'content': prompt}]
+      user_content: Any = prompt
+      if images:
+        parts: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
+        for img in images:
+          b64 = base64.b64encode(img.data).decode("ascii")
+          parts.append(
+              {
+                  "type": "image_url",
+                  "image_url": {
+                      "url": f"data:{img.mime_type};base64,{b64}",
+                  },
+              }
+          )
+        user_content = parts
+
+      messages = [{'role': 'user', 'content': user_content}]
       if system_message:
         messages.insert(0, {'role': 'system', 'content': system_message})
 
@@ -207,6 +230,27 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
     """
     merged_kwargs = self.merge_kwargs(kwargs)
 
+    images_arg = merged_kwargs.get("images")
+    prompt_images: list[list[data.Image] | None] = [None] * len(batch_prompts)
+    if images_arg:
+      if (
+          isinstance(images_arg, list)
+          and images_arg
+          and isinstance(images_arg[0], data.Image)
+      ):
+        prompt_images = [images_arg] * len(batch_prompts)
+      elif (
+          isinstance(images_arg, list)
+          and len(images_arg) == len(batch_prompts)
+          and all(x is None or isinstance(x, list) for x in images_arg)
+      ):
+        prompt_images = images_arg
+      else:
+        raise TypeError(
+            "images must be a list[data.Image] (applied to all prompts) or "
+            "a list[list[data.Image] | None] aligned with batch_prompts."
+        )
+
     config = {}
 
     temp = merged_kwargs.get('temperature', self.temperature)
@@ -238,7 +282,10 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
       ) as executor:
         future_to_index = {
             executor.submit(
-                self._process_single_prompt, prompt, config.copy()
+                self._process_single_prompt,
+                prompt,
+                config.copy(),
+                prompt_images[i],
             ): i
             for i, prompt in enumerate(batch_prompts)
         }
@@ -263,6 +310,6 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
           yield [result]
     else:
       # Sequential processing for single prompt or worker
-      for prompt in batch_prompts:
-        result = self._process_single_prompt(prompt, config.copy())
+      for i, prompt in enumerate(batch_prompts):
+        result = self._process_single_prompt(prompt, config.copy(), prompt_images[i])
         yield [result]  # pylint: disable=duplicate-code

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -436,6 +436,32 @@ class TestGeminiLanguageModel(absltest.TestCase):
         "unknown_runtime_param", config, "Unknown kwargs should be filtered out"
     )
 
+  @mock.patch("google.genai.Client")
+  def test_gemini_infer_with_images_builds_parts(self, mock_client_class):
+    mock_client = mock.Mock()
+    mock_client_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.text = '{"result": "test"}'
+    mock_client.models.generate_content.return_value = mock_response
+
+    model = gemini.GeminiLanguageModel(
+        model_id="gemini-2.5-flash",
+        api_key="test-key",
+    )
+
+    image = data.Image(data=b"img", mime_type="image/png")
+    with mock.patch("google.genai.types.Part.from_text") as mock_from_text, mock.patch(
+        "google.genai.types.Part.from_bytes"
+    ) as mock_from_bytes:
+      mock_from_text.return_value = "TEXT_PART"
+      mock_from_bytes.return_value = "IMG_PART"
+
+      list(model.infer(["prompt"], images=[[image]]))
+
+    call_args = mock_client.models.generate_content.call_args
+    self.assertEqual(call_args.kwargs["contents"], ["TEXT_PART", "IMG_PART"])
+
   def test_gemini_requires_auth_config(self):
     """Test that Gemini requires either API key or Vertex AI config."""
     with self.assertRaises(exceptions.InferenceConfigError) as cm:
@@ -564,6 +590,41 @@ class TestOpenAILanguageModelInference(parameterized.TestCase):
         [types.ScoredOutput(score=1.0, output='{"name": "John", "age": 30}')]
     ]
     self.assertEqual(results, expected_results)
+
+  @mock.patch("openai.OpenAI")
+  def test_openai_infer_with_images_builds_multimodal_message(
+      self, mock_openai_class
+  ):
+    import base64
+
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"name": "Bob"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai.OpenAILanguageModel(
+        model_id="gpt-4o-mini",
+        api_key="test-api-key",
+    )
+
+    image_bytes = b"\x89PNG\r\n\x1a\nfake"
+    image = data.Image(data=image_bytes, mime_type="image/png")
+    list(model.infer(["prompt"], images=[[image]]))
+
+    call_args = mock_client.chat.completions.create.call_args
+    messages = call_args.kwargs["messages"]
+    self.assertEqual(messages[1]["role"], "user")
+    self.assertIsInstance(messages[1]["content"], list)
+    self.assertEqual(messages[1]["content"][0]["type"], "text")
+
+    url = messages[1]["content"][1]["image_url"]["url"]
+    self.assertTrue(url.startswith("data:image/png;base64,"))
+    b64 = url.split(",", 1)[1]
+    self.assertEqual(base64.b64decode(b64), image_bytes)
 
 
 class TestOpenAILanguageModel(absltest.TestCase):

--- a/tests/multimodal_test.py
+++ b/tests/multimodal_test.py
@@ -1,0 +1,118 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for multimodal (text + images) extraction plumbing."""
+
+from absl.testing import absltest
+
+from langextract import exceptions
+from langextract import extraction as extraction_lib
+from langextract.core import base_model
+from langextract.core import data
+from langextract.core import types
+
+
+class _FakeMultimodalModel(base_model.BaseLanguageModel):
+
+  def __init__(self):
+    super().__init__()
+    self.seen_images = []
+
+  @property
+  def supports_images(self) -> bool:
+    return True
+
+  def infer(self, batch_prompts, **kwargs):
+    self.seen_images.append(kwargs.get("images"))
+    for _ in batch_prompts:
+      yield [types.ScoredOutput(score=1.0, output='{"extractions":[{"person":"Bob"}]}')]
+
+
+class _FakeTextOnlyModel(base_model.BaseLanguageModel):
+
+  def infer(self, batch_prompts, **kwargs):
+    for _ in batch_prompts:
+      yield [types.ScoredOutput(score=1.0, output='{"extractions":[{"person":"Bob"}]}')]
+
+
+class MultimodalPlumbingTest(absltest.TestCase):
+
+  def _examples(self):
+    return [
+        data.ExampleData(
+            text="Bob went home.",
+            extractions=[data.Extraction("person", "Bob")],
+        )
+    ]
+
+  def test_extract_passes_global_images_to_model(self):
+    model = _FakeMultimodalModel()
+    extraction_lib.extract(
+        "Bob went home.",
+        prompt_description="Extract people.",
+        examples=self._examples(),
+        model=model,
+        fence_output=False,
+        images=[b"img-bytes"],
+        show_progress=False,
+    )
+
+    self.assertLen(model.seen_images, 1)
+    batch_images = model.seen_images[0]
+    self.assertLen(batch_images, 1)
+    self.assertLen(batch_images[0], 1)
+    self.assertIsInstance(batch_images[0][0], data.Image)
+
+  def test_extract_raises_for_text_only_provider_when_images_present(self):
+    with self.assertRaises(exceptions.InferenceConfigError):
+      extraction_lib.extract(
+          "Bob went home.",
+          prompt_description="Extract people.",
+          examples=self._examples(),
+          model=_FakeTextOnlyModel(),
+          fence_output=False,
+          images=[b"img-bytes"],
+          show_progress=False,
+      )
+
+  def test_document_images_merge_with_global_images(self):
+    model = _FakeMultimodalModel()
+    doc_img = data.Image(data=b"doc", mime_type="image/png")
+    global_img = data.Image(data=b"global", mime_type="image/png")
+    docs = [
+        data.Document("Bob went home.", images=[doc_img]),
+        data.Document("Bob went home.", images=None),
+    ]
+
+    extraction_lib.extract(
+        docs,
+        prompt_description="Extract people.",
+        examples=self._examples(),
+        model=model,
+        fence_output=False,
+        images=[global_img],
+        batch_length=10,
+        show_progress=False,
+    )
+
+    self.assertLen(model.seen_images, 1)
+    batch_images = model.seen_images[0]
+    self.assertLen(batch_images, 2)
+    self.assertEqual(batch_images[0], [doc_img, global_img])
+    self.assertEqual(batch_images[1], [global_img])
+
+
+if __name__ == "__main__":
+  absltest.main()
+


### PR DESCRIPTION
## Summary
- Add an `Image` input type and plumb optional images through `extract()` → `Annotator` → provider inference.
- Implement image-aware request payloads for Gemini (parts) and OpenAI (multimodal message content).
- Fail fast with a clear config error when images are supplied to providers that don’t support them.

## Test plan
- [x] `python3 -m pytest -q`

Fixes #270