### PR TITLE
Fix Ollama API compatibility for newer versions

### DIFF
--- a/langextract/plugins.py
+++ b/langextract/plugins.py
@@ -19,9 +19,9 @@ It supports both built-in providers and third-party providers via entry points.
 """
 from __future__ import annotations
 
-from importlib import metadata
 import functools
 import importlib
+from importlib import metadata
 
 from absl import logging
 

--- a/langextract/plugins.py
+++ b/langextract/plugins.py
@@ -19,9 +19,9 @@ It supports both built-in providers and third-party providers via entry points.
 """
 from __future__ import annotations
 
+from importlib import metadata
 import functools
 import importlib
-from importlib import metadata
 
 from absl import logging
 

--- a/langextract/providers/__init__.py
+++ b/langextract/providers/__init__.py
@@ -19,8 +19,8 @@ Each provider can be imported independently for fine-grained dependency
 management in build systems.
 """
 
-import importlib
 from importlib import metadata
+import importlib
 import os
 
 from absl import logging

--- a/langextract/providers/__init__.py
+++ b/langextract/providers/__init__.py
@@ -19,8 +19,8 @@ Each provider can be imported independently for fine-grained dependency
 management in build systems.
 """
 
-from importlib import metadata
 import importlib
+from importlib import metadata
 import os
 
 from absl import logging

--- a/langextract/providers/ollama.py
+++ b/langextract/providers/ollama.py
@@ -269,7 +269,9 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
             model_url=self._model_url,
             **combined_kwargs,
         )
-        yield [core_types.ScoredOutput(score=1.0, output=response['response'])]
+        # Handle Ollama API changes: newer versions may put content in 'thinking' instead of 'response'
+        output = response.get('response') or response.get('thinking', '')
+        yield [core_types.ScoredOutput(score=1.0, output=output)]
       except Exception as e:
         raise exceptions.InferenceRuntimeError(
             f'Ollama API error: {str(e)}', original=e
@@ -332,7 +334,7 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
 
     Returns:
       A mapping (dictionary-like) containing the server's JSON response. For
-      non-streaming calls, the `"response"` key typically contains the entire
+      non-streaming calls, the `"response"` or `"thinking"` key contains the entire
       generated text.
 
     Raises:

--- a/langextract/providers/ollama.py
+++ b/langextract/providers/ollama.py
@@ -256,7 +256,8 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
     Yields:
       Lists of ScoredOutputs.
     """
-    combined_kwargs = self.merge_kwargs(kwargs)
+    combined_kwargs = dict(self.merge_kwargs(kwargs))
+    combined_kwargs.setdefault('think', False)
 
     for prompt in batch_prompts:
       try:
@@ -269,13 +270,33 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
             model_url=self._model_url,
             **combined_kwargs,
         )
-        # Handle Ollama API changes: newer versions may put content in 'thinking' instead of 'response'
-        output = response.get('response') or response.get('thinking', '')
+        output = self._extract_response_text(response)
         yield [core_types.ScoredOutput(score=1.0, output=output)]
+      except exceptions.InferenceError:
+        raise
       except Exception as e:
         raise exceptions.InferenceRuntimeError(
-            f'Ollama API error: {str(e)}', original=e
+            f'Ollama API error: {str(e)}', original=e, provider='Ollama'
         ) from e
+
+  @staticmethod
+  def _extract_response_text(response: Mapping[str, Any]) -> str:
+    """Returns final generated text from an Ollama generate response."""
+    output = response.get('response')
+    if output:
+      return output
+
+    if response.get('thinking'):
+      raise exceptions.InferenceRuntimeError(
+          'Ollama returned an empty response with a thinking trace. The '
+          'thinking field contains reasoning, not final output.',
+          provider='Ollama',
+      )
+    raise exceptions.InferenceRuntimeError(
+        "Ollama response did not include generated text in the 'response' "
+        'field.',
+        provider='Ollama',
+    )
 
   def _ollama_query(
       self,
@@ -292,6 +313,7 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
       model_url: str | None = None,
       timeout: int | None = None,
       keep_alive: int | None = None,
+      think: bool | None = None,
       num_threads: int | None = None,
       num_ctx: int | None = None,
       stop: str | list[str] | None = None,
@@ -325,6 +347,8 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
       timeout: Timeout (in seconds) for the HTTP request. Defaults to 120.
       keep_alive: How long (in seconds) the model remains loaded after
         generation completes.
+      think: Whether Ollama should return a separate reasoning trace for
+        thinking models.
       num_threads: Number of CPU threads to use. If None, Ollama uses a default
         heuristic.
       num_ctx: Number of context tokens allowed. If None, uses model's default
@@ -334,8 +358,9 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
 
     Returns:
       A mapping (dictionary-like) containing the server's JSON response. For
-      non-streaming calls, the `"response"` or `"thinking"` key contains the entire
-      generated text.
+      non-streaming calls, the `"response"` key contains the final generated
+      text. Thinking models may also return a separate `"thinking"` key with
+      reasoning text.
 
     Raises:
       InferenceConfigError: If the server returns a 404 (model not found).
@@ -408,6 +433,9 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
 
     if structured_output_format is not None:
       payload['format'] = structured_output_format
+
+    if think is not None:
+      payload['think'] = think
 
     if stop is not None:
       payload['stop'] = stop

--- a/langextract/providers/ollama.py
+++ b/langextract/providers/ollama.py
@@ -257,6 +257,7 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
       Lists of ScoredOutputs.
     """
     combined_kwargs = dict(self.merge_kwargs(kwargs))
+    # LangExtract consumes final structured output, not Ollama reasoning traces.
     combined_kwargs.setdefault('think', False)
 
     for prompt in batch_prompts:
@@ -289,7 +290,8 @@ class OllamaLanguageModel(base_model.BaseLanguageModel):
     if response.get('thinking'):
       raise exceptions.InferenceRuntimeError(
           'Ollama returned an empty response with a thinking trace. The '
-          'thinking field contains reasoning, not final output.',
+          'thinking field contains reasoning, not final output. Ensure Ollama '
+          'extraction requests use think=False, which is LangExtract default.',
           provider='Ollama',
       )
     raise exceptions.InferenceRuntimeError(

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -152,6 +152,7 @@ class TestOllamaLanguageModel(absltest.TestCase):
         model="gemma2:latest",
         structured_output_format="json",
         model_url="http://localhost:11434",
+        think=False,
     )
     expected_results = [[
         types.ScoredOutput(
@@ -161,16 +162,13 @@ class TestOllamaLanguageModel(absltest.TestCase):
     self.assertEqual(results, expected_results)
 
   @mock.patch("langextract.providers.ollama.OllamaLanguageModel._ollama_query")
-  def test_ollama_infer_with_thinking_key(self, mock_ollama_query):
-    """Test Ollama inference when response uses 'thinking' key instead of 'response'."""
-    # Response structure for newer Ollama versions that use 'thinking' key
+  def test_ollama_infer_prefers_response_over_thinking(self, mock_ollama_query):
+    """Test Ollama inference ignores reasoning when final output is present."""
     thinking_response = {
         "model": "deepseek-r1:latest",
         "created_at": "2025-01-23T22:37:08.579440841Z",
-        "response": "",  # Empty response
-        "thinking": (
-            "{'bus' : '**autóbusz**'} \n\n\n  \n"
-        ),  # Content in thinking
+        "response": "{'bus' : '**autóbusz**'} \n\n\n  \n",
+        "thinking": "The prompt asks for a Hungarian translation of bus.",
         "done": True,
         "done_reason": "stop",
         "context": [106, 1645, 108],
@@ -195,6 +193,7 @@ class TestOllamaLanguageModel(absltest.TestCase):
         model="deepseek-r1:latest",
         structured_output_format="json",
         model_url="http://localhost:11434",
+        think=False,
     )
     expected_results = [[
         types.ScoredOutput(
@@ -202,6 +201,73 @@ class TestOllamaLanguageModel(absltest.TestCase):
         )
     ]]
     self.assertEqual(results, expected_results)
+
+  @mock.patch("langextract.providers.ollama.OllamaLanguageModel._ollama_query")
+  def test_ollama_infer_raises_on_empty_response_with_thinking(
+      self, mock_ollama_query
+  ):
+    """Test Ollama inference does not treat reasoning as final output."""
+    mock_ollama_query.return_value = {
+        "model": "deepseek-r1:latest",
+        "created_at": "2025-01-23T22:37:08.579440841Z",
+        "response": "",
+        "thinking": "The prompt asks for a Hungarian translation of bus.",
+        "done": True,
+        "done_reason": "stop",
+    }
+    model = ollama.OllamaLanguageModel(
+        model_id="deepseek-r1:latest",
+        model_url="http://localhost:11434",
+        structured_output_format="json",
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError, "thinking trace"
+    ):
+      list(model.infer(["What is bus in Hungarian?"]))
+
+  @mock.patch("langextract.providers.ollama.OllamaLanguageModel._ollama_query")
+  def test_ollama_infer_raises_when_response_missing(self, mock_ollama_query):
+    """Test Ollama inference requires final generated text."""
+    mock_ollama_query.return_value = {
+        "model": "deepseek-r1:latest",
+        "created_at": "2025-01-23T22:37:08.579440841Z",
+        "done": True,
+        "done_reason": "stop",
+    }
+    model = ollama.OllamaLanguageModel(
+        model_id="deepseek-r1:latest",
+        model_url="http://localhost:11434",
+        structured_output_format="json",
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError, "response.*field"
+    ):
+      list(model.infer(["What is bus in Hungarian?"]))
+
+  @mock.patch("langextract.providers.ollama.OllamaLanguageModel._ollama_query")
+  def test_ollama_infer_preserves_explicit_think(self, mock_ollama_query):
+    """Test user-provided think setting is passed through."""
+    mock_ollama_query.return_value = {
+        "response": '{"test": "value"}',
+        "done": True,
+    }
+    model = ollama.OllamaLanguageModel(
+        model_id="deepseek-r1:latest",
+        model_url="http://localhost:11434",
+        structured_output_format="json",
+    )
+
+    list(model.infer(["Test prompt"], think=True))
+
+    mock_ollama_query.assert_called_once_with(
+        prompt="Test prompt",
+        model="deepseek-r1:latest",
+        structured_output_format="json",
+        model_url="http://localhost:11434",
+        think=True,
+    )
 
   @mock.patch("requests.post")
   def test_ollama_extra_kwargs_passed_to_api(self, mock_post):
@@ -229,6 +295,8 @@ class TestOllamaLanguageModel(absltest.TestCase):
     json_payload = call_args.kwargs["json"]
 
     self.assertEqual(json_payload["keep_alive"], 600)
+    self.assertIs(json_payload["think"], False)
+    self.assertNotIn("think", json_payload["options"])
     self.assertEqual(json_payload["options"]["keep_alive"], 600)
     self.assertEqual(json_payload["options"]["num_thread"], 8)
     # timeout is passed to requests.post, not in the JSON payload

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -222,7 +222,7 @@ class TestOllamaLanguageModel(absltest.TestCase):
     )
 
     with self.assertRaisesRegex(
-        exceptions.InferenceRuntimeError, "thinking trace"
+        exceptions.InferenceRuntimeError, "think=False"
     ):
       list(model.infer(["What is bus in Hungarian?"]))
 
@@ -268,6 +268,28 @@ class TestOllamaLanguageModel(absltest.TestCase):
         model_url="http://localhost:11434",
         think=True,
     )
+
+  @mock.patch("langextract.providers.ollama.OllamaLanguageModel._ollama_query")
+  def test_ollama_infer_default_think_does_not_mutate_stored_kwargs(
+      self, mock_ollama_query
+  ):
+    """Test default think setting is per request only."""
+    mock_ollama_query.return_value = {
+        "response": '{"test": "value"}',
+        "done": True,
+    }
+    model = ollama.OllamaLanguageModel(
+        model_id="deepseek-r1:latest",
+        model_url="http://localhost:11434",
+        structured_output_format="json",
+        temperature=0.1,
+    )
+    stored_kwargs = model.merge_kwargs()
+
+    list(model.infer(["Test prompt"]))
+
+    self.assertEqual(model.merge_kwargs(), stored_kwargs)
+    self.assertNotIn("think", model.merge_kwargs())
 
   @mock.patch("requests.post")
   def test_ollama_extra_kwargs_passed_to_api(self, mock_post):

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -160,6 +160,49 @@ class TestOllamaLanguageModel(absltest.TestCase):
     ]]
     self.assertEqual(results, expected_results)
 
+  @mock.patch("langextract.providers.ollama.OllamaLanguageModel._ollama_query")
+  def test_ollama_infer_with_thinking_key(self, mock_ollama_query):
+    """Test Ollama inference when response uses 'thinking' key instead of 'response'."""
+    # Response structure for newer Ollama versions that use 'thinking' key
+    thinking_response = {
+        "model": "deepseek-r1:latest",
+        "created_at": "2025-01-23T22:37:08.579440841Z",
+        "response": "",  # Empty response
+        "thinking": (
+            "{'bus' : '**autóbusz**'} \n\n\n  \n"
+        ),  # Content in thinking
+        "done": True,
+        "done_reason": "stop",
+        "context": [106, 1645, 108],
+        "total_duration": 24038204381,
+        "load_duration": 21551375738,
+        "prompt_eval_count": 15,
+        "prompt_eval_duration": 633000000,
+        "eval_count": 17,
+        "eval_duration": 1848000000,
+    }
+    mock_ollama_query.return_value = thinking_response
+    model = ollama.OllamaLanguageModel(
+        model_id="deepseek-r1:latest",
+        model_url="http://localhost:11434",
+        structured_output_format="json",
+    )
+    batch_prompts = ["What is bus in Hungarian?"]
+    results = list(model.infer(batch_prompts))
+
+    mock_ollama_query.assert_called_once_with(
+        prompt="What is bus in Hungarian?",
+        model="deepseek-r1:latest",
+        structured_output_format="json",
+        model_url="http://localhost:11434",
+    )
+    expected_results = [[
+        types.ScoredOutput(
+            score=1.0, output="{'bus' : '**autóbusz**'} \n\n\n  \n"
+        )
+    ]]
+    self.assertEqual(results, expected_results)
+
   @mock.patch("requests.post")
   def test_ollama_extra_kwargs_passed_to_api(self, mock_post):
     """Verify extra kwargs like timeout and keep_alive are passed to the API."""

--- a/tests/provider_schema_test.py
+++ b/tests/provider_schema_test.py
@@ -252,6 +252,61 @@ class OllamaFormatParameterTest(absltest.TestCase):
         self.assertIsNotNone(result)
         self.assertIsInstance(result, data.AnnotatedDocument)
 
+  def test_extract_with_ollama_passes_think_parameter(self):
+    """Test that lx.extract() passes Ollama think parameter correctly."""
+    with mock.patch("requests.post", autospec=True) as mock_post:
+      mock_response = mock.Mock(spec=["status_code", "json"])
+      mock_response.status_code = 200
+      mock_response.json.return_value = {
+          "response": (
+              '{"extractions": [{"extraction_class": "test", "extraction_text":'
+              ' "example"}]}'
+          )
+      }
+      mock_post.return_value = mock_response
+
+      with mock.patch("langextract.providers.registry.resolve") as mock_resolve:
+        mock_resolve.return_value = ollama.OllamaLanguageModel
+
+        examples = [
+            data.ExampleData(
+                text="Sample text",
+                extractions=[
+                    data.Extraction(
+                        extraction_class="test",
+                        extraction_text="sample",
+                    )
+                ],
+            )
+        ]
+
+        lx.extract(
+            text_or_documents="Test document",
+            prompt_description="Extract test information",
+            examples=examples,
+            model_id="gemma2:2b",
+            model_url="http://localhost:11434",
+            format_type=data.FormatType.JSON,
+            language_model_params={"think": True},
+            use_schema_constraints=True,
+        )
+
+        mock_post.assert_called()
+
+        last_call = mock_post.call_args_list[-1]
+        payload = last_call[1]["json"]
+
+        self.assertIs(
+            payload["think"],
+            True,
+            msg="think should be top-level in the Ollama request",
+        )
+        self.assertNotIn(
+            "think",
+            payload["options"],
+            msg="think should not be passed inside Ollama options",
+        )
+
 
 class OllamaYAMLOverrideTest(absltest.TestCase):
   """Tests for Ollama YAML format override behavior."""


### PR DESCRIPTION
Fixes #413

## Description
Ollama thinking-capable models may return reasoning in `thinking` while final generated content belongs in `response`. This update makes LangExtract request final structured output with top-level `think=False` by default, read generated text only from `response`, and raise a clear error if Ollama returns only a thinking trace.

- Request `think=False` by default while preserving explicit `think=True` overrides
- Treat `thinking` as reasoning metadata, not extraction output
- Added regression tests for response/thinking handling and top-level `think` payload placement
- Updated Ollama response documentation to reflect the `thinking` field

## How Has This Been Tested?
- Ran `pytest tests -ra -m "not live_api"` (`414 passed`)
- Ran `tox -e format,lint-src,lint-tests`
- Verified live Ollama extraction with default `think=False` and explicit `think=True`

## Checklist
- [x] My code follows the style guidelines
- [x] I have self-reviewed my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests passed locally with my changes