### PR TITLE
fix: close progress bars on exception in io.py

### DIFF
--- a/langextract/io.py
+++ b/langextract/io.py
@@ -117,18 +117,19 @@ def save_annotated_documents(
       output_path=str(output_file), disable=not show_progress
   )
 
-  with open(output_file, 'w', encoding='utf-8') as f:
-    for adoc in annotated_documents:
-      if not adoc.document_id:
-        continue
+  try:
+    with open(output_file, 'w', encoding='utf-8') as f:
+      for adoc in annotated_documents:
+        if not adoc.document_id:
+          continue
 
-      doc_dict = data_lib.annotated_document_to_dict(adoc)
-      f.write(json.dumps(doc_dict, ensure_ascii=False) + '\n')
-      has_data = True
-      doc_count += 1
-      progress_bar.update(1)
-
-  progress_bar.close()
+        doc_dict = data_lib.annotated_document_to_dict(adoc)
+        f.write(json.dumps(doc_dict, ensure_ascii=False) + '\n')
+        has_data = True
+        doc_count += 1
+        progress_bar.update(1)
+  finally:
+    progress_bar.close()
 
   if not has_data:
     raise InvalidDatasetError(f'No documents to save in: {output_file}')
@@ -305,12 +306,13 @@ def download_text_from_url(
           total_size=total_size, url=url
       )
 
-      for chunk in response.iter_content(chunk_size=chunk_size):
-        if chunk:
-          chunks.append(chunk)
-          progress_bar.update(len(chunk))
-
-      progress_bar.close()
+      try:
+        for chunk in response.iter_content(chunk_size=chunk_size):
+          if chunk:
+            chunks.append(chunk)
+            progress_bar.update(len(chunk))
+      finally:
+        progress_bar.close()
     else:
       # Download without progress bar
       for chunk in response.iter_content(chunk_size=chunk_size):


### PR DESCRIPTION
# Description

Wrap `tqdm` progress bar usage in `try/finally` blocks in two functions in `langextract/io.py` so that `progress_bar.close()` is always called, even when an exception is raised mid-iteration.

**Location 1 — `save_annotated_documents`:** If the `annotated_documents` generator raises (e.g. an `InferenceOutputError` from a failed LLM call), the original code left the progress bar open since `progress_bar.close()` sat unconditionally after the `with open(...)` block.

**Location 2 — `download_text_from_url`:** If `response.iter_content()` raises a `requests.RequestException` (e.g. a connection reset mid-download), the `except` block re-raised without calling `progress_bar.close()`.

Fixes #401

Bug fix

# How Has This Been Tested?

Ran the existing test suite (excluding the pre-existing `openai` import failure unrelated to this change):

```
$ python -m pytest tests/ -q --ignore=tests/inference_test.py
364 passed, 76 warnings, 29 subtests passed
```

Also manually verified with a generator that raises mid-stream — confirmed `progress_bar.close()` is called in both the exception and success paths.

# Checklist:

-   [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [ ] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
-   [ ] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
-   [ ] I have added tests, or I have ensured existing tests cover the changes
-   [ ] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.