### PR TITLE
perf: replace difflib fuzzy aligner with O(n*m^2) LCS DP

### DIFF
--- a/benchmarks/fuzzy_benchmark.py
+++ b/benchmarks/fuzzy_benchmark.py
@@ -22,6 +22,8 @@ realistic input sizes. Run from repo root:
   python benchmarks/fuzzy_benchmark.py --sizes planted_contiguous,perf_1k
   python benchmarks/fuzzy_benchmark.py --sizes large --runs 1
   python benchmarks/fuzzy_benchmark.py --tokenizer unicode
+  python benchmarks/fuzzy_benchmark.py --algorithm lcs
+  python benchmarks/fuzzy_benchmark.py --algorithm legacy
 """
 
 from __future__ import annotations
@@ -230,7 +232,13 @@ _DEFAULT_SIZES = (
 )
 
 
-def _get_metadata(tokenizer_name: str, seed: int, threshold: float) -> dict:
+def _get_metadata(
+    tokenizer_name: str,
+    seed: int,
+    threshold: float,
+    algorithm: str,
+    min_density: float,
+) -> dict:
   """Collects run metadata for reproducibility."""
   git_sha = "unknown"
   try:
@@ -251,6 +259,8 @@ def _get_metadata(tokenizer_name: str, seed: int, threshold: float) -> dict:
       "tokenizer": tokenizer_name,
       "seed": seed,
       "fuzzy_alignment_threshold": threshold,
+      "fuzzy_alignment_algorithm": algorithm,
+      "fuzzy_alignment_min_density": min_density,
       "git_sha": git_sha,
   }
 
@@ -261,6 +271,8 @@ def _run_single(
     extraction_text: str,
     tokenizer: tokenizer_lib.Tokenizer,
     threshold: float,
+    algorithm: str,
+    min_density: float,
 ) -> dict:
   """Runs a single fuzzy alignment and returns timing + result."""
   resolver_lib._normalize_token.cache_clear()
@@ -270,15 +282,27 @@ def _run_single(
   extraction = _make_extraction(extraction_text)
 
   start = time.perf_counter()
-  result = aligner._fuzzy_align_extraction(
-      extraction=extraction,
-      source_tokens=source_tokens,
-      tokenized_text=tokenized,
-      token_offset=0,
-      char_offset=0,
-      fuzzy_alignment_threshold=threshold,
-      tokenizer_impl=tokenizer,
-  )
+  if algorithm == "lcs":
+    result = aligner._lcs_fuzzy_align_extraction(
+        extraction=extraction,
+        source_tokens=source_tokens,
+        tokenized_text=tokenized,
+        token_offset=0,
+        char_offset=0,
+        fuzzy_alignment_threshold=threshold,
+        fuzzy_alignment_min_density=min_density,
+        tokenizer_impl=tokenizer,
+    )
+  else:
+    result = aligner._fuzzy_align_extraction(
+        extraction=extraction,
+        source_tokens=source_tokens,
+        tokenized_text=tokenized,
+        token_offset=0,
+        char_offset=0,
+        fuzzy_alignment_threshold=threshold,
+        tokenizer_impl=tokenizer,
+    )
   elapsed = time.perf_counter() - start
 
   matched_substring = None
@@ -339,6 +363,18 @@ def main():
       default=0.75,
       help="Fuzzy alignment threshold (default: 0.75)",
   )
+  parser.add_argument(
+      "--algorithm",
+      choices=["lcs", "legacy"],
+      default="lcs",
+      help="Fuzzy alignment algorithm (default: lcs)",
+  )
+  parser.add_argument(
+      "--min-density",
+      type=float,
+      default=1 / 3,
+      help="Min matched-to-span density for LCS algorithm (default: 1/3)",
+  )
   parser.add_argument("--json-output", help="Write results to JSON file")
   args = parser.parse_args()
 
@@ -351,12 +387,17 @@ def main():
     tokenizer = tokenizer_lib.RegexTokenizer()
 
   aligner = resolver_lib.WordAligner()
-  metadata = _get_metadata(args.tokenizer, 42, args.threshold)
+  metadata = _get_metadata(
+      args.tokenizer, 42, args.threshold, args.algorithm, args.min_density
+  )
 
   results = {"_metadata": metadata}
   print(f"Fuzzy alignment benchmark ({args.runs} runs per case)\n")
+  print(f"  algorithm: {args.algorithm}")
   print(f"  tokenizer: {args.tokenizer}")
   print(f"  threshold: {args.threshold}")
+  if args.algorithm == "lcs":
+    print(f"  min_density: {args.min_density:.3f}")
   print(f"  git: {metadata['git_sha']}\n")
 
   for name in selected:
@@ -383,7 +424,13 @@ def main():
     for i in range(args.runs):
       print(f"    run {i + 1}/{args.runs}...", end="", flush=True)
       result = _run_single(
-          aligner, source, extraction_text, tokenizer, args.threshold
+          aligner,
+          source,
+          extraction_text,
+          tokenizer,
+          args.threshold,
+          args.algorithm,
+          args.min_density,
       )
       timings.append(result["elapsed_ms"])
       last_result = result

--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+import dataclasses
 import typing
 from typing import cast
 import warnings
@@ -118,20 +119,17 @@ def extract(
       resolver_params: Parameters for the `resolver.Resolver`, which parses the
         raw language model output string (e.g., extracting JSON from ```json ...
         ``` blocks) into structured `data.Extraction` objects. This dictionary
-        overrides default settings. Keys include: - 'extraction_index_suffix'
-        (str | None): Suffix for keys indicating extraction order. Default is
-        None (order by appearance). Additional alignment parameters can be
-        included: 'enable_fuzzy_alignment' (bool): Whether to use fuzzy matching
-        if exact matching fails. Disabling this can improve performance but may
-        reduce recall. Default is True. 'fuzzy_alignment_threshold' (float):
-        Minimum token overlap ratio for fuzzy match (0.0-1.0). Default is 0.75.
-        'accept_match_lesser' (bool): Whether to accept partial exact matches.
-        Default is True. 'suppress_parse_errors' (bool): Suppresses chunk-level
-        parse and schema errors (FormatError, ValueError) so that one
-        unparseable or malformed chunk does not fail the entire document;
-        defaults to True in extract() while the underlying
-        Resolver.resolve() default remains False. Set to False when
-        prototyping to surface prompt issues early.
+        overrides default settings. Keys include:
+        'extraction_index_suffix' (str | None): Suffix for extraction
+        ordering keys. Default is None (order by appearance).
+        'suppress_parse_errors' (bool): Suppresses chunk-level parse
+        errors so one malformed chunk does not fail the entire document.
+        Default is True in extract().
+        Alignment tuning keys: 'enable_fuzzy_alignment' (bool, True),
+        'fuzzy_alignment_threshold' (float, 0.75),
+        'fuzzy_alignment_algorithm' (str, "lcs"; "legacy" is deprecated),
+        'fuzzy_alignment_min_density' (float, 1/3),
+        'accept_match_lesser' (bool, True).
       language_model_params: Additional parameters for the language model.
       debug: Whether to enable debug logging. When True, enables detailed logging
         of function calls, arguments, return values, and timing for the langextract
@@ -183,10 +181,16 @@ def extract(
     )
 
   if prompt_validation_level is not pv.PromptValidationLevel.OFF:
+    policy_kwargs = {}
+    if resolver_params:
+      for field in dataclasses.fields(pv.AlignmentPolicy):
+        val = resolver_params.get(field.name)
+        if val is not None:
+          policy_kwargs[field.name] = val
     report = pv.validate_prompt_alignment(
         examples=examples,
         aligner=resolver.WordAligner(),
-        policy=pv.AlignmentPolicy(),
+        policy=pv.AlignmentPolicy(**policy_kwargs),
         tokenizer=tokenizer,
     )
     pv.handle_alignment_report(

--- a/langextract/prompt_validation.py
+++ b/langextract/prompt_validation.py
@@ -39,6 +39,8 @@ __all__ = [
 
 
 _FUZZY_ALIGNMENT_MIN_THRESHOLD = 0.75
+_FUZZY_ALIGNMENT_MIN_DENSITY = 1 / 3
+_DEFAULT_FUZZY_ALGORITHM = "lcs"
 
 
 class PromptValidationLevel(enum.Enum):
@@ -111,6 +113,9 @@ class AlignmentPolicy:
   enable_fuzzy_alignment: bool = True
   fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD
   accept_match_lesser: bool = True
+  _: dataclasses.KW_ONLY
+  fuzzy_alignment_algorithm: str = _DEFAULT_FUZZY_ALGORITHM
+  fuzzy_alignment_min_density: float = _FUZZY_ALIGNMENT_MIN_DENSITY
 
 
 def _preview(s: str, n: int = 120) -> str:
@@ -155,6 +160,8 @@ def validate_prompt_alignment(
         char_offset=0,
         enable_fuzzy_alignment=policy.enable_fuzzy_alignment,
         fuzzy_alignment_threshold=policy.fuzzy_alignment_threshold,
+        fuzzy_alignment_algorithm=policy.fuzzy_alignment_algorithm,
+        fuzzy_alignment_min_density=policy.fuzzy_alignment_min_density,
         accept_match_lesser=policy.accept_match_lesser,
         tokenizer_impl=tokenizer,
     )

--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -26,8 +26,11 @@ from collections.abc import Iterator, Mapping, Sequence
 import difflib
 import functools
 import itertools
+import math
 import operator
+import typing
 from typing import Final
+import warnings
 
 from absl import logging
 
@@ -37,7 +40,28 @@ from langextract.core import format_handler as fh
 from langextract.core import schema
 from langextract.core import tokenizer as tokenizer_lib
 
+
+class LcsSpan(typing.NamedTuple):
+  """Result of _best_lcs_span: matched token count and source span."""
+
+  matches: int
+  start: int
+  end: int
+
+  @property
+  def span_len(self) -> int:
+    return 0 if self.start < 0 else self.end - self.start + 1
+
+
 _FUZZY_ALIGNMENT_MIN_THRESHOLD = 0.75
+_FUZZY_ALIGNMENT_MIN_DENSITY = 1 / 3
+_FUZZY_ALGORITHM_LCS = "lcs"
+_FUZZY_ALGORITHM_LEGACY = "legacy"
+_DEFAULT_FUZZY_ALGORITHM = _FUZZY_ALGORITHM_LCS
+_VALID_FUZZY_ALGORITHMS: Final[frozenset[str]] = frozenset({
+    _FUZZY_ALGORITHM_LCS,
+    _FUZZY_ALGORITHM_LEGACY,
+})
 
 # Default suffix for extraction index keys (e.g., "entity_index")
 DEFAULT_INDEX_SUFFIX = "_index"  # Suffix for index fields in extraction sorting
@@ -45,6 +69,8 @@ DEFAULT_INDEX_SUFFIX = "_index"  # Suffix for index fields in extraction sorting
 ALIGNMENT_PARAM_KEYS: Final[frozenset[str]] = frozenset({
     "enable_fuzzy_alignment",
     "fuzzy_alignment_threshold",
+    "fuzzy_alignment_algorithm",
+    "fuzzy_alignment_min_density",
     "accept_match_lesser",
     "suppress_parse_errors",
 })
@@ -129,6 +155,9 @@ class AbstractResolver(abc.ABC):
       enable_fuzzy_alignment: bool = True,
       fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD,
       accept_match_lesser: bool = True,
+      *,
+      fuzzy_alignment_algorithm: str = _DEFAULT_FUZZY_ALGORITHM,
+      fuzzy_alignment_min_density: float = _FUZZY_ALIGNMENT_MIN_DENSITY,
       **kwargs,
   ) -> Iterator[data.Extraction]:
     """Aligns extractions with source text, setting token/char intervals and alignment status.
@@ -139,7 +168,7 @@ class AbstractResolver(abc.ABC):
     Alignment Status Results:
     - MATCH_EXACT: Perfect token-level match
     - MATCH_LESSER: Partial exact match (extraction longer than matched text)
-    - MATCH_FUZZY: Best overlap window meets threshold (≥
+    - MATCH_FUZZY: Best overlap window meets threshold (>=
     fuzzy_alignment_threshold)
     - None: No alignment found
 
@@ -152,10 +181,14 @@ class AbstractResolver(abc.ABC):
         of the chunk.
       enable_fuzzy_alignment: Whether to use fuzzy alignment when exact matching
         fails.
-      fuzzy_alignment_threshold: Minimum token overlap ratio for fuzzy alignment
-        (0-1).
+      fuzzy_alignment_threshold: Minimum fraction of extraction tokens that
+        must be matched (0-1). Default 0.75.
       accept_match_lesser: Whether to accept partial exact matches (MATCH_LESSER
         status).
+      fuzzy_alignment_algorithm: "lcs" (default) or "legacy" (deprecated,
+        will be removed in a future release). Keyword-only.
+      fuzzy_alignment_min_density: Minimum ratio of matched tokens to source
+        span length (LCS only). Keyword-only.
       **kwargs: Additional keyword arguments for provider-specific alignment.
 
     Yields:
@@ -292,15 +325,12 @@ class Resolver(AbstractResolver):
       fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD,
       accept_match_lesser: bool = True,
       tokenizer_inst: tokenizer_lib.Tokenizer | None = None,
+      *,
+      fuzzy_alignment_algorithm: str = _DEFAULT_FUZZY_ALGORITHM,
+      fuzzy_alignment_min_density: float = _FUZZY_ALIGNMENT_MIN_DENSITY,
       **kwargs,
   ) -> Iterator[data.Extraction]:
     """Aligns annotated extractions with source text.
-
-    This uses WordAligner which is based on Python's difflib SequenceMatcher to
-    match tokens in the source text with tokens from the annotated extractions.
-    If
-    the extraction order is significantly different from the source text order,
-    difflib may skip some matches, leaving certain extractions unmatched.
 
     Args:
       extractions: Annotated extractions.
@@ -308,11 +338,14 @@ class Resolver(AbstractResolver):
       token_offset: The starting token index of the chunk.
       char_offset: The starting character index of the chunk.
       enable_fuzzy_alignment: Whether to enable fuzzy alignment fallback.
-      fuzzy_alignment_threshold: Minimum overlap ratio required for fuzzy
-        alignment.
-      accept_match_lesser: Whether to accept partial exact matches (MATCH_LESSER
-        status).
+      fuzzy_alignment_threshold: Minimum fraction of extraction tokens that
+        must be matched (0-1). Default 0.75.
+      accept_match_lesser: Whether to accept partial exact matches.
       tokenizer_inst: Optional tokenizer instance.
+      fuzzy_alignment_algorithm: "lcs" (default) or "legacy" (deprecated,
+        will be removed in a future release). Keyword-only.
+      fuzzy_alignment_min_density: Minimum ratio of matched tokens to source
+        span length (LCS only). Keyword-only.
       **kwargs: Additional parameters.
 
     Yields:
@@ -337,6 +370,8 @@ class Resolver(AbstractResolver):
         char_offset or 0,
         enable_fuzzy_alignment=enable_fuzzy_alignment,
         fuzzy_alignment_threshold=fuzzy_alignment_threshold,
+        fuzzy_alignment_algorithm=fuzzy_alignment_algorithm,
+        fuzzy_alignment_min_density=fuzzy_alignment_min_density,
         accept_match_lesser=accept_match_lesser,
         tokenizer_impl=tokenizer_inst,
     )
@@ -666,6 +701,78 @@ class WordAligner:
 
     return None
 
+  def _lcs_fuzzy_align_extraction(
+      self,
+      extraction: data.Extraction,
+      source_tokens_norm: list[str],
+      tokenized_text: tokenizer_lib.TokenizedText,
+      token_offset: int,
+      char_offset: int,
+      fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD,
+      fuzzy_alignment_min_density: float = _FUZZY_ALIGNMENT_MIN_DENSITY,
+      tokenizer_impl: tokenizer_lib.Tokenizer | None = None,
+  ) -> data.Extraction | None:
+    """Fuzzy-align an extraction using LCS DP with coverage/density gates.
+
+    Args:
+      extraction: The extraction to align.
+      source_tokens_norm: Pre-normalized source tokens.
+      tokenized_text: The tokenized source text.
+      token_offset: Token offset of the current chunk.
+      char_offset: Character offset of the current chunk.
+      fuzzy_alignment_threshold: Minimum coverage fraction for acceptance.
+      fuzzy_alignment_min_density: Minimum matched-to-span density.
+      tokenizer_impl: Optional tokenizer instance.
+
+    Returns:
+      The aligned extraction on success, None otherwise.
+    """
+    extraction_tokens = list(
+        _tokenize_with_lowercase(
+            extraction.extraction_text, tokenizer_inst=tokenizer_impl
+        )
+    )
+    if not extraction_tokens:
+      return None
+
+    extraction_tokens_norm = [_normalize_token(t) for t in extraction_tokens]
+
+    logging.debug(
+        "LCS fuzzy aligning %r (%d tokens)",
+        extraction.extraction_text,
+        len(extraction_tokens),
+    )
+
+    # Try spans by decreasing match count: a sparse max-match span may fail
+    # the density gate while a denser sub-match span still passes coverage.
+    spans = _best_lcs_spans(source_tokens_norm, extraction_tokens_norm)
+    accepted: LcsSpan | None = None
+    for k in sorted(spans.keys(), reverse=True):
+      candidate = spans[k]
+      if _accept_lcs_match(
+          candidate,
+          len(extraction_tokens_norm),
+          threshold=fuzzy_alignment_threshold,
+          min_density=fuzzy_alignment_min_density,
+      ):
+        accepted = candidate
+        break
+    if accepted is None:
+      return None
+
+    extraction.token_interval = tokenizer_lib.TokenInterval(
+        start_index=accepted.start + token_offset,
+        end_index=accepted.end + 1 + token_offset,
+    )
+    start_token = tokenized_text.tokens[accepted.start]
+    end_token = tokenized_text.tokens[accepted.end]
+    extraction.char_interval = data.CharInterval(
+        start_pos=char_offset + start_token.char_interval.start_pos,
+        end_pos=char_offset + end_token.char_interval.end_pos,
+    )
+    extraction.alignment_status = data.AlignmentStatus.MATCH_FUZZY
+    return extraction
+
   def align_extractions(
       self,
       extraction_groups: Sequence[Sequence[data.Extraction]],
@@ -677,6 +784,9 @@ class WordAligner:
       fuzzy_alignment_threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD,
       accept_match_lesser: bool = True,
       tokenizer_impl: tokenizer_lib.Tokenizer | None = None,
+      *,
+      fuzzy_alignment_algorithm: str = _DEFAULT_FUZZY_ALGORITHM,
+      fuzzy_alignment_min_density: float = _FUZZY_ALIGNMENT_MIN_DENSITY,
   ) -> Sequence[Sequence[data.Extraction]]:
     """Aligns extractions with their positions in the source text.
 
@@ -699,16 +809,43 @@ class WordAligner:
       delim: Token used to separate multi-token extractions.
       enable_fuzzy_alignment: Whether to use fuzzy alignment when exact matching
         fails.
-      fuzzy_alignment_threshold: Minimum token overlap ratio for fuzzy alignment
-        (0-1).
+      fuzzy_alignment_threshold: Minimum fraction of extraction tokens that
+        must be matched (0-1). Default 0.75.
       accept_match_lesser: Whether to accept partial exact matches (MATCH_LESSER
         status).
       tokenizer_impl: Optional tokenizer instance.
+      fuzzy_alignment_algorithm: "lcs" (default) or "legacy" (deprecated,
+        will be removed in a future release). Keyword-only.
+      fuzzy_alignment_min_density: Minimum ratio of matched tokens to source
+        span length (LCS only). Keyword-only.
 
     Returns:
       A sequence of extractions aligned with the source text, including token
       intervals.
     """
+    if enable_fuzzy_alignment:
+      if fuzzy_alignment_algorithm not in _VALID_FUZZY_ALGORITHMS:
+        raise ValueError(
+            f"Invalid fuzzy_alignment_algorithm {fuzzy_alignment_algorithm!r};"
+            f" expected one of {sorted(_VALID_FUZZY_ALGORITHMS)}."
+        )
+      if not 0.0 <= fuzzy_alignment_threshold <= 1.0:
+        raise ValueError(
+            "fuzzy_alignment_threshold must be in [0, 1]; got"
+            f" {fuzzy_alignment_threshold!r}."
+        )
+      if not 0.0 <= fuzzy_alignment_min_density <= 1.0:
+        raise ValueError(
+            "fuzzy_alignment_min_density must be in [0, 1]; got"
+            f" {fuzzy_alignment_min_density!r}."
+        )
+      if fuzzy_alignment_algorithm == _FUZZY_ALGORITHM_LEGACY:
+        warnings.warn(
+            "fuzzy_alignment_algorithm='legacy' is deprecated and will be"
+            " removed in a future release. Use the default 'lcs' algorithm.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     logging.debug(
         "WordAligner: Starting alignment of extractions with the source text."
         " Extraction groups to align: %s",
@@ -845,22 +982,39 @@ class WordAligner:
       if extraction not in aligned_extractions:
         unaligned_extractions.append(extraction)
 
-    # Apply fuzzy alignment to remaining extractions
     if enable_fuzzy_alignment and unaligned_extractions:
       logging.debug(
-          "Starting fuzzy alignment for %d unaligned extractions",
+          "Starting fuzzy alignment (%s) for %d unaligned extractions",
+          fuzzy_alignment_algorithm,
           len(unaligned_extractions),
       )
+      src_norm = (
+          [_normalize_token(t) for t in source_tokens]
+          if fuzzy_alignment_algorithm == _FUZZY_ALGORITHM_LCS
+          else None
+      )
       for extraction in unaligned_extractions:
-        aligned_extraction = self._fuzzy_align_extraction(
-            extraction,
-            source_tokens,
-            tokenized_text,
-            token_offset,
-            char_offset,
-            fuzzy_alignment_threshold,
-            tokenizer_impl=tokenizer_impl,
-        )
+        if fuzzy_alignment_algorithm == _FUZZY_ALGORITHM_LCS:
+          aligned_extraction = self._lcs_fuzzy_align_extraction(
+              extraction,
+              src_norm,
+              tokenized_text,
+              token_offset,
+              char_offset,
+              fuzzy_alignment_threshold=fuzzy_alignment_threshold,
+              fuzzy_alignment_min_density=fuzzy_alignment_min_density,
+              tokenizer_impl=tokenizer_impl,
+          )
+        else:
+          aligned_extraction = self._fuzzy_align_extraction(
+              extraction,
+              source_tokens,
+              tokenized_text,
+              token_offset,
+              char_offset,
+              fuzzy_alignment_threshold,
+              tokenizer_impl=tokenizer_impl,
+          )
         if aligned_extraction:
           aligned_extractions.append(aligned_extraction)
           logging.debug(
@@ -913,3 +1067,126 @@ def _normalize_token(token: str) -> str:
   if len(token) > 3 and token.endswith("s") and not token.endswith("ss"):
     token = token[:-1]
   return token
+
+
+_NO_MATCH = LcsSpan(matches=0, start=-1, end=-1)
+
+
+def _best_lcs_spans(
+    source: Sequence[str],
+    extraction: Sequence[str],
+) -> dict[int, LcsSpan]:
+  """Finds the tightest source span for each achievable match count.
+
+  Runs an O(n * m^2) time / O(m^2) memory DP with rolling rows on the
+  i dimension. For each (i, j, k), tracks the latest source index s
+  such that source[s..i) contains at least k tokens of extraction[0..j)
+  as a subsequence. Preferring later starts produces minimum-span
+  results; among spans of equal length, the earliest start wins.
+  Tracking per match count lets the caller try a denser k-1 match if
+  the maximum-match span fails a density gate.
+
+  Args:
+    source: Normalized source tokens.
+    extraction: Normalized extraction tokens.
+
+  Returns:
+    Dict mapping each achievable match count k (1..m) to its tightest
+    LcsSpan. Empty dict if no matches found.
+  """
+  n = len(source)
+  m = len(extraction)
+  if n == 0 or m == 0:
+    return {}
+
+  # Rolling rows: prev_row[j][k] holds span_start[i-1][j][k],
+  # curr_row[j][k] holds span_start[i][j][k]. k=0 is trivially
+  # achievable: at i, source[i..i) is empty, so s=i gives 0 matches.
+  prev_row = [[-1] * (m + 1) for _ in range(m + 1)]
+  curr_row = [[-1] * (m + 1) for _ in range(m + 1)]
+  for j in range(m + 1):
+    prev_row[j][0] = 0  # i=0 base: k=0 achievable with s=0
+
+  # best_per_k[k] = tightest span seen so far with exactly k matches.
+  best_per_k: dict[int, LcsSpan] = {}
+
+  for i in range(1, n + 1):
+    src_tok = source[i - 1]
+    # Initialize column j=0 of curr_row: k=0 achievable with s=i, k>0 not.
+    curr_row[0][0] = i
+    for k in range(1, m + 1):
+      curr_row[0][k] = -1
+
+    for j in range(1, m + 1):
+      curr_row[j][0] = i
+      matches_here = src_tok == extraction[j - 1]
+      for k in range(1, m + 1):
+        skip_source = prev_row[j][k]
+        skip_extraction = curr_row[j - 1][k]
+        best = skip_source if skip_source > skip_extraction else skip_extraction
+        if matches_here:
+          if k == 1:
+            match_cand = i - 1
+          else:
+            match_cand = prev_row[j - 1][k - 1]
+          best = max(best, match_cand)
+        curr_row[j][k] = best
+
+    end = i - 1
+    for k in range(1, m + 1):
+      s = curr_row[m][k]
+      if s < 0:
+        continue
+      existing = best_per_k.get(k)
+      if existing is None:
+        best_per_k[k] = LcsSpan(matches=k, start=s, end=end)
+        continue
+      new_len = end - s + 1
+      cur_len = existing.span_len
+      if new_len < cur_len or (new_len == cur_len and s < existing.start):
+        best_per_k[k] = LcsSpan(matches=k, start=s, end=end)
+
+    prev_row, curr_row = curr_row, prev_row
+
+  return best_per_k
+
+
+def _best_lcs_span(
+    source: Sequence[str],
+    extraction: Sequence[str],
+) -> LcsSpan:
+  """Returns the max-match LCS span. Wrapper over _best_lcs_spans."""
+  spans = _best_lcs_spans(source, extraction)
+  if not spans:
+    return _NO_MATCH
+  return spans[max(spans.keys())]
+
+
+def _accept_lcs_match(
+    span: LcsSpan,
+    extraction_len: int,
+    threshold: float = _FUZZY_ALIGNMENT_MIN_THRESHOLD,
+    min_density: float = _FUZZY_ALIGNMENT_MIN_DENSITY,
+) -> bool:
+  """Applies coverage and density gates to an LCS result.
+
+  Coverage gate (threshold): did we find enough of the extraction?
+  Requires matches >= ceil(extraction_len * threshold).
+
+  Density gate (min_density): is the match tight enough? Requires
+  matches / span_len >= min_density, rejecting scattered matches
+  where matched tokens are spread across too much noise.
+
+  Args:
+    span: LcsSpan result from _best_lcs_span.
+    extraction_len: Number of tokens in the extraction.
+    threshold: Minimum fraction of the extraction that must match.
+    min_density: Minimum ratio of matched tokens to span length.
+  """
+  if span.matches == 0 or extraction_len == 0:
+    return False
+  needed = math.ceil(extraction_len * threshold)
+  if span.span_len <= 0:
+    return False
+  density = span.matches / span.span_len
+  return span.matches >= needed and density >= min_density

--- a/tests/fuzzy_alignment_cases_test.py
+++ b/tests/fuzzy_alignment_cases_test.py
@@ -20,10 +20,12 @@ exact token_interval, char_interval, and matched substring.
 """
 
 import random
+import warnings
 
 from absl.testing import absltest
 from absl.testing import parameterized
 
+from langextract import prompt_validation
 from langextract import resolver as resolver_lib
 from langextract.core import data
 from langextract.core import tokenizer as tokenizer_lib
@@ -120,8 +122,16 @@ def _plant_gapped(source, tokens, start, gap):
   return " ".join(words)
 
 
-def _run(source, extraction_text, tokenizer, aligner):
-  """Runs _fuzzy_align_extraction and returns the result."""
+def _run(
+    source,
+    extraction_text,
+    tokenizer,
+    aligner,
+    algorithm="lcs",
+    token_offset=0,
+    char_offset=0,
+):
+  """Runs fuzzy alignment using the requested algorithm and returns the result."""
   tokenized = tokenizer.tokenize(source)
   source_tokens = [
       source[t.char_interval.start_pos : t.char_interval.end_pos].lower()
@@ -130,12 +140,24 @@ def _run(source, extraction_text, tokenizer, aligner):
   extraction = data.Extraction(
       extraction_class="entity", extraction_text=extraction_text
   )
+  if algorithm == "lcs":
+    source_tokens_norm = [
+        resolver_lib._normalize_token(t) for t in source_tokens
+    ]
+    return aligner._lcs_fuzzy_align_extraction(
+        extraction=extraction,
+        source_tokens_norm=source_tokens_norm,
+        tokenized_text=tokenized,
+        token_offset=token_offset,
+        char_offset=char_offset,
+        tokenizer_impl=tokenizer,
+    )
   return aligner._fuzzy_align_extraction(
       extraction=extraction,
       source_tokens=source_tokens,
       tokenized_text=tokenized,
-      token_offset=0,
-      char_offset=0,
+      token_offset=token_offset,
+      char_offset=char_offset,
       tokenizer_impl=tokenizer,
   )
 
@@ -150,8 +172,72 @@ _GAPPED = _plant_gapped(
 )
 
 
+_PLANTED_POSITIVE_CASES = (
+    dict(
+        testcase_name="contiguous_lcs",
+        algorithm="lcs",
+        source=_PLANTED,
+        extraction_text="metformin hydrochloride tablet",
+        expect_token_interval=(50, 53),
+        expect_char_interval=(451, 481),
+        expect_substring="metformin hydrochloride tablet",
+    ),
+    dict(
+        testcase_name="contiguous_legacy",
+        algorithm="legacy",
+        source=_PLANTED,
+        extraction_text="metformin hydrochloride tablet",
+        expect_token_interval=(50, 53),
+        expect_char_interval=(451, 481),
+        expect_substring="metformin hydrochloride tablet",
+    ),
+    dict(
+        testcase_name="fuzzy_stemming_lcs",
+        algorithm="lcs",
+        source=_PLANTED,
+        extraction_text="metformins hydrochlorides tablets",
+        expect_token_interval=(50, 53),
+        expect_char_interval=(451, 481),
+        expect_substring="metformin hydrochloride tablet",
+    ),
+    dict(
+        testcase_name="fuzzy_stemming_legacy",
+        algorithm="legacy",
+        source=_PLANTED,
+        extraction_text="metformins hydrochlorides tablets",
+        expect_token_interval=(50, 53),
+        expect_char_interval=(451, 481),
+        expect_substring="metformin hydrochloride tablet",
+    ),
+    dict(
+        testcase_name="gapped_lcs",
+        algorithm="lcs",
+        source=_GAPPED,
+        extraction_text="metformin hydrochloride tablet",
+        expect_token_interval=(40, 49),
+        expect_char_interval=(371, 461),
+        expect_substring=(
+            "metformin pulmonary antibiotics assessment"
+            " hydrochloride hypertension pressure with tablet"
+        ),
+    ),
+    dict(
+        testcase_name="gapped_legacy",
+        algorithm="legacy",
+        source=_GAPPED,
+        extraction_text="metformin hydrochloride tablet",
+        expect_token_interval=(40, 49),
+        expect_char_interval=(371, 461),
+        expect_substring=(
+            "metformin pulmonary antibiotics assessment"
+            " hydrochloride hypertension pressure with tablet"
+        ),
+    ),
+)
+
+
 class FuzzyAlignmentCasesTest(parameterized.TestCase):
-  """Planted-span oracle tests for _fuzzy_align_extraction."""
+  """Planted-span oracle tests for the fuzzy aligners."""
 
   def setUp(self):
     super().setUp()
@@ -159,45 +245,24 @@ class FuzzyAlignmentCasesTest(parameterized.TestCase):
     self._aligner = resolver_lib.WordAligner()
     resolver_lib._normalize_token.cache_clear()
 
-  @parameterized.named_parameters(
-      dict(
-          testcase_name="contiguous",
-          source=_PLANTED,
-          extraction_text="metformin hydrochloride tablet",
-          expect_token_interval=(50, 53),
-          expect_char_interval=(451, 481),
-          expect_substring="metformin hydrochloride tablet",
-      ),
-      dict(
-          testcase_name="fuzzy_stemming",
-          source=_PLANTED,
-          extraction_text="metformins hydrochlorides tablets",
-          expect_token_interval=(50, 53),
-          expect_char_interval=(451, 481),
-          expect_substring="metformin hydrochloride tablet",
-      ),
-      dict(
-          testcase_name="gapped",
-          source=_GAPPED,
-          extraction_text="metformin hydrochloride tablet",
-          expect_token_interval=(40, 49),
-          expect_char_interval=(371, 461),
-          expect_substring=(
-              "metformin pulmonary antibiotics assessment"
-              " hydrochloride hypertension pressure with tablet"
-          ),
-      ),
-  )
+  @parameterized.named_parameters(*_PLANTED_POSITIVE_CASES)
   def test_planted_positive(
       self,
+      algorithm,
       source,
       extraction_text,
       expect_token_interval,
       expect_char_interval,
       expect_substring,
   ):
-    """Planted spans align to their expected token and char positions."""
-    result = _run(source, extraction_text, self._tokenizer, self._aligner)
+    """Both algorithms agree on the planted oracle spans."""
+    result = _run(
+        source,
+        extraction_text,
+        self._tokenizer,
+        self._aligner,
+        algorithm=algorithm,
+    )
 
     self.assertIsNotNone(result)
     self.assertEqual(result.alignment_status, data.AlignmentStatus.MATCH_FUZZY)
@@ -217,15 +282,374 @@ class FuzzyAlignmentCasesTest(parameterized.TestCase):
     ]
     self.assertEqual(matched, expect_substring)
 
-  def test_planted_negative(self):
+  @parameterized.named_parameters(
+      dict(testcase_name="lcs", algorithm="lcs"),
+      dict(testcase_name="legacy", algorithm="legacy"),
+  )
+  def test_planted_negative(self, algorithm):
     """Tokens absent from the source produce no alignment."""
     result = _run(
         _BASE_200,
         "warfarin coumadin anticoagulant",
         self._tokenizer,
         self._aligner,
+        algorithm=algorithm,
     )
     self.assertIsNone(result)
+
+
+class LcsBestSpanTest(parameterized.TestCase):
+  """Unit tests for the pure LCS DP helper."""
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="repeated_token_min_span",
+          source=["a", "a", "b"],
+          extraction=["a", "b"],
+          expect=(2, 1, 2),
+      ),
+      dict(
+          testcase_name="single_token_reuse_forbidden",
+          source=["a"],
+          extraction=["a", "a"],
+          expect=(1, 0, 0),
+      ),
+      dict(
+          testcase_name="contiguous",
+          source=["x", "a", "b", "c", "y"],
+          extraction=["a", "b", "c"],
+          expect=(3, 1, 3),
+      ),
+      dict(
+          testcase_name="gapped",
+          source=["a", "x", "b", "y", "c"],
+          extraction=["a", "b", "c"],
+          expect=(3, 0, 4),
+      ),
+      dict(
+          testcase_name="negative",
+          source=["a", "b", "c"],
+          extraction=["x", "y", "z"],
+          expect=(0, -1, -1),
+      ),
+      dict(
+          testcase_name="tie_break_earliest_start",
+          source=["a", "b", "c", "a", "b", "c"],
+          extraction=["a", "b", "c"],
+          expect=(3, 0, 2),
+      ),
+      dict(
+          testcase_name="empty_source",
+          source=[],
+          extraction=["a"],
+          expect=(0, -1, -1),
+      ),
+      dict(
+          testcase_name="empty_extraction",
+          source=["a"],
+          extraction=[],
+          expect=(0, -1, -1),
+      ),
+  )
+  def test_best_lcs_span(self, source, extraction, expect):
+    result = resolver_lib._best_lcs_span(source, extraction)
+    self.assertEqual((result.matches, result.start, result.end), expect)
+
+
+class LcsAcceptanceGateTest(parameterized.TestCase):
+  """Tests for the coverage + density acceptance gate."""
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="perfect_coverage",
+          matches=3,
+          start=0,
+          end=2,
+          ext_len=3,
+          expect=True,
+      ),
+      dict(
+          testcase_name="density_ok_on_gapped",
+          matches=3,
+          start=0,
+          end=8,
+          ext_len=3,
+          expect=True,
+      ),
+      dict(
+          testcase_name="density_too_sparse",
+          matches=3,
+          start=0,
+          end=9,
+          ext_len=3,
+          expect=False,
+      ),
+      dict(
+          testcase_name="coverage_below_ceil",
+          matches=2,
+          start=0,
+          end=2,
+          ext_len=3,
+          expect=False,
+      ),
+      dict(
+          testcase_name="ceil_boundary",
+          matches=3,
+          start=0,
+          end=2,
+          ext_len=4,
+          expect=True,
+      ),
+      dict(
+          testcase_name="zero_matches",
+          matches=0,
+          start=-1,
+          end=-1,
+          ext_len=3,
+          expect=False,
+      ),
+  )
+  def test_accept_lcs_match(self, matches, start, end, ext_len, expect):
+    span = resolver_lib.LcsSpan(matches=matches, start=start, end=end)
+    self.assertEqual(resolver_lib._accept_lcs_match(span, ext_len), expect)
+
+
+class LcsFuzzyAlignmentEdgeCasesTest(absltest.TestCase):
+  """LCS-specific regression tests on _lcs_fuzzy_align_extraction."""
+
+  def setUp(self):
+    super().setUp()
+    self._tokenizer = tokenizer_lib.RegexTokenizer()
+    self._aligner = resolver_lib.WordAligner()
+    resolver_lib._normalize_token.cache_clear()
+
+  def test_repeated_token_selects_min_span(self):
+    """With "a a b" and extraction "a b" the second "a" is chosen."""
+    result = _run(
+        "a a b",
+        "a b",
+        self._tokenizer,
+        self._aligner,
+        algorithm="lcs",
+    )
+    self.assertIsNotNone(result)
+    self.assertEqual(
+        (
+            result.token_interval.start_index,
+            result.token_interval.end_index,
+        ),
+        (1, 3),
+    )
+    self.assertEqual(
+        (result.char_interval.start_pos, result.char_interval.end_pos),
+        (2, 5),
+    )
+
+  def test_density_gate_rejects_over_sparse(self):
+    """A 3-token extraction scattered over a 10-token span fails density."""
+    source = (
+        "metformin alpha beta gamma delta epsilon zeta hydrochloride eta tablet"
+    )
+    result = _run(
+        source,
+        "metformin hydrochloride tablet",
+        self._tokenizer,
+        self._aligner,
+        algorithm="lcs",
+    )
+    self.assertIsNone(result)
+
+  def test_algorithm_switch_legacy_rejects_lcs_accepts(self):
+    source = "alpha beta gamma"
+    extraction_text = "alpha beta gamma delta"
+
+    lcs_result = _run(
+        source,
+        extraction_text,
+        self._tokenizer,
+        self._aligner,
+        algorithm="lcs",
+    )
+    self.assertIsNotNone(lcs_result)
+    self.assertEqual(
+        (
+            lcs_result.token_interval.start_index,
+            lcs_result.token_interval.end_index,
+        ),
+        (0, 3),
+    )
+
+    legacy_result = _run(
+        source,
+        extraction_text,
+        self._tokenizer,
+        self._aligner,
+        algorithm="legacy",
+    )
+    self.assertIsNone(legacy_result)
+
+  def test_sparse_max_match_falls_back_to_dense_submatch(self):
+    """Sparse k=m span failing density should not hide a denser k=m-1 span."""
+    # Source: one leading extraction token, long noise, then a dense cluster
+    # of the remaining extraction tokens. The 4-of-4 span is too sparse to
+    # pass density, but the 3-of-4 dense suffix should still be accepted.
+    source = (
+        "alpha noise noise noise noise noise noise noise noise noise noise"
+        " beta gamma delta"
+    )
+    result = _run(
+        source,
+        "alpha beta gamma delta",
+        self._tokenizer,
+        self._aligner,
+        algorithm="lcs",
+    )
+    self.assertIsNotNone(result)
+    self.assertEqual(
+        (
+            result.token_interval.start_index,
+            result.token_interval.end_index,
+        ),
+        (11, 14),
+    )
+
+  def test_offsets_are_propagated(self):
+    """Nonzero token and char offsets are added to the returned intervals."""
+    result = _run(
+        "metformin hydrochloride tablet",
+        "metformin hydrochloride tablet",
+        self._tokenizer,
+        self._aligner,
+        algorithm="lcs",
+        token_offset=10,
+        char_offset=100,
+    )
+    self.assertIsNotNone(result)
+    self.assertEqual(
+        (
+            result.token_interval.start_index,
+            result.token_interval.end_index,
+        ),
+        (10, 13),
+    )
+    self.assertEqual(
+        (result.char_interval.start_pos, result.char_interval.end_pos),
+        (100, 130),
+    )
+
+
+class PositionalCallCompatTest(absltest.TestCase):
+  """Old positional call shapes must not break after adding new params."""
+
+  def test_align_extractions_positional(self):
+    """align_extractions(..., threshold, accept_lesser, tokenizer) still binds correctly."""
+    aligner = resolver_lib.WordAligner()
+    extraction = data.Extraction(
+        extraction_class="med", extraction_text="aspirin"
+    )
+    source = "patient takes aspirin daily"
+    groups = aligner.align_extractions(
+        [[extraction]],
+        source,
+        0,  # token_offset
+        0,  # char_offset
+        "\u241F",  # delim
+        True,  # enable_fuzzy_alignment
+        0.75,  # fuzzy_alignment_threshold
+        True,  # accept_match_lesser
+        None,  # tokenizer_impl
+    )
+    self.assertLen(groups, 1)
+    self.assertEqual(
+        groups[0][0].alignment_status,
+        data.AlignmentStatus.MATCH_EXACT,
+    )
+
+  def test_alignment_policy_positional(self):
+    """AlignmentPolicy(True, 0.75, True) preserves old 3-arg shape."""
+    policy = prompt_validation.AlignmentPolicy(True, 0.75, True)
+    self.assertTrue(policy.enable_fuzzy_alignment)
+    self.assertEqual(policy.fuzzy_alignment_threshold, 0.75)
+    self.assertTrue(policy.accept_match_lesser)
+    self.assertEqual(policy.fuzzy_alignment_algorithm, "lcs")
+
+  def test_alignment_policy_rejects_fourth_positional(self):
+    """New fields cannot be passed positionally."""
+    with self.assertRaises(TypeError):
+      prompt_validation.AlignmentPolicy(True, 0.75, True, "legacy")
+
+
+class ParameterValidationTest(parameterized.TestCase):
+  """Parameter validation at the alignment boundary."""
+
+  def setUp(self):
+    super().setUp()
+    self._aligner = resolver_lib.WordAligner()
+    self._extraction = data.Extraction(
+        extraction_class="med", extraction_text="aspirin"
+    )
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="out_of_range_threshold",
+          kwargs={"fuzzy_alignment_threshold": 1.5},
+      ),
+      dict(
+          testcase_name="out_of_range_min_density",
+          kwargs={"fuzzy_alignment_min_density": -0.1},
+      ),
+      dict(
+          testcase_name="invalid_algorithm",
+          kwargs={"fuzzy_alignment_algorithm": "bogus"},
+      ),
+  )
+  def test_invalid_params_raise(self, kwargs):
+    with self.assertRaises(ValueError):
+      self._aligner.align_extractions(
+          [[self._extraction]],
+          "patient takes aspirin",
+          **kwargs,
+      )
+
+  def test_disabled_fuzzy_skips_param_validation(self):
+    """Bogus fuzzy params are ignored when fuzzy alignment is disabled."""
+    self._aligner.align_extractions(
+        [[self._extraction]],
+        "patient takes aspirin",
+        enable_fuzzy_alignment=False,
+        fuzzy_alignment_algorithm="bogus",
+        fuzzy_alignment_min_density=-0.1,
+    )
+
+  def test_disabled_fuzzy_skips_deprecation_warning(self):
+    """Legacy algorithm selector is silent when fuzzy alignment is off."""
+    with warnings.catch_warnings(record=True) as caught:
+      warnings.simplefilter("always")
+      self._aligner.align_extractions(
+          [[self._extraction]],
+          "patient takes aspirin",
+          enable_fuzzy_alignment=False,
+          fuzzy_alignment_algorithm="legacy",
+      )
+    deprecations = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    self.assertEmpty(deprecations)
+
+  def test_legacy_dispatch_warns(self):
+    """Legacy algorithm emits DeprecationWarning at the dispatch site."""
+    with warnings.catch_warnings(record=True) as caught:
+      warnings.simplefilter("always")
+      self._aligner.align_extractions(
+          [[self._extraction]],
+          "patient takes aspirin",
+          fuzzy_alignment_algorithm="legacy",
+      )
+    deprecations = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    self.assertLen(deprecations, 1)
+    self.assertIn("legacy", str(deprecations[0].message))
 
 
 if __name__ == "__main__":

--- a/tests/prompt_validation_test.py
+++ b/tests/prompt_validation_test.py
@@ -14,6 +14,8 @@
 
 """Tests for prompt validation module."""
 
+import warnings
+
 from absl.testing import absltest
 from absl.testing import parameterized
 
@@ -420,6 +422,113 @@ class ExtractIntegrationTest(absltest.TestCase):
           prompt_validation_level=prompt_validation.PromptValidationLevel.ERROR,
           model_id="fake-model",
       )
+
+
+class AlgorithmPolicyIntegrationTest(absltest.TestCase):
+  """Tests that extract() builds AlignmentPolicy from resolver_params."""
+
+  def test_lcs_accepts_short_source_legacy_rejects(self):
+    """Prompt validation respects fuzzy_alignment_algorithm from resolver_params."""
+    examples = [
+        data.ExampleData(
+            text="alpha beta gamma",
+            extractions=[
+                data.Extraction(
+                    extraction_class="entity",
+                    extraction_text="alphas betas gammas deltas",
+                    attributes={},
+                )
+            ],
+        )
+    ]
+
+    try:
+      extraction.extract(
+          text_or_documents="Test",
+          prompt_description="Extract entities",
+          examples=examples,
+          prompt_validation_level=(
+              prompt_validation.PromptValidationLevel.ERROR
+          ),
+          model_id="fake-model",
+      )
+    except prompt_validation.PromptAlignmentError:
+      self.fail("LCS prompt validation should not raise for this example")
+    except Exception:  # pylint: disable=broad-except
+      pass
+
+    with self.assertRaises(prompt_validation.PromptAlignmentError):
+      extraction.extract(
+          text_or_documents="Test",
+          prompt_description="Extract entities",
+          examples=examples,
+          resolver_params={"fuzzy_alignment_algorithm": "legacy"},
+          prompt_validation_level=(
+              prompt_validation.PromptValidationLevel.ERROR
+          ),
+          model_id="fake-model",
+      )
+
+
+class LegacyDeprecationWarningTest(absltest.TestCase):
+  """Legacy algorithm emits DeprecationWarning from extract()."""
+
+  def _make_examples(self):
+    return [
+        data.ExampleData(
+            text="patient takes aspirin",
+            extractions=[
+                data.Extraction(
+                    extraction_class="med",
+                    extraction_text="aspirin",
+                    attributes={},
+                )
+            ],
+        )
+    ]
+
+  def test_legacy_emits_warning_via_extract(self):
+    """Warning fires when extract() routes through prompt validation."""
+    with warnings.catch_warnings(record=True) as caught:
+      warnings.simplefilter("always")
+      try:
+        extraction.extract(
+            text_or_documents="Test",
+            prompt_description="Extract medications",
+            examples=self._make_examples(),
+            resolver_params={"fuzzy_alignment_algorithm": "legacy"},
+            prompt_validation_level=(
+                prompt_validation.PromptValidationLevel.WARNING
+            ),
+            model_id="fake-model",
+        )
+      except Exception:  # pylint: disable=broad-except
+        pass
+    deprecations = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    self.assertGreaterEqual(len(deprecations), 1)
+    self.assertTrue(any("legacy" in str(w.message) for w in deprecations))
+
+  def test_lcs_default_does_not_warn(self):
+    with warnings.catch_warnings(record=True) as caught:
+      warnings.simplefilter("always")
+      try:
+        extraction.extract(
+            text_or_documents="Test",
+            prompt_description="Extract medications",
+            examples=self._make_examples(),
+            prompt_validation_level=(
+                prompt_validation.PromptValidationLevel.WARNING
+            ),
+            model_id="fake-model",
+        )
+      except Exception:  # pylint: disable=broad-except
+        pass
+    deprecations = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    self.assertFalse(any("legacy" in str(w.message) for w in deprecations))
 
 
 if __name__ == "__main__":

--- a/tests/resolver_test.py
+++ b/tests/resolver_test.py
@@ -1620,8 +1620,6 @@ class AlignEntitiesTest(parameterized.TestCase):
       ),
       dict(
           testcase_name="fuzzy_alignment_partial_overlap_success",
-          # An extraction where the number of matched tokens divided by total extraction tokens
-          # is >= the threshold (3/4 = 0.75).
           extractions=[[
               data.Extraction(
                   extraction_class="finding",
@@ -1635,11 +1633,10 @@ class AlignEntitiesTest(parameterized.TestCase):
               data.Extraction(
                   extraction_class="finding",
                   extraction_text="mild degenerative disc disease",
-                  # The best window found is "degenerative disc disease"
                   token_interval=tokenizer.TokenInterval(
                       start_index=3, end_index=6
                   ),
-                  char_interval=data.CharInterval(start_pos=20, end_pos=50),
+                  char_interval=data.CharInterval(start_pos=25, end_pos=50),
                   alignment_status=data.AlignmentStatus.MATCH_FUZZY,
               )
           ]],


### PR DESCRIPTION
Fixes #386, fixes #197. Related: #188.

## Summary

Replace the legacy fuzzy aligner with an O(n·m²) time, O(m²) memory
LCS DP gated by coverage and density rules, where n is source length
and m is extraction length (typically 3-8 tokens). The old path
enumerated candidate windows and scored each with difflib, which
scales badly on long documents.

Speedup: 1,000-token sources drop from ~33s to under 5ms; 5,000-token
sources from ~69min (est.) to under 20ms.

## Changes

- LCS DP with rolling rows: O(m²) memory regardless of source length,
  no allocation guard needed
- Tightest span tracked per achievable match count, so a denser
  sub-match can be considered when the max-match span fails density
- Coverage and density acceptance gates to reject weak partial matches
- Pre-normalized source tokens computed once per chunk
- New params are keyword-only; positional callers are unaffected
- Fuzzy-param validation and deprecation warning gated behind
  enable_fuzzy_alignment so exact-match-only callers stay quiet
- Algorithm choice is consistent between prompt validation and runtime
- Legacy algorithm kept as a deprecated opt-out with DeprecationWarning

## Test plan

- 443 tests pass (39 new)
- Covers LCS correctness, acceptance gates, sparse-vs-dense submatch
  regression, positional API compat, deprecation warning, param
  validation, fuzzy-disabled quiet path, and end-to-end extract()
  integration