### PR TITLE
Make IssueKind public and export it in __all__

### DIFF
--- a/langextract/prompt_validation.py
+++ b/langextract/prompt_validation.py
@@ -28,6 +28,7 @@ from langextract.core import data
 from langextract.core import tokenizer as tokenizer_lib
 
 __all__ = [
+    "IssueKind",
     "PromptValidationLevel",
     "ValidationIssue",
     "ValidationReport",
@@ -49,8 +50,8 @@ class PromptValidationLevel(enum.Enum):
   ERROR = "error"
 
 
-class _IssueKind(enum.Enum):
-  """Internal categorization of alignment issues."""
+class IssueKind(enum.Enum):
+  """Categorization of alignment issues."""
 
   FAILED = "failed"  # alignment_status is None
   NON_EXACT = "non_exact"  # MATCH_FUZZY or MATCH_LESSER
@@ -65,7 +66,7 @@ class ValidationIssue:
   extraction_class: str
   extraction_text_preview: str
   alignment_status: data.AlignmentStatus | None
-  issue_kind: _IssueKind
+  issue_kind: IssueKind
   char_interval: tuple[int, int] | None = None
   token_interval: tuple[int, int] | None = None
 
@@ -92,12 +93,12 @@ class ValidationReport:
   @property
   def has_failed(self) -> bool:
     """Returns True if any extraction failed to align."""
-    return any(i.issue_kind is _IssueKind.FAILED for i in self.issues)
+    return any(i.issue_kind is IssueKind.FAILED for i in self.issues)
 
   @property
   def has_non_exact(self) -> bool:
     """Returns True if any extraction has non-exact alignment."""
-    return any(i.issue_kind is _IssueKind.NON_EXACT for i in self.issues)
+    return any(i.issue_kind is IssueKind.NON_EXACT for i in self.issues)
 
 
 class PromptAlignmentError(RuntimeError):
@@ -174,7 +175,7 @@ def validate_prompt_alignment(
                 extraction_class=klass,
                 extraction_text_preview=_preview(text),
                 alignment_status=None,
-                issue_kind=_IssueKind.FAILED,
+                issue_kind=IssueKind.FAILED,
                 char_interval=None,
                 token_interval=None,
             )
@@ -200,7 +201,7 @@ def validate_prompt_alignment(
                 extraction_class=klass,
                 extraction_text_preview=_preview(text),
                 alignment_status=status,
-                issue_kind=_IssueKind.NON_EXACT,
+                issue_kind=IssueKind.NON_EXACT,
                 char_interval=char_interval_tuple,
                 token_interval=token_interval_tuple,
             )
@@ -229,7 +230,7 @@ def handle_alignment_report(
     return
 
   for issue in report.issues:
-    if issue.issue_kind is _IssueKind.NON_EXACT:
+    if issue.issue_kind is IssueKind.NON_EXACT:
       logging.warning(
           "Prompt alignment: non-exact match: %s", issue.short_msg()
       )
@@ -239,9 +240,9 @@ def handle_alignment_report(
       )
 
   if level is PromptValidationLevel.ERROR:
-    failed = [i for i in report.issues if i.issue_kind is _IssueKind.FAILED]
+    failed = [i for i in report.issues if i.issue_kind is IssueKind.FAILED]
     non_exact = [
-        i for i in report.issues if i.issue_kind is _IssueKind.NON_EXACT
+        i for i in report.issues if i.issue_kind is IssueKind.NON_EXACT
     ]
 
     if failed:


### PR DESCRIPTION
# Description

Fixes #389

Make IssueKind public and export it in __all__.

The IssueKind enum was private (_IssueKind) but used in the public ValidationIssue.issue_kind field, forcing users to import a private symbol to filter issues. This change makes IssueKind part of the public API.

Changes:
- Renamed _IssueKind to IssueKind (removed leading underscore)
- Added IssueKind to __all__ exports
- Updated docstring from 'Internal categorization' to 'Categorization'
- Updated all internal references from _IssueKind to IssueKind

# How Has This Been Tested?

- Verified that IssueKind is now exported in __all__
- Verified that all internal references were updated from _IssueKind to IssueKind
- The existing test suite passes

# Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Existing tests pass with my changes