### PR TITLE
fix(gemini): allow thinking_config passthrough

### DIFF
--- a/langextract/providers/gemini.py
+++ b/langextract/providers/gemini.py
@@ -45,6 +45,7 @@ _API_CONFIG_KEYS: Final[set[str]] = {
     'tools',
     'stop_sequences',
     'candidate_count',
+    'thinking_config',
 }
 
 
@@ -125,8 +126,9 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
         Gemini handles this based on schema).
       **kwargs: Additional Gemini API parameters. Only allowlisted keys are
         forwarded to the API (response_schema, response_mime_type, tools,
-        safety_settings, stop_sequences, candidate_count, system_instruction).
-        See https://ai.google.dev/api/generate-content for details.
+        safety_settings, stop_sequences, candidate_count,
+        system_instruction, thinking_config). See
+        https://ai.google.dev/api/generate-content for details.
     """
     try:
       # pylint: disable=import-outside-toplevel

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -363,6 +363,7 @@ class TestGeminiLanguageModel(absltest.TestCase):
         tools=["tool1", "tool2"],
         stop_sequences=["\n\n"],
         system_instruction="Be helpful",
+        thinking_config={"thinking_level": "minimal"},
         # Unknown parameters to test filtering
         unknown_param="should_be_ignored",
         another_unknown="also_ignored",
@@ -372,6 +373,7 @@ class TestGeminiLanguageModel(absltest.TestCase):
         "tools": ["tool1", "tool2"],
         "stop_sequences": ["\n\n"],
         "system_instruction": "Be helpful",
+        "thinking_config": {"thinking_level": "minimal"},
     }
     self.assertEqual(
         expected_extra_kwargs,
@@ -386,7 +388,12 @@ class TestGeminiLanguageModel(absltest.TestCase):
     call_args = mock_client.models.generate_content.call_args
     config = call_args.kwargs["config"]
 
-    for key in ["tools", "stop_sequences", "system_instruction"]:
+    for key in [
+        "tools",
+        "stop_sequences",
+        "system_instruction",
+        "thinking_config",
+    ]:
       self.assertIn(key, config, f"Expected {key} to be in API config")
       self.assertEqual(
           expected_extra_kwargs[key],
@@ -415,6 +422,7 @@ class TestGeminiLanguageModel(absltest.TestCase):
             prompts,
             candidate_count=2,
             safety_settings={"HARM_CATEGORY_DANGEROUS": "BLOCK_NONE"},
+            thinking_config={"thinking_level": "minimal"},
             unknown_runtime_param="ignored",
         )
     )
@@ -431,6 +439,11 @@ class TestGeminiLanguageModel(absltest.TestCase):
         {"HARM_CATEGORY_DANGEROUS": "BLOCK_NONE"},
         config.get("safety_settings"),
         "safety_settings should be passed through to API",
+    )
+    self.assertEqual(
+        {"thinking_level": "minimal"},
+        config.get("thinking_config"),
+        "thinking_config should be passed through to API",
     )
     self.assertNotIn(
         "unknown_runtime_param", config, "Unknown kwargs should be filtered out"


### PR DESCRIPTION
# Description

Add `thinking_config` to the Gemini provider allowlist so `language_model_params={"thinking_config": ...}` survives `GeminiLanguageModel.__init__` filtering and is forwarded to the Gemini API. This also updates the provider docstring and adds regression coverage for both constructor-time and runtime passthrough.

Fixes #319

Bug fix

# How Has This Been Tested?

- `uv run --extra openai --extra test pytest tests/inference_test.py -k gemini`

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [ ] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes.
- [ ] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.

<!-- draft rerun trigger -->
