### PR TITLE
fix: replace curl with ollama list in Ollama Docker healthcheck

### DIFF
--- a/examples/ollama/docker-compose.yml
+++ b/examples/ollama/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ollama-data:/root/.ollama  # Cross-platform support
     command: serve
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/version"]
+      test: ["CMD", "ollama", "list"]
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## Problem

The Ollama example's `docker-compose.yml` healthcheck uses `curl`, which is not available in the `ollama/ollama` image:

```
exec: "curl": executable file not found in $PATH
```

This causes `docker compose up` to fail with the container marked as unhealthy.

## Fix

Replace `curl -f http://localhost:11434/api/version` with `ollama list`, which is guaranteed to exist in the image and verifies server responsiveness.

Fixes #361