### PR TITLE
fix: suppress schema errors in resolve() when enabled

### DIFF
--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -127,10 +127,11 @@ def extract(
         Minimum token overlap ratio for fuzzy match (0.0-1.0). Default is 0.75.
         'accept_match_lesser' (bool): Whether to accept partial exact matches.
         Default is True. 'suppress_parse_errors' (bool): Suppresses chunk-level
-        FormatError parsing failures so that one unparseable chunk does not
-        fail the entire document; defaults to True in extract() while the
-        underlying Resolver.resolve() default remains False. Set to False
-        when prototyping to surface prompt issues early.
+        parse and schema errors (FormatError, ValueError) so that one
+        unparseable or malformed chunk does not fail the entire document;
+        defaults to True in extract() while the underlying
+        Resolver.resolve() default remains False. Set to False when
+        prototyping to surface prompt issues early.
       language_model_params: Additional parameters for the language model.
       debug: Whether to enable debug logging. When True, enables detailed logging
         of function calls, arguments, return values, and timing for the langextract

--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -241,7 +241,9 @@ class Resolver(AbstractResolver):
 
     Args:
         input_text: The input text to be processed.
-        suppress_parse_errors: Log errors and continue pipeline.
+        suppress_parse_errors: When True, logs a warning and returns []
+          on parse failures (FormatError) or schema/type errors (ValueError)
+          instead of raising.
         **kwargs: Additional keyword arguments.
 
     Returns:
@@ -268,7 +270,13 @@ class Resolver(AbstractResolver):
         return []
       raise ResolverParsingError(str(e)) from e
 
-    processed_extractions = self.extract_ordered_extractions(extraction_data)
+    try:
+      processed_extractions = self.extract_ordered_extractions(extraction_data)
+    except ValueError as e:
+      if suppress_parse_errors:
+        logging.warning("Skipping chunk: schema error: %s", e)
+        return []
+      raise ResolverParsingError(str(e)) from e
 
     logging.debug("Completed the resolver process.")
 
@@ -402,8 +410,8 @@ class Resolver(AbstractResolver):
         extractions have the same index, their group order dictates the sorting
         order.
     Raises:
-        ValueError: If the extraction text is not a string or integer, or if the
-        index is not an integer.
+        ValueError: If an index is not an integer, attributes are not a dict
+        or None, or extraction text is not a string, integer, or float.
     """
     logging.debug("Starting to extract and order extractions from data.")
 
@@ -419,7 +427,7 @@ class Resolver(AbstractResolver):
       for extraction_class, extraction_value in group.items():
         if index_suffix and extraction_class.endswith(index_suffix):
           if not isinstance(extraction_value, int):
-            logging.error(
+            logging.debug(
                 "Index must be an integer. Found: %s",
                 type(extraction_value),
             )
@@ -428,7 +436,7 @@ class Resolver(AbstractResolver):
 
         if attributes_suffix and extraction_class.endswith(attributes_suffix):
           if not isinstance(extraction_value, (dict, type(None))):
-            logging.error(
+            logging.debug(
                 "Attributes must be a dict or None. Found: %s",
                 type(extraction_value),
             )
@@ -438,7 +446,7 @@ class Resolver(AbstractResolver):
           continue
 
         if not isinstance(extraction_value, (str, int, float)):
-          logging.error(
+          logging.debug(
               "Extraction text must be a string, integer, or float. Found: %s",
               type(extraction_value),
           )

--- a/tests/resolver_test.py
+++ b/tests/resolver_test.py
@@ -14,6 +14,7 @@
 
 import textwrap
 from typing import Sequence
+from unittest import mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -1864,6 +1865,46 @@ class ResolverTest(parameterized.TestCase):
 
   def test_resolve_empty_yaml_without_suppress_parse_errors(self):
     test_input = "```json\n```"
+    with self.assertRaises(resolver_lib.ResolverParsingError):
+      self.default_resolver.resolve(test_input, suppress_parse_errors=False)
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="non_dict_attributes",
+          test_input=(
+              '```json\n{"extractions":'
+              ' [{"entity": "test", "entity_index": 1,'
+              ' "entity_attributes": "bad"}]}\n```'
+          ),
+      ),
+      dict(
+          testcase_name="malformed_key_trailing_colon",
+          test_input=(
+              '```json\n{"extractions":'
+              ' [{"emotion": "joy", "emotion_index": 1,'
+              ' "emotion_attributes:": {"intensity": "high"}}]}\n```'
+          ),
+      ),
+  )
+  def test_resolve_schema_error_suppressed(self, test_input):
+    """Schema errors are suppressed with warning-only logging."""
+    with mock.patch("langextract.resolver.logging") as mock_log:
+      actual = self.default_resolver.resolve(
+          test_input, suppress_parse_errors=True
+      )
+      self.assertEmpty(actual)
+      mock_log.warning.assert_called()
+      log_msg = mock_log.warning.call_args[0][0]
+      self.assertIn("schema error", log_msg)
+      mock_log.error.assert_not_called()
+
+  def test_resolve_schema_error_raises_without_suppression(self):
+    """Malformed attributes raise ResolverParsingError when not suppressed."""
+    test_input = (
+        '```json\n{"extractions":'
+        ' [{"entity": "test", "entity_index": 1,'
+        ' "entity_attributes": "bad"}]}\n```'
+    )
     with self.assertRaises(resolver_lib.ResolverParsingError):
       self.default_resolver.resolve(test_input, suppress_parse_errors=False)
 


### PR DESCRIPTION
## Summary
Extends `suppress_parse_errors` to catch `ValueError` from `extract_ordered_extractions()` so malformed-but-parseable LLM output does not crash the job.

- Wraps `extract_ordered_extractions()` in try/except for `ValueError`, same pattern as existing `FormatError` handling
- Updates `suppress_parse_errors` docs to cover both parse and schema errors
- Updates `Resolver.resolve()` docstring

Addresses #222
Related to #427