### PR TITLE
Add minimal Novita OpenAI-compatible integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,29 @@ result = lx.extract(
 
 Note: OpenAI models require `fence_output=True` and `use_schema_constraints=False` because LangExtract doesn't implement schema constraints for OpenAI yet.
 
+### Using Novita's OpenAI-compatible endpoint
+
+Novita can be used through the built-in OpenAI provider by setting `base_url` to `https://api.novita.ai/openai`.
+
+```python
+import os
+import langextract as lx
+
+result = lx.extract(
+    text_or_documents=input_text,
+    prompt_description=prompt,
+    examples=examples,
+    model_id="deepseek/deepseek-r1",  # Example Novita-served model
+    provider="OpenAILanguageModel",   # Explicit provider for non-gpt model IDs
+    api_key=os.environ.get("NOVITA_API_KEY"),  # optional if env var is set
+    base_url="https://api.novita.ai/openai",
+    fence_output=True,
+    use_schema_constraints=False,
+)
+```
+
+If `base_url` is set to Novita and `api_key` is omitted, LangExtract will automatically use `NOVITA_API_KEY` from the environment.
+
 ## Using Local LLMs with Ollama
 LangExtract supports local inference using Ollama, allowing you to run models without API keys:
 

--- a/langextract/factory.py
+++ b/langextract/factory.py
@@ -66,31 +66,42 @@ def _kwargs_with_environment_defaults(
 
   if "api_key" not in resolved and not resolved.get("vertexai", False):
     model_lower = model_id.lower()
+    base_url = (resolved.get("base_url") or "").lower()
     env_vars_by_provider = {
         "gemini": ("GEMINI_API_KEY", "LANGEXTRACT_API_KEY"),
         "gpt": ("OPENAI_API_KEY", "LANGEXTRACT_API_KEY"),
     }
 
-    for provider_prefix, env_vars in env_vars_by_provider.items():
-      if provider_prefix in model_lower:
-        found_keys = []
-        for env_var in env_vars:
-          key_val = os.getenv(env_var)
-          if key_val:
-            found_keys.append((env_var, key_val))
+    def _set_api_key_from_env(*env_vars: str) -> bool:
+      found_keys = []
+      for env_var in env_vars:
+        key_val = os.getenv(env_var)
+        if key_val:
+          found_keys.append((env_var, key_val))
 
-        if found_keys:
-          resolved["api_key"] = found_keys[0][1]
+      if not found_keys:
+        return False
 
-          if len(found_keys) > 1:
-            keys_list = ", ".join(k[0] for k in found_keys)
-            warnings.warn(
-                f"Multiple API keys detected in environment: {keys_list}. "
-                f"Using {found_keys[0][0]} and ignoring others.",
-                UserWarning,
-                stacklevel=3,
-            )
-        break
+      resolved["api_key"] = found_keys[0][1]
+      if len(found_keys) > 1:
+        keys_list = ", ".join(k[0] for k in found_keys)
+        warnings.warn(
+            f"Multiple API keys detected in environment: {keys_list}. "
+            f"Using {found_keys[0][0]} and ignoring others.",
+            UserWarning,
+            stacklevel=3,
+        )
+      return True
+
+    if "api.novita.ai/openai" in base_url:
+      _set_api_key_from_env(
+          "NOVITA_API_KEY", "OPENAI_API_KEY", "LANGEXTRACT_API_KEY"
+      )
+    else:
+      for provider_prefix, env_vars in env_vars_by_provider.items():
+        if provider_prefix in model_lower:
+          _set_api_key_from_env(*env_vars)
+          break
 
   if "ollama" in model_id.lower() and "base_url" not in resolved:
     resolved["base_url"] = os.getenv(

--- a/tests/factory_test.py
+++ b/tests/factory_test.py
@@ -120,6 +120,24 @@ class FactoryTest(absltest.TestCase):  # pylint: disable=too-many-public-methods
     self.assertEqual(model.api_key, "env-openai-key")
 
   @mock.patch.dict(
+      os.environ,
+      {
+          "NOVITA_API_KEY": "env-novita-key",
+          "OPENAI_API_KEY": "env-openai-key",
+      },
+  )
+  def test_novita_base_url_prefers_novita_api_key_from_environment(self):
+    """Factory should use NOVITA_API_KEY for Novita OpenAI-compatible endpoints."""
+    config = factory.ModelConfig(
+        model_id="deepseek/deepseek-r1",
+        provider="FakeOpenAIProvider",
+        provider_kwargs={"base_url": "https://api.novita.ai/openai"},
+    )
+
+    model = factory.create_model(config)
+    self.assertEqual(model.api_key, "env-novita-key")
+
+  @mock.patch.dict(
       os.environ, {"LANGEXTRACT_API_KEY": "env-langextract-key"}, clear=True
   )
   def test_falls_back_to_langextract_api_key_when_provider_key_missing(self):


### PR DESCRIPTION
## Summary
- add Novita API key auto-resolution in factory when `base_url` targets `https://api.novita.ai/openai`
- add a factory unit test validating `NOVITA_API_KEY` precedence for Novita base URL
- document Novita usage via explicit OpenAI provider and base URL in README

## Why
Novita is OpenAI-compatible. This keeps integration minimal by reusing the existing OpenAI provider while improving setup ergonomics.

## Testing
- `uv run --extra test python -m pytest tests/factory_test.py -q`
