### PR TITLE
fix: make IssueKind public and export it in __all__

### DIFF
--- a/langextract/prompt_validation.py
+++ b/langextract/prompt_validation.py
@@ -28,6 +28,7 @@ from langextract.core import data
 from langextract.core import tokenizer as tokenizer_lib
 
 __all__ = [
+    "IssueKind",
     "PromptValidationLevel",
     "ValidationIssue",
     "ValidationReport",
@@ -49,8 +50,8 @@ class PromptValidationLevel(enum.Enum):
   ERROR = "error"
 
 
-class _IssueKind(enum.Enum):
-  """Internal categorization of alignment issues."""
+class IssueKind(enum.Enum):
+  """Categorization of alignment issues."""
 
   FAILED = "failed"  # alignment_status is None
   NON_EXACT = "non_exact"  # MATCH_FUZZY or MATCH_LESSER
@@ -65,7 +66,7 @@ class ValidationIssue:
   extraction_class: str
   extraction_text_preview: str
   alignment_status: data.AlignmentStatus | None
-  issue_kind: _IssueKind
+  issue_kind: IssueKind
   char_interval: tuple[int, int] | None = None
   token_interval: tuple[int, int] | None = None
 
@@ -92,12 +93,12 @@ class ValidationReport:
   @property
   def has_failed(self) -> bool:
     """Returns True if any extraction failed to align."""
-    return any(i.issue_kind is _IssueKind.FAILED for i in self.issues)
+    return any(i.issue_kind is IssueKind.FAILED for i in self.issues)
 
   @property
   def has_non_exact(self) -> bool:
     """Returns True if any extraction has non-exact alignment."""
-    return any(i.issue_kind is _IssueKind.NON_EXACT for i in self.issues)
+    return any(i.issue_kind is IssueKind.NON_EXACT for i in self.issues)
 
 
 class PromptAlignmentError(RuntimeError):
@@ -174,7 +175,7 @@ def validate_prompt_alignment(
                 extraction_class=klass,
                 extraction_text_preview=_preview(text),
                 alignment_status=None,
-                issue_kind=_IssueKind.FAILED,
+                issue_kind=IssueKind.FAILED,
                 char_interval=None,
                 token_interval=None,
             )
@@ -200,7 +201,7 @@ def validate_prompt_alignment(
                 extraction_class=klass,
                 extraction_text_preview=_preview(text),
                 alignment_status=status,
-                issue_kind=_IssueKind.NON_EXACT,
+                issue_kind=IssueKind.NON_EXACT,
                 char_interval=char_interval_tuple,
                 token_interval=token_interval_tuple,
             )
@@ -229,7 +230,7 @@ def handle_alignment_report(
     return
 
   for issue in report.issues:
-    if issue.issue_kind is _IssueKind.NON_EXACT:
+    if issue.issue_kind is IssueKind.NON_EXACT:
       logging.warning(
           "Prompt alignment: non-exact match: %s", issue.short_msg()
       )
@@ -239,9 +240,9 @@ def handle_alignment_report(
       )
 
   if level is PromptValidationLevel.ERROR:
-    failed = [i for i in report.issues if i.issue_kind is _IssueKind.FAILED]
+    failed = [i for i in report.issues if i.issue_kind is IssueKind.FAILED]
     non_exact = [
-        i for i in report.issues if i.issue_kind is _IssueKind.NON_EXACT
+        i for i in report.issues if i.issue_kind is IssueKind.NON_EXACT
     ]
 
     if failed:


### PR DESCRIPTION
# Description

Rename `_IssueKind` → `IssueKind` (drop the leading underscore) and add it to `__all__` in `prompt_validation.py`.

`ValidationIssue.issue_kind` is a public field typed as `_IssueKind`, a private enum not included in `__all__`. This forces users to import a private symbol to filter individual issues:

```python
# Before (accessing private symbol)
from langextract.prompt_validation import _IssueKind
failed = [i for i in report.issues if i.issue_kind == _IssueKind.FAILED]

# After (clean public API)
from langextract.prompt_validation import IssueKind
failed = [i for i in report.issues if i.issue_kind == IssueKind.FAILED]
```

Fixes #389

Bug fix

# How Has This Been Tested?

```
$ pytest tests/prompt_validation_test.py -q
15 passed in 1.18s

$ pytest tests/ -q --ignore=tests/inference_test.py
370 passed, 76 warnings, 29 subtests passed
```

# Checklist:

-   [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.