### PR TITLE
fix: pass reasoning_effort directly to OpenAI API

### DIFF
--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -114,28 +114,12 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
     )
     self._extra_kwargs = kwargs or {}
 
-  def _normalize_reasoning_params(self, config: dict) -> dict:
-    """Normalize reasoning parameters for API compatibility.
-
-    Converts flat 'reasoning_effort' to nested 'reasoning' structure.
-    Merges with existing reasoning dict if present.
-    """
-    result = config.copy()
-
-    if 'reasoning_effort' in result:
-      effort = result.pop('reasoning_effort')
-      reasoning = result.get('reasoning', {}) or {}
-      reasoning.setdefault('effort', effort)
-      result['reasoning'] = reasoning
-
-    return result
-
   def _process_single_prompt(
       self, prompt: str, config: dict
   ) -> core_types.ScoredOutput:
     """Process a single prompt and return a ScoredOutput."""
     try:
-      normalized_config = self._normalize_reasoning_params(config)
+      normalized_config = config.copy()
 
       system_message = ''
       if self.format_type == data.FormatType.JSON:
@@ -175,7 +159,7 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
           'stop',
           'logprobs',
           'top_logprobs',
-          'reasoning',
+          'reasoning_effort',
           'response_format',
       ]:
         if (v := normalized_config.get(key)) is not None:
@@ -225,7 +209,6 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
         'logprobs',
         'top_logprobs',
         'reasoning_effort',
-        'reasoning',
         'response_format',
     ]:
       if key in merged_kwargs:

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -768,6 +768,29 @@ class TestOpenAILanguageModel(absltest.TestCase):
     self.assertEqual(messages[0]["role"], "user")
     self.assertEqual(messages[0]["content"], "test prompt")
 
+  @mock.patch("openai.OpenAI", autospec=True)
+  def test_openai_reasoning_effort_passed_directly(self, mock_openai_class):
+    """reasoning_effort is passed as a top-level API parameter."""
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai.OpenAILanguageModel(
+        api_key="test-key",
+        reasoning_effort="low",
+    )
+
+    list(model.infer(["test prompt"]))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(call_args.kwargs["reasoning_effort"], "low")
+    self.assertNotIn("reasoning", call_args.kwargs)
+
   @mock.patch("google.genai.Client")
   def test_gemini_none_values_filtered(self, mock_client_class):
     """Test that None values are not passed to Gemini API."""

--- a/tests/test_kwargs_passthrough.py
+++ b/tests/test_kwargs_passthrough.py
@@ -28,8 +28,8 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
   """Test OpenAI provider's enhanced kwargs handling."""
 
   @mock.patch('openai.OpenAI')
-  def test_reasoning_effort_alias_normalization(self, mock_openai_class):
-    """Reasoning_effort parameter should be normalized to {reasoning: {effort: ...}}."""
+  def test_reasoning_effort_passed_as_top_level(self, mock_openai_class):
+    """reasoning_effort is passed as a top-level Chat Completions parameter."""
     mock_client = mock.Mock()
     mock_openai_class.return_value = mock_client
 
@@ -42,17 +42,18 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
     model = openai.OpenAILanguageModel(
         model_id='gpt-4o-mini',
         api_key='test-key',
-        reasoning_effort='minimal',
+        reasoning_effort='low',
     )
 
     list(model.infer(['test prompt']))
 
     call_args = mock_client.chat.completions.create.call_args
-    self.assertEqual(call_args.kwargs.get('reasoning'), {'effort': 'minimal'})
+    self.assertEqual(call_args.kwargs.get('reasoning_effort'), 'low')
+    self.assertNotIn('reasoning', call_args.kwargs)
 
   @mock.patch('openai.OpenAI')
-  def test_reasoning_parameter_normalized(self, mock_openai_class):
-    """Runtime reasoning_effort should normalize even without constructor param."""
+  def test_runtime_reasoning_effort_override(self, mock_openai_class):
+    """Runtime reasoning_effort overrides constructor value."""
     mock_client = mock.Mock()
     mock_openai_class.return_value = mock_client
 
@@ -63,14 +64,15 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
     mock_client.chat.completions.create.return_value = mock_response
 
     model = openai.OpenAILanguageModel(
-        model_id='gpt-5-nano',
+        model_id='o4-mini',
         api_key='test-key',
+        reasoning_effort='low',
     )
 
-    list(model.infer(['test prompt'], reasoning_effort='maximal'))
+    list(model.infer(['test prompt'], reasoning_effort='high'))
 
     call_args = mock_client.chat.completions.create.call_args
-    self.assertEqual(call_args.kwargs.get('reasoning'), {'effort': 'maximal'})
+    self.assertEqual(call_args.kwargs.get('reasoning_effort'), 'high')
 
   @mock.patch('openai.OpenAI')
   def test_runtime_kwargs_override_stored(self, mock_openai_class):
@@ -124,8 +126,8 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
     self.assertEqual(call_args.kwargs.get('top_logprobs'), 0)
 
   @mock.patch('openai.OpenAI')
-  def test_both_reasoning_forms_merge(self, mock_openai_class):
-    """Both reasoning and reasoning_effort should merge without clobbering."""
+  def test_reasoning_effort_not_nested(self, mock_openai_class):
+    """reasoning_effort should not be converted to a nested reasoning dict."""
     mock_client = mock.Mock()
     mock_openai_class.return_value = mock_client
 
@@ -136,19 +138,16 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
     mock_client.chat.completions.create.return_value = mock_response
 
     model = openai.OpenAILanguageModel(
-        model_id='gpt-5',
+        model_id='o4-mini',
         api_key='test-key',
-        reasoning={'other_field': 'value'},
-        reasoning_effort='maximal',
+        reasoning_effort='medium',
     )
 
     list(model.infer(['test prompt']))
 
     call_args = mock_client.chat.completions.create.call_args
-    self.assertEqual(
-        call_args.kwargs.get('reasoning'),
-        {'other_field': 'value', 'effort': 'maximal'},
-    )
+    self.assertEqual(call_args.kwargs.get('reasoning_effort'), 'medium')
+    self.assertNotIn('reasoning', call_args.kwargs)
 
   @mock.patch('openai.OpenAI')
   def test_custom_response_format(self, mock_openai_class):
@@ -182,8 +181,8 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
     )
 
   @mock.patch('openai.OpenAI')
-  def test_direct_reasoning_parameter(self, mock_openai_class):
-    """Direct reasoning parameter should pass through without modification."""
+  def test_reasoning_not_in_chat_completions(self, mock_openai_class):
+    """reasoning dict is not forwarded to Chat Completions API."""
     mock_client = mock.Mock()
     mock_openai_class.return_value = mock_client
 
@@ -194,14 +193,14 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
     mock_client.chat.completions.create.return_value = mock_response
 
     model = openai.OpenAILanguageModel(
-        model_id='gpt-5',
+        model_id='o4-mini',
         api_key='test-key',
     )
 
-    list(model.infer(['test prompt'], reasoning={'effort': 'minimal'}))
+    list(model.infer(['test prompt'], reasoning={'effort': 'low'}))
 
     call_args = mock_client.chat.completions.create.call_args
-    self.assertEqual(call_args.kwargs.get('reasoning'), {'effort': 'minimal'})
+    self.assertNotIn('reasoning', call_args.kwargs)
 
 
 class TestOllamaAuthSupport(parameterized.TestCase):

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -1007,3 +1007,31 @@ class TestLiveAPIOpenAI(unittest.TestCase):
       assert any(
           c in extraction_classes for c in [_CLASS_DOSAGE, "dose"]
       ), f"{med_name} group missing dosage"
+
+  @skip_if_no_openai
+  @live_api
+  @retry_on_transient_errors(max_retries=2)
+  def test_reasoning_effort_passthrough(self):
+    """reasoning_effort is accepted by reasoning models."""
+    examples = get_basic_medication_examples()
+    input_text = "Patient took 400 mg PO Ibuprofen q4h for two days."
+
+    config = lx.factory.ModelConfig(
+        model_id="o4-mini",
+        provider="OpenAILanguageModel",
+        provider_kwargs={
+            "api_key": OPENAI_API_KEY,
+            "reasoning_effort": "low",
+        },
+    )
+
+    result = lx.extract(
+        text_or_documents=input_text,
+        prompt_description="Extract medications.",
+        examples=examples,
+        config=config,
+        use_schema_constraints=False,
+    )
+
+    assert result is not None
+    self.assertIsInstance(result, lx.data.AnnotatedDocument)


### PR DESCRIPTION
## Summary
Fix `reasoning_effort` being incorrectly nested into `reasoning: {effort: ...}` (Responses API shape) instead of passed as a top-level Chat Completions parameter.

- Pass `reasoning_effort` directly to `chat.completions.create()`
- Remove `_normalize_reasoning_params()` and `reasoning` dict passthrough
- Update legacy kwargs tests to match new behavior

## Test Plan
- Unit test for direct passthrough
- Live API test with `o4-mini`
- Updated 4 legacy reasoning kwargs tests

Fixes #237