### PR TITLE
fix(resolver): avoid O(n²) fuzzy alignment on long examples

### DIFF
--- a/langextract/core/fuzzy_alignment.py
+++ b/langextract/core/fuzzy_alignment.py
@@ -1,0 +1,199 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fast fuzzy alignment helpers.
+
+These utilities are designed for cases where exhaustive sliding-window fuzzy
+alignment becomes too slow (e.g., long example texts used for prompt validation).
+They operate on *normalized token strings* to find a best-effort span in the
+source tokens that maximizes the number of extraction tokens matched in order.
+"""
+
+from __future__ import annotations
+
+import bisect
+from collections.abc import Mapping, Sequence
+
+
+def build_token_positions(tokens: Sequence[str]) -> dict[str, list[int]]:
+  """Build an inverted index of token -> sorted list of positions."""
+  positions: dict[str, list[int]] = {}
+  for i, tok in enumerate(tokens):
+    positions.setdefault(tok, []).append(i)
+  return positions
+
+
+def _iter_limited_positions(
+    positions: Sequence[int], *, max_items: int
+) -> Sequence[int]:
+  if max_items <= 0 or len(positions) <= max_items:
+    return positions
+
+  if max_items == 1:
+    return [positions[len(positions) // 2]]
+
+  stride = max(1, len(positions) // max_items)
+  sampled = list(positions[0::stride])
+  if len(sampled) > max_items:
+    sampled = sampled[:max_items]
+  if sampled[-1] != positions[-1] and len(sampled) < max_items:
+    sampled.append(positions[-1])
+  return sampled
+
+
+def greedy_subsequence_match_positions(
+    extraction_tokens: Sequence[str],
+    token_positions: Mapping[str, Sequence[int]],
+    *,
+    start_at: int = 0,
+) -> list[int]:
+  """Greedily match extraction tokens as a subsequence of source tokens.
+
+  Args:
+    extraction_tokens: Tokens to match (in order).
+    token_positions: Map of token -> sorted positions in the source token list.
+    start_at: Earliest source index that the first match may use.
+
+  Returns:
+    List of matched source indices (monotonic increasing). May be empty.
+  """
+  if not extraction_tokens:
+    return []
+
+  matched: list[int] = []
+  current = max(-1, start_at - 1)
+
+  for tok in extraction_tokens:
+    pos_list = token_positions.get(tok)
+    if not pos_list:
+      continue
+    j = bisect.bisect_right(pos_list, current)
+    if j >= len(pos_list):
+      continue
+    current = pos_list[j]
+    matched.append(current)
+
+  return matched
+
+
+def generate_candidate_starts(
+    extraction_tokens: Sequence[str],
+    token_positions: Mapping[str, Sequence[int]],
+    *,
+    max_candidates: int,
+    max_anchor_occurrences: int,
+    max_anchors: int = 3,
+) -> list[int]:
+  """Generate candidate start indices based on rare anchor tokens.
+
+  Candidates are derived by aligning occurrences of a small number of
+  low-frequency extraction tokens ("anchors") to their positions in the
+  extraction token list.
+  """
+  if max_candidates <= 0:
+    return [0]
+
+  token_to_extraction_indices: dict[str, list[int]] = {}
+  for j, tok in enumerate(extraction_tokens):
+    token_to_extraction_indices.setdefault(tok, []).append(j)
+
+  # Prefer anchors that appear in the source and are rare there.
+  anchors: list[tuple[int, str]] = []
+  for tok in token_to_extraction_indices:
+    freq = len(token_positions.get(tok, ()))
+    if freq > 0:
+      anchors.append((freq, tok))
+  anchors.sort(key=lambda x: x[0])
+
+  candidate_set: set[int] = {0}
+  candidates: list[int] = [0]
+  if len(candidates) >= max_candidates:
+    return candidates
+
+  for _, anchor in anchors[:max_anchors]:
+    extraction_idxs = token_to_extraction_indices[anchor]
+    source_positions = token_positions.get(anchor, ())
+    limited_positions = _iter_limited_positions(
+        source_positions, max_items=max_anchor_occurrences
+    )
+    for src_i in limited_positions:
+      for ex_j in extraction_idxs:
+        if len(candidates) >= max_candidates:
+          return candidates
+        start = src_i - ex_j
+        start = start if start > 0 else 0
+        if start in candidate_set:
+          continue
+        candidate_set.add(start)
+        candidates.append(start)
+        if len(candidates) >= max_candidates:
+          return candidates
+
+  return candidates
+
+
+def find_best_fuzzy_span(
+    source_tokens: Sequence[str],
+    extraction_tokens: Sequence[str],
+    *,
+    max_candidates: int,
+    max_anchor_occurrences: int,
+) -> tuple[int, int, int] | None:
+  """Find best source span for an extraction by subsequence matching.
+
+  The "best" span maximizes the number of matched extraction tokens (in order).
+  Ties are broken by preferring smaller spans, then earlier spans.
+
+  Returns:
+    Tuple of (start_index, end_index_exclusive, matched_tokens) or None.
+  """
+  if not extraction_tokens or not source_tokens:
+    return None
+
+  token_positions = build_token_positions(source_tokens)
+  candidates = generate_candidate_starts(
+      extraction_tokens,
+      token_positions,
+      max_candidates=max_candidates,
+      max_anchor_occurrences=max_anchor_occurrences,
+  )
+
+  best: tuple[int, int, int] | None = None
+  for start in candidates:
+    matched_positions = greedy_subsequence_match_positions(
+        extraction_tokens, token_positions, start_at=start
+    )
+    if not matched_positions:
+      continue
+    span_start = matched_positions[0]
+    span_end = matched_positions[-1] + 1
+    matched = len(matched_positions)
+
+    if best is None:
+      best = (span_start, span_end, matched)
+      continue
+
+    best_start, best_end, best_matched = best
+    if matched > best_matched:
+      best = (span_start, span_end, matched)
+      continue
+    if matched == best_matched:
+      span_len = span_end - span_start
+      best_len = best_end - best_start
+      if span_len < best_len or (
+          span_len == best_len and span_start < best_start
+      ):
+        best = (span_start, span_end, matched)
+
+  return best

--- a/langextract/prompt_validation.py
+++ b/langextract/prompt_validation.py
@@ -110,6 +110,9 @@ class AlignmentPolicy:
 
   enable_fuzzy_alignment: bool = True
   fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD
+  # Prompt validation runs before any model calls; keep fuzzy alignment bounded
+  # so long examples can't dominate runtime.
+  fuzzy_alignment_max_candidates: int | None = 250
   accept_match_lesser: bool = True
 
 
@@ -155,6 +158,7 @@ def validate_prompt_alignment(
         char_offset=0,
         enable_fuzzy_alignment=policy.enable_fuzzy_alignment,
         fuzzy_alignment_threshold=policy.fuzzy_alignment_threshold,
+        fuzzy_alignment_max_candidates=policy.fuzzy_alignment_max_candidates,
         accept_match_lesser=policy.accept_match_lesser,
         tokenizer_impl=tokenizer,
     )

--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -34,10 +34,14 @@ from absl import logging
 from langextract.core import data
 from langextract.core import exceptions
 from langextract.core import format_handler as fh
+from langextract.core import fuzzy_alignment as fuzzy_alignment_lib
 from langextract.core import schema
 from langextract.core import tokenizer as tokenizer_lib
 
 _FUZZY_ALIGNMENT_MIN_THRESHOLD = 0.75
+_FUZZY_ALIGNMENT_EXHAUSTIVE_MAX_WINDOWS = 200_000
+_DEFAULT_FUZZY_ALIGNMENT_MAX_CANDIDATES = 250
+_DEFAULT_FUZZY_ALIGNMENT_MAX_ANCHOR_OCCURRENCES = 64
 
 # Default suffix for extraction index keys (e.g., "entity_index")
 DEFAULT_INDEX_SUFFIX = "_index"  # Suffix for index fields in extraction sorting
@@ -45,6 +49,7 @@ DEFAULT_INDEX_SUFFIX = "_index"  # Suffix for index fields in extraction sorting
 ALIGNMENT_PARAM_KEYS: Final[frozenset[str]] = frozenset({
     "enable_fuzzy_alignment",
     "fuzzy_alignment_threshold",
+    "fuzzy_alignment_max_candidates",
     "accept_match_lesser",
     "suppress_parse_errors",
 })
@@ -128,6 +133,7 @@ class AbstractResolver(abc.ABC):
       char_offset: int | None = None,
       enable_fuzzy_alignment: bool = True,
       fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD,
+      fuzzy_alignment_max_candidates: int | None = None,
       accept_match_lesser: bool = True,
       **kwargs,
   ) -> Iterator[data.Extraction]:
@@ -284,6 +290,7 @@ class Resolver(AbstractResolver):
       char_offset: int | None = None,
       enable_fuzzy_alignment: bool = True,
       fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD,
+      fuzzy_alignment_max_candidates: int | None = None,
       accept_match_lesser: bool = True,
       tokenizer_inst: tokenizer_lib.Tokenizer | None = None,
       **kwargs,
@@ -304,6 +311,8 @@ class Resolver(AbstractResolver):
       enable_fuzzy_alignment: Whether to enable fuzzy alignment fallback.
       fuzzy_alignment_threshold: Minimum overlap ratio required for fuzzy
         alignment.
+      fuzzy_alignment_max_candidates: Optional cap on the number of candidate
+        starts evaluated by the fast-path fuzzy aligner.
       accept_match_lesser: Whether to accept partial exact matches (MATCH_LESSER
         status).
       tokenizer_inst: Optional tokenizer instance.
@@ -331,6 +340,7 @@ class Resolver(AbstractResolver):
         char_offset or 0,
         enable_fuzzy_alignment=enable_fuzzy_alignment,
         fuzzy_alignment_threshold=fuzzy_alignment_threshold,
+        fuzzy_alignment_max_candidates=fuzzy_alignment_max_candidates,
         accept_match_lesser=accept_match_lesser,
         tokenizer_impl=tokenizer_inst,
     )
@@ -543,6 +553,7 @@ class WordAligner:
       char_offset: int,
       fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD,
       tokenizer_impl: tokenizer_lib.Tokenizer | None = None,
+      fuzzy_alignment_max_candidates: int | None = None,
   ) -> data.Extraction | None:
     """Fuzzy-align an extraction using difflib.SequenceMatcher on tokens.
 
@@ -561,6 +572,8 @@ class WordAligner:
       char_offset: The character offset of the current chunk.
       fuzzy_alignment_threshold: The minimum ratio for a fuzzy match.
       tokenizer_impl: Optional tokenizer instance.
+      fuzzy_alignment_max_candidates: Optional cap on the number of candidate
+        starts evaluated by the fast-path fuzzy aligner.
 
     Returns:
       The aligned data.Extraction if successful, None otherwise.
@@ -588,6 +601,57 @@ class WordAligner:
 
     len_e = len(extraction_tokens)
     max_window = len(source_tokens)
+
+    if len_e > max_window:
+      return None
+
+    windows_to_check = (
+        (max_window - len_e + 1) * (max_window - len_e + 2) // 2
+        if max_window >= len_e
+        else 0
+    )
+
+    if windows_to_check > _FUZZY_ALIGNMENT_EXHAUSTIVE_MAX_WINDOWS:
+      max_candidates = (
+          fuzzy_alignment_max_candidates
+          if fuzzy_alignment_max_candidates is not None
+          else _DEFAULT_FUZZY_ALIGNMENT_MAX_CANDIDATES
+      )
+      best = fuzzy_alignment_lib.find_best_fuzzy_span(
+          source_tokens=[_normalize_token(t) for t in source_tokens],
+          extraction_tokens=extraction_tokens_norm,
+          max_candidates=max_candidates,
+          max_anchor_occurrences=_DEFAULT_FUZZY_ALIGNMENT_MAX_ANCHOR_OCCURRENCES,
+      )
+      if best is None:
+        return None
+
+      start_idx, end_idx, matched = best
+      ratio = matched / len_e
+      if ratio < fuzzy_alignment_threshold:
+        return None
+
+      window_size = end_idx - start_idx
+      try:
+        extraction.token_interval = tokenizer_lib.TokenInterval(
+            start_index=start_idx + token_offset,
+            end_index=start_idx + window_size + token_offset,
+        )
+
+        start_token = tokenized_text.tokens[start_idx]
+        end_token = tokenized_text.tokens[start_idx + window_size - 1]
+        extraction.char_interval = data.CharInterval(
+            start_pos=char_offset + start_token.char_interval.start_pos,
+            end_pos=char_offset + end_token.char_interval.end_pos,
+        )
+
+        extraction.alignment_status = data.AlignmentStatus.MATCH_FUZZY
+        return extraction
+      except IndexError:
+        logging.exception(
+            "Index error while setting intervals during fuzzy alignment."
+        )
+        return None
 
     extraction_counts = collections.Counter(extraction_tokens_norm)
     min_overlap = int(len_e * fuzzy_alignment_threshold)
@@ -669,6 +733,7 @@ class WordAligner:
       delim: str = "\u241F",  # Unicode Symbol for unit separator
       enable_fuzzy_alignment: bool = True,
       fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD,
+      fuzzy_alignment_max_candidates: int | None = None,
       accept_match_lesser: bool = True,
       tokenizer_impl: tokenizer_lib.Tokenizer | None = None,
   ) -> Sequence[Sequence[data.Extraction]]:
@@ -695,6 +760,8 @@ class WordAligner:
         fails.
       fuzzy_alignment_threshold: Minimum token overlap ratio for fuzzy alignment
         (0-1).
+      fuzzy_alignment_max_candidates: Optional cap on the number of candidate
+        starts evaluated by the fast-path fuzzy aligner.
       accept_match_lesser: Whether to accept partial exact matches (MATCH_LESSER
         status).
       tokenizer_impl: Optional tokenizer instance.
@@ -854,6 +921,7 @@ class WordAligner:
             char_offset,
             fuzzy_alignment_threshold,
             tokenizer_impl=tokenizer_impl,
+            fuzzy_alignment_max_candidates=fuzzy_alignment_max_candidates,
         )
         if aligned_extraction:
           aligned_extractions.append(aligned_extraction)

--- a/tests/fuzzy_alignment_test.py
+++ b/tests/fuzzy_alignment_test.py
@@ -1,0 +1,58 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for fast fuzzy alignment helpers."""
+
+from absl.testing import absltest
+
+from langextract.core import fuzzy_alignment
+
+
+class FuzzyAlignmentTest(absltest.TestCase):
+
+  def test_greedy_subsequence_match_skips_missing_tokens(self):
+    source = ["a", "b", "c", "d"]
+    positions = fuzzy_alignment.build_token_positions(source)
+
+    matched = fuzzy_alignment.greedy_subsequence_match_positions(
+        ["x", "b", "y", "d"], positions
+    )
+    self.assertEqual(matched, [1, 3])
+
+  def test_generate_candidate_starts_respects_max_candidates(self):
+    source = ["x", "a", "b", "c", "d"]
+    positions = fuzzy_alignment.build_token_positions(source)
+
+    candidates = fuzzy_alignment.generate_candidate_starts(
+        ["a", "b"],
+        positions,
+        max_candidates=1,
+        max_anchor_occurrences=10,
+    )
+    self.assertEqual(candidates, [0])
+
+  def test_find_best_fuzzy_span_prefers_tighter_span_on_tie(self):
+    # Two perfect matches exist: [0..2] spans 3 tokens, [3..4] spans 2 tokens.
+    source = ["a", "x", "b", "a", "b"]
+    best = fuzzy_alignment.find_best_fuzzy_span(
+        source,
+        ["a", "b"],
+        max_candidates=10,
+        max_anchor_occurrences=10,
+    )
+    self.assertEqual(best, (3, 5, 2))
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/prompt_validation_test.py
+++ b/tests/prompt_validation_test.py
@@ -390,6 +390,38 @@ class PromptAlignmentValidationTest(parameterized.TestCase):
     self.assertEqual(report.has_failed, expected_has_failed)
     self.assertEqual(report.has_non_exact, expected_has_non_exact)
 
+  def test_long_examples_do_not_hang_fuzzy_alignment(self):
+    """Regression test for long examples causing very slow fuzzy alignment."""
+    words = [f"w{i}" for i in range(3000)]
+    # Add a plural token that will only match after normalization.
+    words[2500] = "hamstrings"
+    long_text = " ".join(words)
+
+    # Prefix with an out-of-source token so exact/lesser matching won't align.
+    extraction_tokens = ["prefix"] + words[2480:2520]
+    extraction_tokens[1 + (2500 - 2480)] = "hamstring"  # singular form
+    extraction_text = " ".join(extraction_tokens)
+
+    example = data.ExampleData(
+        text=long_text,
+        extractions=[
+            data.Extraction(
+                extraction_class="Quote",
+                extraction_text=extraction_text,
+                attributes={},
+            )
+        ],
+    )
+
+    report = prompt_validation.validate_prompt_alignment([example])
+
+    self.assertFalse(report.has_failed)
+    self.assertTrue(report.has_non_exact)
+    self.assertLen(report.issues, 1)
+    self.assertEqual(
+        report.issues[0].alignment_status, data.AlignmentStatus.MATCH_FUZZY
+    )
+
 
 class ExtractIntegrationTest(absltest.TestCase):
   """Minimal integration test for extract() entry point validation."""


### PR DESCRIPTION
## Summary
- Add a fast-path fuzzy aligner for large token windows to avoid quadratic sliding-window scans.
- Bound prompt-validation fuzzy alignment work with a default `fuzzy_alignment_max_candidates` cap.
- Add focused unit tests covering long-example alignment and helper edge cases.

## Test plan
- [x] `python3 -m pytest -q tests/fuzzy_alignment_test.py tests/prompt_validation_test.py tests/resolver_test.py`

Fixes #277