### PR TITLE
fix(format_handler): treat refusal outputs as empty extractions

### DIFF
--- a/langextract/annotation.py
+++ b/langextract/annotation.py
@@ -40,6 +40,7 @@ from langextract.core import base_model
 from langextract.core import data
 from langextract.core import exceptions
 from langextract.core import format_handler as fh
+from langextract.core import refusal as refusal_lib
 from langextract.core import tokenizer as tokenizer_lib
 
 
@@ -399,9 +400,21 @@ class Annotator:
                 "No scored outputs from language model."
             )
 
+          output_text = scored_outputs[0].output or ""
           resolved_extractions = resolver.resolve(
-              scored_outputs[0].output, debug=debug, **kwargs
+              output_text, debug=debug, **kwargs
           )
+          if (
+              debug
+              and not resolved_extractions
+              and refusal_lib.looks_like_refusal(output_text)
+          ):
+            logging.info(
+                "Chunk produced refusal-like output; treating as empty "
+                "extractions. document_id=%s char_interval=%s",
+                text_chunk.document_id,
+                text_chunk.char_interval,
+            )
 
           token_offset = (
               text_chunk.token_interval.start_index

--- a/langextract/core/format_handler.py
+++ b/langextract/core/format_handler.py
@@ -25,6 +25,7 @@ import yaml
 
 from langextract.core import data
 from langextract.core import exceptions
+from langextract.core import refusal
 
 ExtractionValueType = str | int | float | dict | list | None
 
@@ -72,6 +73,7 @@ class FormatHandler:
       attribute_suffix: str = data.ATTRIBUTE_SUFFIX,
       strict_fences: bool = False,
       allow_top_level_list: bool = True,
+      treat_refusals_as_empty: bool = True,
   ) -> None:
     """Initialize format handler.
 
@@ -89,6 +91,8 @@ class FormatHandler:
         with model output variations.
       allow_top_level_list: Allow top-level list when not strict and
         wrapper not required.
+      treat_refusals_as_empty: If True, treat common refusal/no-entity plain
+        text responses as an empty extraction list.
     """
     self.format_type = format_type
     self.use_wrapper = use_wrapper
@@ -102,6 +106,7 @@ class FormatHandler:
     self.attribute_suffix = attribute_suffix
     self.strict_fences = strict_fences
     self.allow_top_level_list = allow_top_level_list
+    self.treat_refusals_as_empty = treat_refusals_as_empty
 
   def __repr__(self) -> str:
     return (
@@ -110,7 +115,8 @@ class FormatHandler:
         f"wrapper_key={self.wrapper_key!r}, use_fences={self.use_fences}, "
         f"attribute_suffix={self.attribute_suffix!r}, "
         f"strict_fences={self.strict_fences}, "
-        f"allow_top_level_list={self.allow_top_level_list})"
+        f"allow_top_level_list={self.allow_top_level_list}, "
+        f"treat_refusals_as_empty={self.treat_refusals_as_empty})"
     )
 
   def format_extraction_example(
@@ -170,10 +176,14 @@ class FormatHandler:
       raise exceptions.FormatParseError("Empty or invalid input string.")
 
     content = self._extract_content(text)
+    if self.treat_refusals_as_empty and refusal.looks_like_refusal(content):
+      return []
 
     try:
       parsed = self._parse_with_fallback(content, strict)
     except (yaml.YAMLError, json.JSONDecodeError) as e:
+      if self.treat_refusals_as_empty and refusal.looks_like_refusal(content):
+        return []
       msg = (
           f"Failed to parse {self.format_type.value.upper()} content:"
           f" {str(e)[:200]}"
@@ -222,6 +232,8 @@ class FormatHandler:
       # Some models return [...] instead of {"extractions": [...]}.
       items = parsed
     else:
+      if self.treat_refusals_as_empty and refusal.looks_like_refusal(content):
+        return []
       raise exceptions.FormatParseError(
           f"Expected list or dict, got {type(parsed)}"
       )

--- a/langextract/core/refusal.py
+++ b/langextract/core/refusal.py
@@ -1,0 +1,81 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Heuristics for detecting refusal / non-structured model outputs."""
+
+from __future__ import annotations
+
+import re
+
+_THINK_TAG_RE = re.compile(r"<think>[\s\S]*?</think>\s*", re.IGNORECASE)
+_FENCE_LINE_RE = re.compile(r"^\s*```.*$", re.MULTILINE)
+
+_REFUSAL_PHRASES = (
+    "no entities",
+    "no entity",
+    "nothing to extract",
+    "nothing found",
+    "none found",
+    "no relevant",
+    "no relevant entities",
+    "no relevant information",
+    "not found",
+    "not mentioned",
+    "cannot find",
+    "can't find",
+    "unable to find",
+    "i cannot",
+    "i can't",
+    "i am sorry",
+    "i'm sorry",
+    "sorry",
+    "unable to comply",
+    "cannot comply",
+    "can't comply",
+    "refuse",
+    "refused",
+)
+
+_REFUSAL_EXACT = frozenset({"none", "no", "n/a", "na", "null"})
+
+
+def _strip_common_wrappers(text: str) -> str:
+  text = _THINK_TAG_RE.sub("", text)
+  text = _FENCE_LINE_RE.sub("", text)
+  return text.strip()
+
+
+def looks_like_refusal(text: str) -> bool:
+  """Best-effort check for refusal / non-JSON/YAML outputs.
+
+  This is intentionally conservative: it only returns True for short,
+  plain-language responses that resemble common refusal / no-entity replies.
+  """
+  cleaned = _strip_common_wrappers(text)
+  if not cleaned:
+    return False
+
+  lowered = cleaned.lower().strip()
+  if lowered in _REFUSAL_EXACT:
+    return True
+
+  # If the model is attempting structured output, don't treat it as refusal.
+  if any(ch in cleaned for ch in ("{", "}", "[", "]")):
+    return False
+
+  for phrase in _REFUSAL_PHRASES:
+    if phrase in lowered:
+      return True
+
+  return False

--- a/tests/format_handler_test.py
+++ b/tests/format_handler_test.py
@@ -22,6 +22,7 @@ from absl.testing import parameterized
 from langextract import prompting
 from langextract import resolver
 from langextract.core import data
+from langextract.core import exceptions
 from langextract.core import format_handler
 
 
@@ -206,6 +207,62 @@ class FormatHandlerTest(parameterized.TestCase):
     self.assertEqual(
         extractions[0].extraction_text, "Bob", "Extraction text should be 'Bob'"
     )
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="json_refusal_plain_text",
+          handler=format_handler.FormatHandler(
+              format_type=data.FormatType.JSON,
+              use_wrapper=True,
+              wrapper_key="extractions",
+              use_fences=True,
+          ),
+          model_output="No entities found in this chunk.",
+      ),
+      dict(
+          testcase_name="json_refusal_fenced",
+          handler=format_handler.FormatHandler(
+              format_type=data.FormatType.JSON,
+              use_wrapper=True,
+              wrapper_key="extractions",
+              use_fences=True,
+          ),
+          model_output="```json\nI'm sorry, I can't find any entities.\n```",
+      ),
+      dict(
+          testcase_name="yaml_refusal_plain_text",
+          handler=format_handler.FormatHandler(
+              format_type=data.FormatType.YAML,
+              use_wrapper=True,
+              wrapper_key="extractions",
+              use_fences=False,
+          ),
+          model_output="None found.",
+      ),
+  )
+  def test_parse_refusal_returns_empty_list(self, handler, model_output):
+    parsed = handler.parse_output(model_output)
+    self.assertEmpty(parsed)
+
+  def test_parse_non_refusal_plain_text_still_raises(self):
+    handler = format_handler.FormatHandler(
+        format_type=data.FormatType.JSON,
+        use_wrapper=True,
+        wrapper_key="extractions",
+        use_fences=False,
+    )
+    with self.assertRaises(exceptions.FormatParseError):
+      handler.parse_output("Hello world")
+
+  def test_parse_malformed_json_still_raises(self):
+    handler = format_handler.FormatHandler(
+        format_type=data.FormatType.JSON,
+        use_wrapper=True,
+        wrapper_key="extractions",
+        use_fences=False,
+    )
+    with self.assertRaises(exceptions.FormatParseError):
+      handler.parse_output('{"extractions": [')
 
   @parameterized.named_parameters(
       dict(

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -21,6 +21,7 @@ import warnings
 from absl.testing import absltest
 from absl.testing import parameterized
 
+from langextract import prompt_validation
 from langextract import prompting
 import langextract as lx
 from langextract.core import base_model
@@ -154,6 +155,63 @@ class InitTest(parameterized.TestCase):
     )
 
     self.assertDataclassEqual(expected_result, actual_result)
+
+  @mock.patch("langextract.extraction.factory.create_model")
+  def test_extract_treats_refusal_chunks_as_empty(self, mock_create_model):
+    """Chunks that return refusal text should not fail the whole extraction."""
+    mock_model = mock.MagicMock()
+    mock_model.requires_fence_output = False
+    mock_model.schema = None
+
+    good = [[
+        types.ScoredOutput(
+            output=(
+                '{"extractions":[{"entity":"Aspirin","entity_attributes":{}}]}'
+            ),
+            score=1.0,
+        )
+    ]]
+    refusal = [[types.ScoredOutput(output="No entities found.", score=1.0)]]
+
+    calls = {"n": 0}
+
+    def infer_side_effect(batch_prompts, **kwargs):  # pylint: disable=unused-argument
+      calls["n"] += 1
+      return good if calls["n"] == 1 else refusal
+
+    mock_model.infer.side_effect = infer_side_effect
+    mock_create_model.return_value = mock_model
+
+    examples = [
+        lx.data.ExampleData(
+            text="Aspirin helps.",
+            extractions=[
+                lx.data.Extraction(
+                    extraction_class="entity",
+                    extraction_text="Aspirin",
+                    attributes={},
+                )
+            ],
+        )
+    ]
+
+    text = "Aspirin helps. " + ("filler " * 200)
+    result = lx.extract(
+        text_or_documents=text,
+        prompt_description="Extract entities.",
+        examples=examples,
+        api_key="test_key",
+        use_schema_constraints=False,
+        max_char_buffer=20,
+        batch_length=1,
+        show_progress=False,
+        prompt_validation_level=prompt_validation.PromptValidationLevel.OFF,
+    )
+
+    self.assertGreaterEqual(mock_model.infer.call_count, 2)
+    self.assertTrue(
+        any(e.extraction_text == "Aspirin" for e in result.extractions)
+    )
 
   @mock.patch("langextract.extraction.resolver.Resolver.align")
   @mock.patch("langextract.extraction.factory.create_model")


### PR DESCRIPTION
## Summary
- Treat common "no entities" / refusal plain-text outputs as an empty extraction list instead of raising a parse error.
- Add a small refusal detector that strips common wrappers (``` fences / <think> tags).
- Add coverage for refusal, malformed JSON, and a chunked `extract()` regression test.

## Test plan
- [x] `python3 -m pytest -q tests/format_handler_test.py tests/init_test.py`

Fixes #301