### PR TITLE
fix: normalize trailing-colon keys in resolver to prevent ValueError on non-Gemini models

### DIFF
--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -415,7 +415,25 @@ class Resolver(AbstractResolver):
     index_suffix = self.extraction_index_suffix
     attributes_suffix = self.format_handler.attribute_suffix
 
-    for group_index, group in enumerate(extraction_data):
+    for group_index, raw_group in enumerate(extraction_data):
+      # Normalize keys with trailing punctuation (e.g. "emotion_attributes:"
+      # instead of "emotion_attributes") that some non-Gemini models emit.
+      # Build a normalized dict so that subsequent lookups (for index and
+      # attributes companion keys) also work correctly.
+      group = {}
+      for raw_key, value in raw_group.items():
+        normalized_key = raw_key.rstrip(":")
+        if normalized_key != raw_key:
+          logging.debug(
+              "Normalized key %r -> %r (stripped trailing colon).",
+              raw_key,
+              normalized_key,
+          )
+        # If both "emotion_attributes" and "emotion_attributes:" exist in
+        # the same group, the first one wins (preserves clean key priority).
+        if normalized_key not in group:
+          group[normalized_key] = value
+
       for extraction_class, extraction_value in group.items():
         if index_suffix and extraction_class.endswith(index_suffix):
           if not isinstance(extraction_value, int):

--- a/tests/resolver_test.py
+++ b/tests/resolver_test.py
@@ -1868,26 +1868,13 @@ class ResolverTest(parameterized.TestCase):
     with self.assertRaises(resolver_lib.ResolverParsingError):
       self.default_resolver.resolve(test_input, suppress_parse_errors=False)
 
-  @parameterized.named_parameters(
-      dict(
-          testcase_name="non_dict_attributes",
-          test_input=(
-              '```json\n{"extractions":'
-              ' [{"entity": "test", "entity_index": 1,'
-              ' "entity_attributes": "bad"}]}\n```'
-          ),
-      ),
-      dict(
-          testcase_name="malformed_key_trailing_colon",
-          test_input=(
-              '```json\n{"extractions":'
-              ' [{"emotion": "joy", "emotion_index": 1,'
-              ' "emotion_attributes:": {"intensity": "high"}}]}\n```'
-          ),
-      ),
-  )
-  def test_resolve_schema_error_suppressed(self, test_input):
+  def test_resolve_schema_error_suppressed(self):
     """Schema errors are suppressed with warning-only logging."""
+    test_input = (
+        '```json\n{"extractions":'
+        ' [{"entity": "test", "entity_index": 1,'
+        ' "entity_attributes": "bad"}]}\n```'
+    )
     with mock.patch("langextract.resolver.logging") as mock_log:
       actual = self.default_resolver.resolve(
           test_input, suppress_parse_errors=True
@@ -1897,6 +1884,24 @@ class ResolverTest(parameterized.TestCase):
       log_msg = mock_log.warning.call_args[0][0]
       self.assertIn("schema error", log_msg)
       mock_log.error.assert_not_called()
+
+  def test_resolve_normalizes_trailing_colon_keys_when_suppressed(self):
+    """Trailing-colon companion keys are normalized instead of dropped."""
+    test_input = (
+        '```json\n{"extractions":'
+        ' [{"emotion": "joy", "emotion_index": 1,'
+        ' "emotion_attributes:": {"intensity": "high"}}]}\n```'
+    )
+
+    actual = self.default_resolver.resolve(
+        test_input, suppress_parse_errors=True
+    )
+
+    self.assertLen(actual, 1)
+    self.assertEqual(actual[0].extraction_class, "emotion")
+    self.assertEqual(actual[0].extraction_text, "joy")
+    self.assertEqual(actual[0].extraction_index, 1)
+    self.assertEqual(actual[0].attributes, {"intensity": "high"})
 
   def test_resolve_schema_error_raises_without_suppression(self):
     """Malformed attributes raise ResolverParsingError when not suppressed."""

--- a/tests/test_resolver_malformed_keys.py
+++ b/tests/test_resolver_malformed_keys.py
@@ -34,231 +34,232 @@ def _make_resolver(
     attribute_suffix: str = data.ATTRIBUTE_SUFFIX,
     index_suffix: str | None = None,
 ) -> resolver_lib.Resolver:
-    handler = fh.FormatHandler(
-        format_type=data.FormatType.YAML,
-        use_wrapper=True,
-        wrapper_key=data.EXTRACTIONS_KEY,
-        use_fences=False,
-        attribute_suffix=attribute_suffix,
-    )
-    return resolver_lib.Resolver(
-        format_handler=handler,
-        extraction_index_suffix=index_suffix,
-    )
+  handler = fh.FormatHandler(
+      format_type=data.FormatType.YAML,
+      use_wrapper=True,
+      wrapper_key=data.EXTRACTIONS_KEY,
+      use_fences=False,
+      attribute_suffix=attribute_suffix,
+  )
+  return resolver_lib.Resolver(
+      format_handler=handler,
+      extraction_index_suffix=index_suffix,
+  )
 
 
 class MalformedAttributeKeyTest(parameterized.TestCase):
-    """Verifies that trailing-colon keys are normalized before matching."""
+  """Verifies that trailing-colon keys are normalized before matching."""
 
-    # ── core regression test (issue #428) ──────────────────────────────
+  # ── core regression test (issue #428) ──────────────────────────────
 
-    def test_trailing_colon_on_attributes_key_does_not_crash(self):
-        """A key like 'emotion_attributes:' should be recognized as attributes."""
-        resolver = _make_resolver()
-        extraction_data = [
-            {
-                "emotion": "But soft!",
-                # Malformed key with trailing colon
-                "emotion_attributes:": {
-                    "feeling": "gentle awe",
-                    "character": "Romeo",
-                },
+  def test_trailing_colon_on_attributes_key_does_not_crash(self):
+    """A key like 'emotion_attributes:' should be recognized as attributes."""
+    resolver = _make_resolver()
+    extraction_data = [
+        {
+            "emotion": "But soft!",
+            # Malformed key with trailing colon
+            "emotion_attributes:": {
+                "feeling": "gentle awe",
+                "character": "Romeo",
             },
-        ]
-        results = resolver.extract_ordered_extractions(extraction_data)
-        self.assertLen(results, 1)
-        self.assertEqual(results[0].extraction_class, "emotion")
-        self.assertEqual(results[0].extraction_text, "But soft!")
-        self.assertEqual(results[0].attributes, {
+        },
+    ]
+    results = resolver.extract_ordered_extractions(extraction_data)
+    self.assertLen(results, 1)
+    self.assertEqual(results[0].extraction_class, "emotion")
+    self.assertEqual(results[0].extraction_text, "But soft!")
+    self.assertEqual(
+        results[0].attributes,
+        {
             "feeling": "gentle awe",
             "character": "Romeo",
-        })
+        },
+    )
 
-    def test_trailing_colon_on_index_key_does_not_crash(self):
-        """A key like 'emotion_index:' should be recognized as an index."""
-        resolver = _make_resolver(index_suffix="_index")
-        extraction_data = [
-            {
-                "emotion": "But soft!",
-                "emotion_attributes": {"feeling": "awe"},
-                # Malformed index key with trailing colon
-                "emotion_index:": 1,
-            },
-        ]
-        results = resolver.extract_ordered_extractions(extraction_data)
-        self.assertLen(results, 1)
-        self.assertEqual(results[0].extraction_text, "But soft!")
-        self.assertEqual(results[0].extraction_index, 1)
+  def test_trailing_colon_on_index_key_does_not_crash(self):
+    """A key like 'emotion_index:' should be recognized as an index."""
+    resolver = _make_resolver(index_suffix="_index")
+    extraction_data = [
+        {
+            "emotion": "But soft!",
+            "emotion_attributes": {"feeling": "awe"},
+            # Malformed index key with trailing colon
+            "emotion_index:": 1,
+        },
+    ]
+    results = resolver.extract_ordered_extractions(extraction_data)
+    self.assertLen(results, 1)
+    self.assertEqual(results[0].extraction_text, "But soft!")
+    self.assertEqual(results[0].extraction_index, 1)
 
-    def test_trailing_colon_on_extraction_class_key(self):
-        """'character:' (extraction class with colon) is normalized to 'character'."""
-        resolver = _make_resolver()
-        extraction_data = [
-            {
-                # Malformed extraction class key
-                "character:": "ROMEO",
-                "character_attributes": {"emotional_state": "wonder"},
-            },
-        ]
-        results = resolver.extract_ordered_extractions(extraction_data)
-        self.assertLen(results, 1)
-        self.assertEqual(results[0].extraction_class, "character")
-        self.assertEqual(results[0].extraction_text, "ROMEO")
-        self.assertEqual(
-            results[0].attributes, {"emotional_state": "wonder"}
-        )
+  def test_trailing_colon_on_extraction_class_key(self):
+    """'character:' (extraction class with colon) is normalized to 'character'."""
+    resolver = _make_resolver()
+    extraction_data = [
+        {
+            # Malformed extraction class key
+            "character:": "ROMEO",
+            "character_attributes": {"emotional_state": "wonder"},
+        },
+    ]
+    results = resolver.extract_ordered_extractions(extraction_data)
+    self.assertLen(results, 1)
+    self.assertEqual(results[0].extraction_class, "character")
+    self.assertEqual(results[0].extraction_text, "ROMEO")
+    self.assertEqual(results[0].attributes, {"emotional_state": "wonder"})
 
-    # ── verifying correct keys still work ──────────────────────────────
+  # ── verifying correct keys still work ──────────────────────────────
 
-    def test_clean_keys_still_work(self):
-        """Normal keys without trailing colons continue to work correctly."""
-        resolver = _make_resolver()
-        extraction_data = [
-            {
-                "character": "ROMEO",
-                "character_attributes": {"emotional_state": "wonder"},
+  def test_clean_keys_still_work(self):
+    """Normal keys without trailing colons continue to work correctly."""
+    resolver = _make_resolver()
+    extraction_data = [
+        {
+            "character": "ROMEO",
+            "character_attributes": {"emotional_state": "wonder"},
+        },
+        {
+            "emotion": "But soft!",
+            "emotion_attributes": {
+                "feeling": "gentle awe",
+                "character": "Romeo",
             },
-            {
-                "emotion": "But soft!",
-                "emotion_attributes": {
-                    "feeling": "gentle awe",
-                    "character": "Romeo",
-                },
-            },
-        ]
-        results = resolver.extract_ordered_extractions(extraction_data)
-        self.assertLen(results, 2)
-        self.assertEqual(results[0].extraction_class, "character")
-        self.assertEqual(results[1].extraction_class, "emotion")
+        },
+    ]
+    results = resolver.extract_ordered_extractions(extraction_data)
+    self.assertLen(results, 2)
+    self.assertEqual(results[0].extraction_class, "character")
+    self.assertEqual(results[1].extraction_class, "emotion")
 
-    # ── edge cases ─────────────────────────────────────────────────────
+  # ── edge cases ─────────────────────────────────────────────────────
 
-    def test_multiple_trailing_colons_stripped(self):
-        """Keys like 'emotion_attributes:::' are normalized."""
-        resolver = _make_resolver()
-        extraction_data = [
-            {
-                "emotion": "Alas!",
-                "emotion_attributes:::": {"feeling": "sorrow"},
-            },
-        ]
-        results = resolver.extract_ordered_extractions(extraction_data)
-        self.assertLen(results, 1)
-        self.assertEqual(results[0].attributes, {"feeling": "sorrow"})
+  def test_multiple_trailing_colons_stripped(self):
+    """Keys like 'emotion_attributes:::' are normalized."""
+    resolver = _make_resolver()
+    extraction_data = [
+        {
+            "emotion": "Alas!",
+            "emotion_attributes:::": {"feeling": "sorrow"},
+        },
+    ]
+    results = resolver.extract_ordered_extractions(extraction_data)
+    self.assertLen(results, 1)
+    self.assertEqual(results[0].attributes, {"feeling": "sorrow"})
 
-    def test_colon_only_in_middle_of_key_not_stripped(self):
-        """Colons that are NOT trailing should not be stripped."""
-        resolver = _make_resolver()
-        extraction_data = [
-            {
-                # Key with colon in the middle — not a suffix issue
-                "emo:tion": "Alas!",
-                "emo:tion_attributes": {"feeling": "sorrow"},
-            },
-        ]
-        results = resolver.extract_ordered_extractions(extraction_data)
-        self.assertLen(results, 1)
-        # The normalized class should keep the middle colon intact
-        self.assertEqual(results[0].extraction_class, "emo:tion")
+  def test_colon_only_in_middle_of_key_not_stripped(self):
+    """Colons that are NOT trailing should not be stripped."""
+    resolver = _make_resolver()
+    extraction_data = [
+        {
+            # Key with colon in the middle — not a suffix issue
+            "emo:tion": "Alas!",
+            "emo:tion_attributes": {"feeling": "sorrow"},
+        },
+    ]
+    results = resolver.extract_ordered_extractions(extraction_data)
+    self.assertLen(results, 1)
+    # The normalized class should keep the middle colon intact
+    self.assertEqual(results[0].extraction_class, "emo:tion")
 
-    def test_both_attribute_and_class_have_trailing_colon(self):
-        """Both extraction class and attributes key have trailing colons."""
-        resolver = _make_resolver()
-        extraction_data = [
-            {
-                "relationship:": "Juliet is the sun",
-                "relationship_attributes:": {
-                    "type": "metaphor",
-                    "character_1": "Romeo",
-                    "character_2": "Juliet",
-                },
+  def test_both_attribute_and_class_have_trailing_colon(self):
+    """Both extraction class and attributes key have trailing colons."""
+    resolver = _make_resolver()
+    extraction_data = [
+        {
+            "relationship:": "Juliet is the sun",
+            "relationship_attributes:": {
+                "type": "metaphor",
+                "character_1": "Romeo",
+                "character_2": "Juliet",
             },
-        ]
-        results = resolver.extract_ordered_extractions(extraction_data)
-        self.assertLen(results, 1)
-        self.assertEqual(results[0].extraction_class, "relationship")
-        self.assertEqual(results[0].extraction_text, "Juliet is the sun")
-        self.assertEqual(results[0].attributes["type"], "metaphor")
+        },
+    ]
+    results = resolver.extract_ordered_extractions(extraction_data)
+    self.assertLen(results, 1)
+    self.assertEqual(results[0].extraction_class, "relationship")
+    self.assertEqual(results[0].extraction_text, "Juliet is the sun")
+    self.assertEqual(results[0].attributes["type"], "metaphor")
 
-    def test_numeric_extraction_value_with_trailing_colon(self):
-        """Numeric extraction values with trailing colon on key still work."""
-        resolver = _make_resolver()
-        extraction_data = [
-            {
-                "score:": 42,
-                "score_attributes:": {"unit": "points"},
-            },
-        ]
-        results = resolver.extract_ordered_extractions(extraction_data)
-        self.assertLen(results, 1)
-        self.assertEqual(results[0].extraction_class, "score")
-        # Numeric values get stringified
-        self.assertEqual(results[0].extraction_text, "42")
+  def test_numeric_extraction_value_with_trailing_colon(self):
+    """Numeric extraction values with trailing colon on key still work."""
+    resolver = _make_resolver()
+    extraction_data = [
+        {
+            "score:": 42,
+            "score_attributes:": {"unit": "points"},
+        },
+    ]
+    results = resolver.extract_ordered_extractions(extraction_data)
+    self.assertLen(results, 1)
+    self.assertEqual(results[0].extraction_class, "score")
+    # Numeric values get stringified
+    self.assertEqual(results[0].extraction_text, "42")
 
-    def test_float_extraction_value_with_trailing_colon(self):
-        """Float extraction values with trailing colon on key still work."""
-        resolver = _make_resolver()
-        extraction_data = [
-            {
-                "temperature:": 36.6,
-            },
-        ]
-        results = resolver.extract_ordered_extractions(extraction_data)
-        self.assertLen(results, 1)
-        self.assertEqual(results[0].extraction_text, "36.6")
+  def test_float_extraction_value_with_trailing_colon(self):
+    """Float extraction values with trailing colon on key still work."""
+    resolver = _make_resolver()
+    extraction_data = [
+        {
+            "temperature:": 36.6,
+        },
+    ]
+    results = resolver.extract_ordered_extractions(extraction_data)
+    self.assertLen(results, 1)
+    self.assertEqual(results[0].extraction_text, "36.6")
 
-    def test_mixed_clean_and_malformed_keys_in_same_group(self):
-        """Groups with both clean and malformed keys are handled correctly."""
-        resolver = _make_resolver(index_suffix="_index")
-        extraction_data = [
-            {
-                # Clean extraction class
-                "character": "ROMEO",
-                # Malformed attributes key
-                "character_attributes:": {"emotional_state": "wonder"},
-                # Clean index key
-                "character_index": 1,
-            },
-            {
-                # Malformed extraction class
-                "emotion:": "But soft!",
-                # Clean attributes key
-                "emotion_attributes": {"feeling": "awe"},
-                # Malformed index key
-                "emotion_index:": 2,
-            },
-        ]
-        results = resolver.extract_ordered_extractions(extraction_data)
-        self.assertLen(results, 2)
-        self.assertEqual(results[0].extraction_class, "character")
-        self.assertEqual(results[0].attributes, {"emotional_state": "wonder"})
-        self.assertEqual(results[1].extraction_class, "emotion")
-        self.assertEqual(results[1].extraction_text, "But soft!")
+  def test_mixed_clean_and_malformed_keys_in_same_group(self):
+    """Groups with both clean and malformed keys are handled correctly."""
+    resolver = _make_resolver(index_suffix="_index")
+    extraction_data = [
+        {
+            # Clean extraction class
+            "character": "ROMEO",
+            # Malformed attributes key
+            "character_attributes:": {"emotional_state": "wonder"},
+            # Clean index key
+            "character_index": 1,
+        },
+        {
+            # Malformed extraction class
+            "emotion:": "But soft!",
+            # Clean attributes key
+            "emotion_attributes": {"feeling": "awe"},
+            # Malformed index key
+            "emotion_index:": 2,
+        },
+    ]
+    results = resolver.extract_ordered_extractions(extraction_data)
+    self.assertLen(results, 2)
+    self.assertEqual(results[0].extraction_class, "character")
+    self.assertEqual(results[0].attributes, {"emotional_state": "wonder"})
+    self.assertEqual(results[1].extraction_class, "emotion")
+    self.assertEqual(results[1].extraction_text, "But soft!")
 
-    def test_attributes_key_collision_after_normalization(self):
-        """If both clean and malformed attribute keys exist, the clean key is used."""
-        resolver = _make_resolver()
-        # This is an unlikely edge case where the model emits both
-        # "emotion_attributes" and "emotion_attributes:" in the same group.
-        # After normalization, both map to "emotion_attributes". The first one
-        # encountered in dict iteration will be processed as attributes; the
-        # second will also be recognized as attributes (and skipped as a
-        # duplicate continue). The extraction text comes from "emotion".
-        extraction_data = [
-            {
-                "emotion": "O Romeo!",
-                "emotion_attributes": {"feeling": "yearning"},
-                "emotion_attributes:": {"feeling": "longing"},
-            },
-        ]
-        results = resolver.extract_ordered_extractions(extraction_data)
-        self.assertLen(results, 1)
-        self.assertEqual(results[0].extraction_text, "O Romeo!")
-        # The attributes from the last-processed attributes key wins for the
-        # lookup via group.get(), but the extraction itself uses the clean key.
-        # What matters is no crash.
-        self.assertIsNotNone(results[0].attributes)
+  def test_attributes_key_collision_after_normalization(self):
+    """If both clean and malformed attribute keys exist, the clean key is used."""
+    resolver = _make_resolver()
+    # This is an unlikely edge case where the model emits both
+    # "emotion_attributes" and "emotion_attributes:" in the same group.
+    # After normalization, both map to "emotion_attributes". The first one
+    # encountered in dict iteration will be processed as attributes; the
+    # second will also be recognized as attributes (and skipped as a
+    # duplicate continue). The extraction text comes from "emotion".
+    extraction_data = [
+        {
+            "emotion": "O Romeo!",
+            "emotion_attributes": {"feeling": "yearning"},
+            "emotion_attributes:": {"feeling": "longing"},
+        },
+    ]
+    results = resolver.extract_ordered_extractions(extraction_data)
+    self.assertLen(results, 1)
+    self.assertEqual(results[0].extraction_text, "O Romeo!")
+    # The attributes from the last-processed attributes key wins for the
+    # lookup via group.get(), but the extraction itself uses the clean key.
+    # What matters is no crash.
+    self.assertIsNotNone(results[0].attributes)
 
 
 if __name__ == "__main__":
-    absltest.main()
+  absltest.main()

--- a/tests/test_resolver_malformed_keys.py
+++ b/tests/test_resolver_malformed_keys.py
@@ -1,0 +1,264 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for resolver handling of malformed attribute keys.
+
+Regression tests for https://github.com/google/langextract/issues/428
+where non-Gemini model providers (e.g. DeepSeek via OpenAILanguageModel)
+occasionally emit keys with a trailing colon (e.g. "emotion_attributes:")
+instead of the expected "emotion_attributes".  Without normalization the
+dict value falls through to the extraction_text type check and raises
+``ValueError: Extraction text must be a string, integer, or float.``
+"""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from langextract import resolver as resolver_lib
+from langextract.core import data
+from langextract.core import format_handler as fh
+
+
+def _make_resolver(
+    attribute_suffix: str = data.ATTRIBUTE_SUFFIX,
+    index_suffix: str | None = None,
+) -> resolver_lib.Resolver:
+    handler = fh.FormatHandler(
+        format_type=data.FormatType.YAML,
+        use_wrapper=True,
+        wrapper_key=data.EXTRACTIONS_KEY,
+        use_fences=False,
+        attribute_suffix=attribute_suffix,
+    )
+    return resolver_lib.Resolver(
+        format_handler=handler,
+        extraction_index_suffix=index_suffix,
+    )
+
+
+class MalformedAttributeKeyTest(parameterized.TestCase):
+    """Verifies that trailing-colon keys are normalized before matching."""
+
+    # ── core regression test (issue #428) ──────────────────────────────
+
+    def test_trailing_colon_on_attributes_key_does_not_crash(self):
+        """A key like 'emotion_attributes:' should be recognized as attributes."""
+        resolver = _make_resolver()
+        extraction_data = [
+            {
+                "emotion": "But soft!",
+                # Malformed key with trailing colon
+                "emotion_attributes:": {
+                    "feeling": "gentle awe",
+                    "character": "Romeo",
+                },
+            },
+        ]
+        results = resolver.extract_ordered_extractions(extraction_data)
+        self.assertLen(results, 1)
+        self.assertEqual(results[0].extraction_class, "emotion")
+        self.assertEqual(results[0].extraction_text, "But soft!")
+        self.assertEqual(results[0].attributes, {
+            "feeling": "gentle awe",
+            "character": "Romeo",
+        })
+
+    def test_trailing_colon_on_index_key_does_not_crash(self):
+        """A key like 'emotion_index:' should be recognized as an index."""
+        resolver = _make_resolver(index_suffix="_index")
+        extraction_data = [
+            {
+                "emotion": "But soft!",
+                "emotion_attributes": {"feeling": "awe"},
+                # Malformed index key with trailing colon
+                "emotion_index:": 1,
+            },
+        ]
+        results = resolver.extract_ordered_extractions(extraction_data)
+        self.assertLen(results, 1)
+        self.assertEqual(results[0].extraction_text, "But soft!")
+        self.assertEqual(results[0].extraction_index, 1)
+
+    def test_trailing_colon_on_extraction_class_key(self):
+        """'character:' (extraction class with colon) is normalized to 'character'."""
+        resolver = _make_resolver()
+        extraction_data = [
+            {
+                # Malformed extraction class key
+                "character:": "ROMEO",
+                "character_attributes": {"emotional_state": "wonder"},
+            },
+        ]
+        results = resolver.extract_ordered_extractions(extraction_data)
+        self.assertLen(results, 1)
+        self.assertEqual(results[0].extraction_class, "character")
+        self.assertEqual(results[0].extraction_text, "ROMEO")
+        self.assertEqual(
+            results[0].attributes, {"emotional_state": "wonder"}
+        )
+
+    # ── verifying correct keys still work ──────────────────────────────
+
+    def test_clean_keys_still_work(self):
+        """Normal keys without trailing colons continue to work correctly."""
+        resolver = _make_resolver()
+        extraction_data = [
+            {
+                "character": "ROMEO",
+                "character_attributes": {"emotional_state": "wonder"},
+            },
+            {
+                "emotion": "But soft!",
+                "emotion_attributes": {
+                    "feeling": "gentle awe",
+                    "character": "Romeo",
+                },
+            },
+        ]
+        results = resolver.extract_ordered_extractions(extraction_data)
+        self.assertLen(results, 2)
+        self.assertEqual(results[0].extraction_class, "character")
+        self.assertEqual(results[1].extraction_class, "emotion")
+
+    # ── edge cases ─────────────────────────────────────────────────────
+
+    def test_multiple_trailing_colons_stripped(self):
+        """Keys like 'emotion_attributes:::' are normalized."""
+        resolver = _make_resolver()
+        extraction_data = [
+            {
+                "emotion": "Alas!",
+                "emotion_attributes:::": {"feeling": "sorrow"},
+            },
+        ]
+        results = resolver.extract_ordered_extractions(extraction_data)
+        self.assertLen(results, 1)
+        self.assertEqual(results[0].attributes, {"feeling": "sorrow"})
+
+    def test_colon_only_in_middle_of_key_not_stripped(self):
+        """Colons that are NOT trailing should not be stripped."""
+        resolver = _make_resolver()
+        extraction_data = [
+            {
+                # Key with colon in the middle — not a suffix issue
+                "emo:tion": "Alas!",
+                "emo:tion_attributes": {"feeling": "sorrow"},
+            },
+        ]
+        results = resolver.extract_ordered_extractions(extraction_data)
+        self.assertLen(results, 1)
+        # The normalized class should keep the middle colon intact
+        self.assertEqual(results[0].extraction_class, "emo:tion")
+
+    def test_both_attribute_and_class_have_trailing_colon(self):
+        """Both extraction class and attributes key have trailing colons."""
+        resolver = _make_resolver()
+        extraction_data = [
+            {
+                "relationship:": "Juliet is the sun",
+                "relationship_attributes:": {
+                    "type": "metaphor",
+                    "character_1": "Romeo",
+                    "character_2": "Juliet",
+                },
+            },
+        ]
+        results = resolver.extract_ordered_extractions(extraction_data)
+        self.assertLen(results, 1)
+        self.assertEqual(results[0].extraction_class, "relationship")
+        self.assertEqual(results[0].extraction_text, "Juliet is the sun")
+        self.assertEqual(results[0].attributes["type"], "metaphor")
+
+    def test_numeric_extraction_value_with_trailing_colon(self):
+        """Numeric extraction values with trailing colon on key still work."""
+        resolver = _make_resolver()
+        extraction_data = [
+            {
+                "score:": 42,
+                "score_attributes:": {"unit": "points"},
+            },
+        ]
+        results = resolver.extract_ordered_extractions(extraction_data)
+        self.assertLen(results, 1)
+        self.assertEqual(results[0].extraction_class, "score")
+        # Numeric values get stringified
+        self.assertEqual(results[0].extraction_text, "42")
+
+    def test_float_extraction_value_with_trailing_colon(self):
+        """Float extraction values with trailing colon on key still work."""
+        resolver = _make_resolver()
+        extraction_data = [
+            {
+                "temperature:": 36.6,
+            },
+        ]
+        results = resolver.extract_ordered_extractions(extraction_data)
+        self.assertLen(results, 1)
+        self.assertEqual(results[0].extraction_text, "36.6")
+
+    def test_mixed_clean_and_malformed_keys_in_same_group(self):
+        """Groups with both clean and malformed keys are handled correctly."""
+        resolver = _make_resolver(index_suffix="_index")
+        extraction_data = [
+            {
+                # Clean extraction class
+                "character": "ROMEO",
+                # Malformed attributes key
+                "character_attributes:": {"emotional_state": "wonder"},
+                # Clean index key
+                "character_index": 1,
+            },
+            {
+                # Malformed extraction class
+                "emotion:": "But soft!",
+                # Clean attributes key
+                "emotion_attributes": {"feeling": "awe"},
+                # Malformed index key
+                "emotion_index:": 2,
+            },
+        ]
+        results = resolver.extract_ordered_extractions(extraction_data)
+        self.assertLen(results, 2)
+        self.assertEqual(results[0].extraction_class, "character")
+        self.assertEqual(results[0].attributes, {"emotional_state": "wonder"})
+        self.assertEqual(results[1].extraction_class, "emotion")
+        self.assertEqual(results[1].extraction_text, "But soft!")
+
+    def test_attributes_key_collision_after_normalization(self):
+        """If both clean and malformed attribute keys exist, the clean key is used."""
+        resolver = _make_resolver()
+        # This is an unlikely edge case where the model emits both
+        # "emotion_attributes" and "emotion_attributes:" in the same group.
+        # After normalization, both map to "emotion_attributes". The first one
+        # encountered in dict iteration will be processed as attributes; the
+        # second will also be recognized as attributes (and skipped as a
+        # duplicate continue). The extraction text comes from "emotion".
+        extraction_data = [
+            {
+                "emotion": "O Romeo!",
+                "emotion_attributes": {"feeling": "yearning"},
+                "emotion_attributes:": {"feeling": "longing"},
+            },
+        ]
+        results = resolver.extract_ordered_extractions(extraction_data)
+        self.assertLen(results, 1)
+        self.assertEqual(results[0].extraction_text, "O Romeo!")
+        # The attributes from the last-processed attributes key wins for the
+        # lookup via group.get(), but the extraction itself uses the clean key.
+        # What matters is no crash.
+        self.assertIsNotNone(results[0].attributes)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
# Description

Normalize extraction-group keys by stripping trailing colons before resolver matching so non-Gemini providers do not crash when they emit malformed companion keys such as `emotion_attributes:` or `emotion_index:`.

This prevents `extract_ordered_extractions()` from misclassifying dict-valued companion fields as extraction text and raising `ValueError: Extraction text must be a string, integer, or float.`

Related to #59
Addresses the concrete malformed-key bug reported in #428.

Bug fix

# How Has This Been Tested?

```bash
pytest -q tests/test_resolver_malformed_keys.py
pytest -q tests/resolver_test.py
```

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes.
- [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.
