### PR TITLE
fix: accept fenced JSON output in raw JSON mode for OpenAI-compatible backends

### DIFF
--- a/docs/examples/japanese_extraction.md
+++ b/docs/examples/japanese_extraction.md
@@ -51,7 +51,7 @@ for entity in result.extractions:
     if entity.char_interval:
         start, end = entity.char_interval.start_pos, entity.char_interval.end_pos
         position_info = f" (pos: {start}-{end})"
-    
+
     print(f"• {entity.extraction_class}: {entity.extraction_text}{position_info}")
 
 # Expected Output:

--- a/langextract/core/format_handler.py
+++ b/langextract/core/format_handler.py
@@ -299,17 +299,17 @@ class FormatHandler:
         candidates = [
             m
             for m in matches
-            if self._is_valid_language_tag(m.group('lang'), valid_tags)
+            if self._is_valid_language_tag(m.group("lang"), valid_tags)
         ]
 
         if len(candidates) == 1:
-          return candidates[0].group('body').strip()
+          return candidates[0].group("body").strip()
         if len(candidates) > 1:
           raise exceptions.FormatParseError(
-              'Multiple fenced blocks found. Expected exactly one.'
+              "Multiple fenced blocks found. Expected exactly one."
           )
         if not self.strict_fences and len(matches) == 1:
-          return matches[0].group('body').strip()
+          return matches[0].group("body").strip()
 
       return text.strip()
 

--- a/langextract/core/format_handler.py
+++ b/langextract/core/format_handler.py
@@ -288,6 +288,7 @@ class FormatHandler:
       FormatParseError: When fences required but not found or multiple
         blocks found.
     """
+    strip_text = text.strip()
     if not self.use_fences:
       matches = list(_FENCE_RE.finditer(text))
 
@@ -311,7 +312,7 @@ class FormatHandler:
         if not self.strict_fences and len(matches) == 1:
           return matches[0].group("body").strip()
 
-      return text.strip()
+      return strip_text
 
     matches = list(_FENCE_RE.finditer(text))
 
@@ -352,7 +353,7 @@ class FormatHandler:
           f"No {self.format_type.value} code block found."
       )
 
-    return text.strip()
+    return strip_text
 
   # ---- Backward compatibility methods (to be removed in v2.0.0) ----
 

--- a/langextract/core/format_handler.py
+++ b/langextract/core/format_handler.py
@@ -289,6 +289,28 @@ class FormatHandler:
         blocks found.
     """
     if not self.use_fences:
+      matches = list(_FENCE_RE.finditer(text))
+
+      if matches:
+        valid_tags = {
+            data.FormatType.YAML: {_YAML_FORMAT, _YML_FORMAT},
+            data.FormatType.JSON: {_JSON_FORMAT},
+        }
+        candidates = [
+            m
+            for m in matches
+            if self._is_valid_language_tag(m.group('lang'), valid_tags)
+        ]
+
+        if len(candidates) == 1:
+          return candidates[0].group('body').strip()
+        if len(candidates) > 1:
+          raise exceptions.FormatParseError(
+              'Multiple fenced blocks found. Expected exactly one.'
+          )
+        if not self.strict_fences and len(matches) == 1:
+          return matches[0].group('body').strip()
+
       return text.strip()
 
     matches = list(_FENCE_RE.finditer(text))

--- a/tests/format_handler_test.py
+++ b/tests/format_handler_test.py
@@ -273,6 +273,24 @@ class NonGeminiModelParsingTest(parameterized.TestCase):
     self.assertLen(parsed, 1)
     self.assertEqual(parsed[0]["person"], "Alice")
 
+  def test_fenced_json_accepted_when_fences_disabled(self):
+    # Some OpenAI-compatible backends may return fenced JSON even when raw
+    # JSON mode is expected.
+    handler = format_handler.FormatHandler(
+        format_type=data.FormatType.JSON,
+        use_wrapper=True,
+        wrapper_key="extractions",
+        use_fences=False,
+    )
+    fenced_json = textwrap.dedent("""
+        ```json
+        {"extractions": [{"person": "Alice"}]}
+        ```
+    """).strip()
+    parsed = handler.parse_output(fenced_json)
+    self.assertLen(parsed, 1)
+    self.assertEqual(parsed[0]["person"], "Alice")
+
   def test_top_level_list_accepted_as_fallback(self):
     # Some models return [...] instead of {"extractions": [...]}
     handler = format_handler.FormatHandler(


### PR DESCRIPTION
# Description

Fixes issue #414 where vLLM/lmdeploy OpenAI-compatible backends may return fenced JSON output even when LangExtract is configured for raw JSON mode. This updates `langextract/core/format_handler.py` so `FormatHandler._extract_content()` detects and strips a single fenced JSON block when `use_fences=False`, and adds a regression test for fenced JSON output in raw JSON mode.

Fixes #414

Bug fix

# How Has This Been Tested?

- Added regression test in `tests/format_handler_test.py`
- Verified modified files compile with `python3 -m py_compile`
- Full unit tests not run in the current environment due to missing `absl` dependency

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes
- [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.
