### PR TITLE
Fix progress bar cleanup on streaming failures

### DIFF
--- a/langextract/io.py
+++ b/langextract/io.py
@@ -117,18 +117,19 @@ def save_annotated_documents(
       output_path=str(output_file), disable=not show_progress
   )
 
-  with open(output_file, 'w', encoding='utf-8') as f:
-    for adoc in annotated_documents:
-      if not adoc.document_id:
-        continue
+  try:
+    with open(output_file, 'w', encoding='utf-8') as f:
+      for adoc in annotated_documents:
+        if not adoc.document_id:
+          continue
 
-      doc_dict = data_lib.annotated_document_to_dict(adoc)
-      f.write(json.dumps(doc_dict, ensure_ascii=False) + '\n')
-      has_data = True
-      doc_count += 1
-      progress_bar.update(1)
-
-  progress_bar.close()
+        doc_dict = data_lib.annotated_document_to_dict(adoc)
+        f.write(json.dumps(doc_dict, ensure_ascii=False) + '\n')
+        has_data = True
+        doc_count += 1
+        progress_bar.update(1)
+  finally:
+    progress_bar.close()
 
   if not has_data:
     raise InvalidDatasetError(f'No documents to save in: {output_file}')
@@ -305,12 +306,13 @@ def download_text_from_url(
           total_size=total_size, url=url
       )
 
-      for chunk in response.iter_content(chunk_size=chunk_size):
-        if chunk:
-          chunks.append(chunk)
-          progress_bar.update(len(chunk))
-
-      progress_bar.close()
+      try:
+        for chunk in response.iter_content(chunk_size=chunk_size):
+          if chunk:
+            chunks.append(chunk)
+            progress_bar.update(len(chunk))
+      finally:
+        progress_bar.close()
     else:
       # Download without progress bar
       for chunk in response.iter_content(chunk_size=chunk_size):

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for langextract.io module."""
+
+import pathlib
+import tempfile
+from unittest import mock
+
+import pytest
+import requests
+
+from langextract import io
+from langextract.core import data
+
+
+def test_save_annotated_documents_closes_progress_bar_on_exception():
+  """save_annotated_documents closes the progress bar on iteration errors."""
+  progress_bar = mock.Mock()
+
+  def annotated_documents():
+    yield data.AnnotatedDocument(document_id="doc-1", text="hello")
+    raise RuntimeError("boom")
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+    with mock.patch.object(
+        io.progress,
+        "create_save_progress_bar",
+        return_value=progress_bar,
+    ):
+      with pytest.raises(RuntimeError, match="boom"):
+        io.save_annotated_documents(
+            annotated_documents(),
+            output_dir=pathlib.Path(tmpdir),
+            show_progress=True,
+        )
+
+  progress_bar.update.assert_called_once_with(1)
+  progress_bar.close.assert_called_once_with()
+
+
+def test_download_text_from_url_closes_progress_bar_on_stream_exception():
+  """download_text_from_url closes the progress bar on stream errors."""
+  progress_bar = mock.Mock()
+  response = mock.Mock()
+  response.headers = {
+      "Content-Type": "text/plain",
+      "Content-Length": "10",
+  }
+  response.raise_for_status.return_value = None
+
+  def iter_content(chunk_size):
+    del chunk_size
+    yield b"hello"
+    raise requests.RequestException("stream failed")
+
+  response.iter_content.side_effect = iter_content
+
+  with mock.patch.object(io.requests, "get", return_value=response):
+    with mock.patch.object(
+        io.progress,
+        "create_download_progress_bar",
+        return_value=progress_bar,
+    ):
+      with pytest.raises(requests.RequestException, match="stream failed"):
+        io.download_text_from_url("https://example.com/file.txt")
+
+  progress_bar.update.assert_called_once_with(5)
+  progress_bar.close.assert_called_once_with()


### PR DESCRIPTION
# Description

Fix progress bar cleanup in two failure paths inside `langextract/io.py`.

- `save_annotated_documents()` now closes the save progress bar even if the input iterator raises mid-write.
- `download_text_from_url()` now closes the download progress bar even if `response.iter_content()` raises during streaming.

This keeps terminal state clean and avoids leaving tqdm resources open on exception paths.

Fixes #401

# How Has This Been Tested?

- Added `tests/io_test.py`
- Ran `pytest -q tests/io_test.py tests/progress_test.py`

# Checklist

- [x] Focused bug fix
- [x] Added regression tests
- [x] Verified locally
