### PR TITLE
fix: close progress bars when save/download fails

### DIFF
--- a/langextract/io.py
+++ b/langextract/io.py
@@ -281,67 +281,68 @@ def download_text_from_url(
     ValueError: If the content is not text-based.
   """
   try:
-    # Make initial request to get headers
-    response = requests.get(url, stream=True, timeout=timeout)
-    response.raise_for_status()
+    # Make initial request to get headers. Use a `with` block so the
+    # streamed Response is closed even if iter_content raises mid-stream.
+    with requests.get(url, stream=True, timeout=timeout) as response:
+      response.raise_for_status()
 
-    # Check content type
-    content_type = response.headers.get('Content-Type', '').lower()
-    if not any(
-        ct in content_type
-        for ct in ['text/', 'application/json', 'application/xml']
-    ):
-      # Try to proceed anyway, but warn
-      print(f"Warning: Content-Type '{content_type}' may not be text-based")
+      # Check content type
+      content_type = response.headers.get('Content-Type', '').lower()
+      if not any(
+          ct in content_type
+          for ct in ['text/', 'application/json', 'application/xml']
+      ):
+        # Try to proceed anyway, but warn
+        print(f"Warning: Content-Type '{content_type}' may not be text-based")
 
-    # Get content length for progress bar
-    total_size = int(response.headers.get('Content-Length', 0))
+      # Get content length for progress bar
+      total_size = int(response.headers.get('Content-Length', 0))
 
-    filename = url.split('/')[-1][:50]
+      filename = url.split('/')[-1][:50]
 
-    # Download content with progress bar
-    chunks = []
-    if show_progress and total_size > 0:
-      progress_bar = progress.create_download_progress_bar(
-          total_size=total_size, url=url
-      )
+      # Download content with progress bar
+      chunks = []
+      if show_progress and total_size > 0:
+        progress_bar = progress.create_download_progress_bar(
+            total_size=total_size, url=url
+        )
 
-      try:
+        try:
+          for chunk in response.iter_content(chunk_size=chunk_size):
+            if chunk:
+              chunks.append(chunk)
+              progress_bar.update(len(chunk))
+        finally:
+          progress_bar.close()
+      else:
+        # Download without progress bar
         for chunk in response.iter_content(chunk_size=chunk_size):
           if chunk:
             chunks.append(chunk)
-            progress_bar.update(len(chunk))
-      finally:
-        progress_bar.close()
-    else:
-      # Download without progress bar
-      for chunk in response.iter_content(chunk_size=chunk_size):
-        if chunk:
-          chunks.append(chunk)
 
-    # Combine chunks and decode
-    content = b''.join(chunks)
+      # Combine chunks and decode
+      content = b''.join(chunks)
 
-    # Try to decode as text
-    encodings = ['utf-8', 'latin-1', 'ascii', 'utf-16']
-    text_content = None
-    for encoding in encodings:
-      try:
-        text_content = content.decode(encoding)
-        break
-      except UnicodeDecodeError:
-        continue
+      # Try to decode as text
+      encodings = ['utf-8', 'latin-1', 'ascii', 'utf-16']
+      text_content = None
+      for encoding in encodings:
+        try:
+          text_content = content.decode(encoding)
+          break
+        except UnicodeDecodeError:
+          continue
 
-    if text_content is None:
-      raise ValueError(f'Could not decode content from {url} as text')
+      if text_content is None:
+        raise ValueError(f'Could not decode content from {url} as text')
 
-    # Show content summary with clean formatting
-    if show_progress:
-      char_count = len(text_content)
-      word_count = len(text_content.split())
-      progress.print_download_complete(char_count, word_count, filename)
+      # Show content summary with clean formatting
+      if show_progress:
+        char_count = len(text_content)
+        word_count = len(text_content.split())
+        progress.print_download_complete(char_count, word_count, filename)
 
-    return text_content
+      return text_content
 
   except requests.RequestException as e:
     raise requests.RequestException(

--- a/langextract/io.py
+++ b/langextract/io.py
@@ -117,18 +117,19 @@ def save_annotated_documents(
       output_path=str(output_file), disable=not show_progress
   )
 
-  with open(output_file, 'w', encoding='utf-8') as f:
-    for adoc in annotated_documents:
-      if not adoc.document_id:
-        continue
+  try:
+    with open(output_file, 'w', encoding='utf-8') as f:
+      for adoc in annotated_documents:
+        if not adoc.document_id:
+          continue
 
-      doc_dict = data_lib.annotated_document_to_dict(adoc)
-      f.write(json.dumps(doc_dict, ensure_ascii=False) + '\n')
-      has_data = True
-      doc_count += 1
-      progress_bar.update(1)
-
-  progress_bar.close()
+        doc_dict = data_lib.annotated_document_to_dict(adoc)
+        f.write(json.dumps(doc_dict, ensure_ascii=False) + '\n')
+        has_data = True
+        doc_count += 1
+        progress_bar.update(1)
+  finally:
+    progress_bar.close()
 
   if not has_data:
     raise InvalidDatasetError(f'No documents to save in: {output_file}')
@@ -305,12 +306,13 @@ def download_text_from_url(
           total_size=total_size, url=url
       )
 
-      for chunk in response.iter_content(chunk_size=chunk_size):
-        if chunk:
-          chunks.append(chunk)
-          progress_bar.update(len(chunk))
-
-      progress_bar.close()
+      try:
+        for chunk in response.iter_content(chunk_size=chunk_size):
+          if chunk:
+            chunks.append(chunk)
+            progress_bar.update(len(chunk))
+      finally:
+        progress_bar.close()
     else:
       # Download without progress bar
       for chunk in response.iter_content(chunk_size=chunk_size):

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -1,0 +1,93 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for langextract.io module."""
+
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+import requests
+
+from langextract import io
+from langextract.core import data
+
+
+class _ClosingTracker:
+
+  def __init__(self):
+    self.closed = False
+    self.updates = []
+
+  def update(self, value):
+    self.updates.append(value)
+
+  def close(self):
+    self.closed = True
+
+
+class IoTest(unittest.TestCase):
+
+  def test_save_annotated_documents_closes_progress_bar_on_generator_error(self):
+    tracker = _ClosingTracker()
+
+    def annotated_documents():
+      yield data.AnnotatedDocument(document_id='doc-1', text='hello', extractions=[])
+      raise RuntimeError('boom')
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+      with mock.patch(
+          'langextract.io.progress.create_save_progress_bar', return_value=tracker
+      ):
+        with self.assertRaisesRegex(RuntimeError, 'boom'):
+          io.save_annotated_documents(
+              annotated_documents(),
+              output_dir=pathlib.Path(tmpdir),
+              show_progress=True,
+          )
+
+    self.assertTrue(tracker.closed)
+    self.assertEqual(tracker.updates, [1])
+
+  def test_download_text_from_url_closes_progress_bar_on_stream_error(self):
+    tracker = _ClosingTracker()
+    response = mock.Mock()
+    response.headers = {
+        'Content-Type': 'text/plain',
+        'Content-Length': '10',
+    }
+    response.raise_for_status.return_value = None
+
+    def broken_iter_content(*, chunk_size):
+      del chunk_size
+      yield b'hello'
+      raise requests.RequestException('connection reset')
+
+    response.iter_content.side_effect = broken_iter_content
+
+    with mock.patch('langextract.io.requests.get', return_value=response):
+      with mock.patch(
+          'langextract.io.progress.create_download_progress_bar',
+          return_value=tracker,
+      ):
+        with self.assertRaisesRegex(requests.RequestException, 'connection reset'):
+          io.download_text_from_url('https://example.com/file.txt')
+
+    self.assertTrue(tracker.closed)
+    self.assertEqual(tracker.updates, [5])
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -40,16 +40,21 @@ class _ClosingTracker:
 
 class IoTest(unittest.TestCase):
 
-  def test_save_annotated_documents_closes_progress_bar_on_generator_error(self):
+  def test_save_annotated_documents_closes_progress_bar_on_generator_error(
+      self,
+  ):
     tracker = _ClosingTracker()
 
     def annotated_documents():
-      yield data.AnnotatedDocument(document_id='doc-1', text='hello', extractions=[])
+      yield data.AnnotatedDocument(
+          document_id='doc-1', text='hello', extractions=[]
+      )
       raise RuntimeError('boom')
 
     with tempfile.TemporaryDirectory() as tmpdir:
       with mock.patch(
-          'langextract.io.progress.create_save_progress_bar', return_value=tracker
+          'langextract.io.progress.create_save_progress_bar',
+          return_value=tracker,
       ):
         with self.assertRaisesRegex(RuntimeError, 'boom'):
           io.save_annotated_documents(
@@ -82,7 +87,9 @@ class IoTest(unittest.TestCase):
           'langextract.io.progress.create_download_progress_bar',
           return_value=tracker,
       ):
-        with self.assertRaisesRegex(requests.RequestException, 'connection reset'):
+        with self.assertRaisesRegex(
+            requests.RequestException, 'connection reset'
+        ):
           io.download_text_from_url('https://example.com/file.txt')
 
     self.assertTrue(tracker.closed)

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -68,7 +68,9 @@ class IoTest(unittest.TestCase):
 
   def test_download_text_from_url_closes_progress_bar_on_stream_error(self):
     tracker = _ClosingTracker()
-    response = mock.Mock()
+    response = mock.MagicMock()
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
     response.headers = {
         'Content-Type': 'text/plain',
         'Content-Length': '10',


### PR DESCRIPTION
# Description

Fixes the progress-bar cleanup bug in `langextract/io.py` by closing both the save and download tqdm bars from `finally` blocks, so generator failures and streaming request errors do not leave terminal state behind.

Fixes #401

Bug fix

# How Has This Been Tested?

```bash
pytest -q tests/io_test.py
```

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes.
- [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.