### PR TITLE
docs: add langextract-usage Agent Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ LangExtract supports custom LLM providers via a lightweight plugin system. You c
 
 See the detailed guide in [Provider System Documentation](langextract/providers/README.md) to learn how to:
 
-- Register a provider with `@registry.register(...)`
+- Register a provider with `@router.register(...)` from `langextract.providers`
 - Publish an entry point for discovery
 - Optionally provide a schema with `get_schema_class()` for structured output
 - Integrate with the factory via `create_model(...)`
@@ -310,18 +310,34 @@ LangExtract supports OpenAI models (requires optional dependency: `pip install l
 ```python
 import langextract as lx
 
+# OPENAI_API_KEY in the environment is picked up automatically; pass
+# api_key=... explicitly only if you need to override it.
 result = lx.extract(
     text_or_documents=input_text,
     prompt_description=prompt,
     examples=examples,
     model_id="gpt-4o",  # Automatically selects OpenAI provider
-    api_key=os.environ.get('OPENAI_API_KEY'),
-    fence_output=True,
-    use_schema_constraints=False
 )
 ```
 
-Note: OpenAI models require `fence_output=True` and `use_schema_constraints=False` because LangExtract doesn't implement schema constraints for OpenAI yet.
+The OpenAI provider uses JSON mode and auto-determines fence and schema behavior — leave `fence_output` and `use_schema_constraints` unset.
+
+For OpenAI-compatible endpoints or non-GPT model IDs (which skip auto-routing), use `ModelConfig` with an explicit provider:
+
+```python
+from langextract.factory import ModelConfig
+
+result = lx.extract(
+    text_or_documents=input_text,
+    prompt_description=prompt,
+    examples=examples,
+    config=ModelConfig(
+        model_id="my-openai-compatible-model",
+        provider="openai",
+        provider_kwargs={"api_key": "sk-...", "base_url": "https://..."},
+    ),
+)
+```
 
 ## Using Local LLMs with Ollama
 LangExtract supports local inference using Ollama, allowing you to run models without API keys:
@@ -335,10 +351,10 @@ result = lx.extract(
     examples=examples,
     model_id="gemma2:2b",  # Automatically selects Ollama provider
     model_url="http://localhost:11434",
-    fence_output=False,
-    use_schema_constraints=False
 )
 ```
+
+The Ollama provider exposes `FormatModeSchema` for JSON mode. Leave `fence_output` and `use_schema_constraints` unset so the factory auto-configures from the provider's schema.
 
 **Quick setup:** Install Ollama from [ollama.com](https://ollama.com/), run `ollama pull gemma2:2b`, then `ollama serve`.
 

--- a/examples/custom_provider_plugin/README.md
+++ b/examples/custom_provider_plugin/README.md
@@ -28,10 +28,13 @@ custom_provider_plugin/
 ### Provider Implementation (`provider.py`)
 
 ```python
-@lx.providers.registry.register(
+from langextract.core import base_model
+from langextract.providers import router
+
+@router.register(
     r'^gemini',  # Pattern for model IDs this provider handles
 )
-class CustomGeminiProvider(lx.inference.BaseLanguageModel):
+class CustomGeminiProvider(base_model.BaseLanguageModel):
     def __init__(self, model_id: str, **kwargs):
         # Initialize your backend client
 
@@ -55,7 +58,9 @@ Providers can optionally implement custom schemas for structured output:
 **Flow:** Examples → `from_examples()` → `to_provider_config()` → Provider kwargs → Inference
 
 ```python
-class CustomProviderSchema(lx.schema.BaseSchema):
+from langextract.core import schema as core_schema
+
+class CustomProviderSchema(core_schema.BaseSchema):
     @classmethod
     def from_examples(cls, examples_data, attribute_suffix="_attributes"):
         # Analyze examples to find patterns
@@ -70,15 +75,15 @@ class CustomProviderSchema(lx.schema.BaseSchema):
         }
 
     @property
-    def supports_strict_mode(self):
-        # True = valid JSON output, no markdown fences needed
+    def requires_raw_output(self):
+        # True = provider emits raw JSON, no markdown fences needed
         return True
 ```
 
 Then in your provider:
 
 ```python
-class CustomProvider(lx.inference.BaseLanguageModel):
+class CustomProvider(base_model.BaseLanguageModel):
     @classmethod
     def get_schema_class(cls):
         return CustomProviderSchema  # Tell LangExtract about your schema
@@ -113,30 +118,32 @@ Since this example registers the same pattern as the default Gemini provider, yo
 ```python
 import langextract as lx
 
-# Create a configured model with explicit provider selection
+# Option A: build a model explicitly and pass it to extract()
 config = lx.factory.ModelConfig(
     model_id="gemini-2.5-flash",
     provider="CustomGeminiProvider",
-    provider_kwargs={"api_key": "your-api-key"}
+    provider_kwargs={"api_key": "your-api-key"},
 )
 model = lx.factory.create_model(config)
 
-# Note: Passing model directly to extract() is coming soon.
-# For now, use the model's infer() method directly or pass parameters individually:
 result = lx.extract(
     text_or_documents="Your text here",
-    model_id="gemini-2.5-flash",
-    api_key="your-api-key",
+    model=model,
     prompt_description="Extract key information",
-    examples=[...]
+    examples=[...],
 )
 
-# Coming soon: Direct model passing
-# result = lx.extract(
-#     text_or_documents="Your text here",
-#     model=model,  # Planned feature
-#     prompt_description="Extract key information"
-# )
+# Option B: let extract() build the model from a ModelConfig
+result = lx.extract(
+    text_or_documents="Your text here",
+    config=lx.factory.ModelConfig(
+        model_id="gemini-2.5-flash",
+        provider="CustomGeminiProvider",
+        provider_kwargs={"api_key": "your-api-key"},
+    ),
+    prompt_description="Extract key information",
+    examples=[...],
+)
 ```
 
 ## Creating Your Own Provider - Step by Step
@@ -160,7 +167,7 @@ Edit `pyproject.toml`:
 ### 3. Modify Provider Implementation
 Edit `provider.py`:
 - Change class name from `CustomGeminiProvider` to `MyProvider`
-- Update `@register()` patterns to match your model IDs
+- Update `@router.register(...)` patterns to match your model IDs
 - Replace Gemini API calls with your backend
 - Add any provider-specific parameters
 
@@ -169,7 +176,7 @@ Edit `schema.py`:
 - Rename to `MyProviderSchema`
 - Customize `from_examples()` for your extraction format
 - Update `to_provider_config()` for your API requirements
-- Set `supports_strict_mode` based on your capabilities
+- Implement `requires_raw_output` (abstract in `BaseSchema`) based on whether your provider emits raw JSON/YAML or fenced output
 
 ### 5. Install and Test
 ```bash
@@ -178,9 +185,9 @@ pip install -e .
 
 # Test your provider
 python -c "
-import langextract as lx
-lx.providers.load_plugins_once()
-print('Provider registered:', any('myprovider' in str(e) for e in lx.providers.registry.list_entries()))
+from langextract.providers import load_plugins_once, router
+load_plugins_once()
+print('Provider registered:', any('myprovider' in str(e) for e in router.list_entries()))
 "
 ```
 

--- a/examples/custom_provider_plugin/langextract_provider_example/provider.py
+++ b/examples/custom_provider_plugin/langextract_provider_example/provider.py
@@ -22,13 +22,17 @@ from typing import Any, Iterator, Sequence
 from langextract_provider_example import schema as custom_schema
 
 import langextract as lx
+from langextract.core import base_model
+from langextract.core import schema as core_schema
+from langextract.core import types
+from langextract.providers import router
 
 
-@lx.providers.registry.register(
+@router.register(
     r'^gemini',  # Matches Gemini model IDs (same as default provider)
 )
 @dataclasses.dataclass(init=False)
-class CustomGeminiProvider(lx.inference.BaseLanguageModel):
+class CustomGeminiProvider(base_model.BaseLanguageModel):
   """Example custom LangExtract provider implementation.
 
   This demonstrates how to create a custom provider for LangExtract
@@ -100,7 +104,7 @@ class CustomGeminiProvider(lx.inference.BaseLanguageModel):
     self._client = genai.Client(api_key=self.api_key)
 
   @classmethod
-  def get_schema_class(cls) -> type[lx.schema.BaseSchema] | None:
+  def get_schema_class(cls) -> type[core_schema.BaseSchema] | None:
     """Return our custom schema class.
 
     This allows LangExtract to use our custom schema implementation
@@ -111,7 +115,9 @@ class CustomGeminiProvider(lx.inference.BaseLanguageModel):
     """
     return custom_schema.CustomProviderSchema
 
-  def apply_schema(self, schema_instance: lx.schema.BaseSchema | None) -> None:
+  def apply_schema(
+      self, schema_instance: core_schema.BaseSchema | None
+  ) -> None:
     """Apply or clear schema configuration.
 
     This method is called by LangExtract to dynamically apply schema
@@ -137,7 +143,7 @@ class CustomGeminiProvider(lx.inference.BaseLanguageModel):
 
   def infer(
       self, batch_prompts: Sequence[str], **kwargs: Any
-  ) -> Iterator[Sequence[lx.inference.ScoredOutput]]:
+  ) -> Iterator[Sequence[types.ScoredOutput]]:
     """Run inference on a batch of prompts.
 
     Args:
@@ -170,7 +176,7 @@ class CustomGeminiProvider(lx.inference.BaseLanguageModel):
             model=self.model_id, contents=prompt, config=config
         )
         output = response.text.strip()
-        yield [lx.inference.ScoredOutput(score=1.0, output=output)]
+        yield [types.ScoredOutput(score=1.0, output=output)]
 
       except Exception as e:
         raise lx.exceptions.InferenceRuntimeError(

--- a/examples/custom_provider_plugin/langextract_provider_example/schema.py
+++ b/examples/custom_provider_plugin/langextract_provider_example/schema.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 from typing import Any, Sequence
 
 import langextract as lx
+from langextract.core import schema as core_schema
 
 
-class CustomProviderSchema(lx.schema.BaseSchema):
+class CustomProviderSchema(core_schema.BaseSchema):
   """Example custom schema implementation for a provider plugin.
 
   This demonstrates how plugins can provide their own schema implementations
@@ -36,15 +37,16 @@ class CustomProviderSchema(lx.schema.BaseSchema):
   the Gemini backend (which this example provider wraps) for structured output.
   """
 
-  def __init__(self, schema_dict: dict[str, Any], strict_mode: bool = True):
+  def __init__(self, schema_dict: dict[str, Any], raw_output: bool = True):
     """Initialize the custom schema.
 
     Args:
       schema_dict: The generated JSON schema dictionary.
-      strict_mode: Whether the provider guarantees valid output.
+      raw_output: Whether the provider emits raw JSON without fence markers
+        (True when JSON mode is guaranteed; False when output needs fencing).
     """
     self._schema_dict = schema_dict
-    self._strict_mode = strict_mode
+    self._raw_output = raw_output
 
   @classmethod
   def from_examples(
@@ -117,7 +119,7 @@ class CustomProviderSchema(lx.schema.BaseSchema):
           "extraction_class"
       ]["enum"]
 
-    return cls(schema_dict, strict_mode=True)
+    return cls(schema_dict, raw_output=True)
 
   def to_provider_config(self) -> dict[str, Any]:
     """Convert schema to provider-specific configuration.
@@ -142,14 +144,14 @@ class CustomProviderSchema(lx.schema.BaseSchema):
     }
 
   @property
-  def supports_strict_mode(self) -> bool:
-    """Whether this schema guarantees valid structured output.
+  def requires_raw_output(self) -> bool:
+    """Whether the provider emits raw JSON/YAML without fence markers.
 
-    Returns:
-      True if the provider will emit valid JSON without needing
-      Markdown fences for extraction.
+    Required abstract property of `BaseSchema`. Return True when the
+    provider guarantees syntactically valid JSON (so no fence markers
+    are needed), False when output should be wrapped in fences.
     """
-    return self._strict_mode
+    return self._raw_output
 
   @property
   def schema_dict(self) -> dict[str, Any]:

--- a/langextract/providers/README.md
+++ b/langextract/providers/README.md
@@ -9,11 +9,11 @@ python scripts/create_provider_plugin.py MyProvider --with-schema
 
 ## Architecture Overview
 
-The provider system uses a **registry pattern** with **automatic discovery**:
+The provider system uses a **router pattern** with **automatic discovery**:
 
-1. **Registry** (`registry.py`): Maps model ID patterns to provider classes
+1. **Router** (`router.py`): Maps model ID patterns to provider classes. A legacy `registry.py` alias still imports — new code should use `router` directly.
 2. **Factory** (`../factory.py`): Creates provider instances based on model IDs
-3. **Providers**: Implement the `BaseLanguageModel` interface
+3. **Providers**: Implement the `BaseLanguageModel` interface (from `langextract.core.base_model`)
 
 ### Provider Resolution Flow
 
@@ -27,7 +27,7 @@ User Code                    LangExtract                      Provider
     |                             |                              |
     |                    factory.create_model()                  |
     |                             |                              |
-    |                    registry.resolve("gemini-2.5-flash")    |
+    |                    router.resolve("gemini-2.5-flash")      |
     |                       Pattern match: ^gemini               |
     |                             ↓                              |
     |                       GeminiLanguageModel                  |
@@ -103,8 +103,10 @@ pip install langextract-yourprovider
 # Use it immediately - no imports needed!
 import langextract as lx
 result = lx.extract(
-    text="...",
-    model_id="yourmodel-latest"  # Automatically finds the provider
+    text_or_documents="...",
+    prompt_description="Extract key information",
+    examples=[...],
+    model_id="yourmodel-latest",  # Automatically finds the provider
 )
 ```
 
@@ -113,7 +115,7 @@ result = lx.extract(
 ```
 1. pip install langextract-yourprovider
    └── Installs package containing:
-       • Provider class with @lx.providers.registry.register decorator
+       • Provider class with @router.register decorator
        • Python entry point pointing to this class
 
 2. import langextract
@@ -122,9 +124,9 @@ result = lx.extract(
 
 3. lx.extract(model_id="yourmodel-latest")
    └── Triggers plugin discovery via entry points
-       └── @lx.providers.registry.register decorator fires
-           └── Provider patterns added to registry
-               └── Registry matches pattern and uses your provider
+       └── @router.register decorator fires
+           └── Provider patterns added to router
+               └── Router matches pattern and uses your provider
 ```
 
 **Important Notes:**
@@ -138,7 +140,7 @@ result = lx.extract(
 When you call `lx.extract(model_id="gemini-2.5-flash", ...)`, here's what happens:
 
 1. **Factory receives model_id**: "gemini-2.5-flash"
-2. **Registry searches patterns**: Each provider registers regex patterns
+2. **Router searches patterns**: Each provider registers regex patterns
 3. **First match wins**: Returns the matching provider class
 4. **Provider instantiated**: With model_id and any kwargs
 5. **Inference runs**: Using the selected provider
@@ -146,15 +148,16 @@ When you call `lx.extract(model_id="gemini-2.5-flash", ...)`, here's what happen
 ### Pattern Registration Example
 
 ```python
-import langextract as lx
+from langextract.core import base_model
+from langextract.providers import router
 
 # Gemini provider registration:
-@lx.providers.registry.register(
+@router.register(
     r'^GeminiLanguageModel$',  # Explicit: model_id="GeminiLanguageModel"
     r'^gemini',                # Prefix: model_id="gemini-2.5-flash"
     r'^palm'                   # Legacy: model_id="palm-2"
 )
-class GeminiLanguageModel(lx.inference.BaseLanguageModel):
+class GeminiLanguageModel(base_model.BaseLanguageModel):
     def __init__(self, model_id: str, api_key: str = None, **kwargs):
         # Initialize Gemini client
         ...
@@ -172,8 +175,10 @@ import langextract as lx
 
 # Automatically selects Gemini provider
 result = lx.extract(
-    text="...",
-    model_id="gemini-2.5-flash"
+    text_or_documents="...",
+    prompt_description="Extract key information",
+    examples=[...],
+    model_id="gemini-2.5-flash",
 )
 ```
 
@@ -184,19 +189,20 @@ Parameters flow from `lx.extract()` to providers through several mechanisms:
 ```python
 # 1. Common parameters handled by lx.extract itself:
 result = lx.extract(
-    text="Your document",
+    text_or_documents="Your document",
     model_id="gemini-2.5-flash",
     prompt_description="Extract key facts",
-    examples=[...],           # Used for few-shot prompting
-    num_workers=4,            # Parallel processing
-    max_chunk_size=3000,      # Document chunking
+    examples=[...],             # Used for few-shot prompting (required)
+    max_workers=4,              # Parallel processing (provider-dependent)
+    max_char_buffer=3000,       # Document chunking
 )
 
 # 2. Provider-specific parameters passed via **kwargs:
 result = lx.extract(
-    text="Your document",
+    text_or_documents="Your document",
     model_id="gemini-2.5-flash",
     prompt_description="Extract entities",
+    examples=[...],
     # These go directly to the Gemini provider:
     temperature=0.7,          # Sampling temperature
     api_key="your-key",      # Override environment variable
@@ -271,14 +277,14 @@ yourprovider = "langextract_yourprovider:YourProviderLanguageModel"
 
 #### ☐ **3. Implement Provider** (`provider.py`)
 - [ ] Import required modules
-- [ ] Add `@lx.providers.registry.register()` decorator with patterns
-- [ ] Inherit from `lx.inference.BaseLanguageModel`
+- [ ] Add `@router.register()` decorator with patterns
+- [ ] Inherit from `base_model.BaseLanguageModel`
 - [ ] Implement `__init__()` method
 - [ ] Implement `infer()` method returning `ScoredOutput` objects
 - [ ] Export class from `__init__.py`
 
 #### ☐ **4. (Optional) Add Schema Support** (`schema.py`)
-- [ ] Create schema class inheriting from `lx.schema.BaseSchema`
+- [ ] Create schema class inheriting from `langextract.core.schema.BaseSchema`
 - [ ] Implement `from_examples()` class method
 - [ ] Implement `to_provider_config()` method
 - [ ] Add `get_schema_class()` to provider
@@ -301,7 +307,7 @@ yourprovider = "langextract_yourprovider:YourProviderLanguageModel"
 - [ ] Test in clean environment
 - [ ] Publish to PyPI with `twine upload dist/*`
 - [ ] Share your provider by opening an issue on [LangExtract GitHub](https://github.com/google/langextract/issues) to get feedback and help others discover it
-- [ ] Consider submitting a PR to add your provider to the community providers list (coming soon)
+- [ ] Consider submitting a PR to add your provider to [COMMUNITY_PROVIDERS.md](../../COMMUNITY_PROVIDERS.md)
 
 ### Option 1: External Plugin (Recommended)
 
@@ -348,10 +354,12 @@ myprovider = "langextract_myprovider:MyProviderLanguageModel"
 ```python
 # langextract_myprovider/__init__.py
 import os
-import langextract as lx
 
-@lx.providers.registry.register(r'^mymodel', r'^custom', priority=10)
-class MyProviderLanguageModel(lx.inference.BaseLanguageModel):
+from langextract.core import base_model, types
+from langextract.providers import router
+
+@router.register(r'^mymodel', r'^custom', priority=10)
+class MyProviderLanguageModel(base_model.BaseLanguageModel):
     def __init__(self, model_id: str, api_key: str = None, **kwargs):
         super().__init__()
         self.model_id = model_id
@@ -363,17 +371,18 @@ class MyProviderLanguageModel(lx.inference.BaseLanguageModel):
         # Implement inference
         for prompt in batch_prompts:
             result = self.client.generate(prompt, **kwargs)
-            yield [lx.inference.ScoredOutput(score=1.0, output=result)]
+            yield [types.ScoredOutput(score=1.0, output=result)]
 ```
 
 **Pattern Registration Explained:**
-- The `@register` decorator patterns (e.g., `r'^mymodel'`, `r'^custom'`) define which model IDs your provider supports
-- When users call `lx.extract(model_id="mymodel-3b")`, the registry matches against these patterns
+- The `@router.register` decorator patterns (e.g., `r'^mymodel'`, `r'^custom'`) define which model IDs your provider supports
+- When users call `lx.extract(model_id="mymodel-3b")`, the router matches against these patterns
 - Your provider will handle any model_id starting with "mymodel" or "custom"
 - Users can explicitly select your provider using its class name:
   ```python
   config = lx.factory.ModelConfig(provider="MyProviderLanguageModel")
   # Or partial match: provider="myprovider" (matches class name)
+  ```
 
 4. Publish your package to PyPI:
 ```bash
@@ -392,10 +401,9 @@ Schemas enable structured output with strict JSON constraints. Here's how to add
 
 ```python
 # langextract_myprovider/schema.py
-import langextract as lx
-from langextract import schema
+from langextract.core import schema
 
-class MyProviderSchema(lx.schema.BaseSchema):
+class MyProviderSchema(schema.BaseSchema):
     def __init__(self, schema_dict: dict):
         self._schema_dict = schema_dict
 
@@ -436,8 +444,8 @@ class MyProviderSchema(lx.schema.BaseSchema):
         }
 
     @property
-    def supports_strict_mode(self) -> bool:
-        """Return True if provider enforces valid JSON output."""
+    def requires_raw_output(self) -> bool:
+        """Return True if provider emits raw JSON without fence markers."""
         return True
 ```
 
@@ -445,7 +453,9 @@ class MyProviderSchema(lx.schema.BaseSchema):
 
 ```python
 # langextract_myprovider/provider.py
-class MyProviderLanguageModel(lx.inference.BaseLanguageModel):
+from langextract.core import base_model, types
+
+class MyProviderLanguageModel(base_model.BaseLanguageModel):
     def __init__(self, model_id: str, **kwargs):
         super().__init__()
         self.model_id = model_id
@@ -478,7 +488,7 @@ class MyProviderLanguageModel(lx.inference.BaseLanguageModel):
                 api_params['response_schema'] = self.response_schema
 
             result = self.client.generate(prompt, **api_params)
-            yield [lx.inference.ScoredOutput(score=1.0, output=result)]
+            yield [types.ScoredOutput(score=1.0, output=result)]
 ```
 
 #### 3. Schema Usage
@@ -503,10 +513,11 @@ This approach should only be used for providers that benefit a large portion of 
 1. Create your provider file:
 ```python
 # langextract/providers/myprovider.py
-import langextract as lx
+from langextract.core import base_model
+from langextract.providers import router
 
-@lx.providers.registry.register(r'^mymodel', r'^custom')
-class MyProviderLanguageModel(lx.inference.BaseLanguageModel):
+@router.register(r'^mymodel', r'^custom')
+class MyProviderLanguageModel(base_model.BaseLanguageModel):
     # Implementation same as above
 ```
 
@@ -544,9 +555,9 @@ The factory automatically resolves API keys from environment:
 
 ### Provider Not Found
 ```python
-ValueError: No provider registered for model_id='unknown-model'
+InferenceConfigError: No provider registered for model_id='unknown-model'
 ```
-**Solution**: Check available patterns with `registry.list_entries()`
+**Solution**: Check available patterns with `langextract.providers.router.list_entries()`
 
 ### Plugin Not Loading
 ```python
@@ -571,7 +582,7 @@ InferenceConfigError: OpenAI provider requires openai package
 **Solutions**:
 1. Ensure provider implements `get_schema_class()`
 2. Check `use_schema_constraints=True` is set
-3. Verify schema's `supports_strict_mode` returns `True`
+3. Verify schema's `requires_raw_output` returns `True`
 4. Test schema creation with `Schema.from_examples(examples)`
 
 ### Pattern Conflicts
@@ -582,5 +593,6 @@ InferenceConfigError: OpenAI provider requires openai package
 ```python
 config = lx.factory.ModelConfig(
     model_id="model-name",
-    provider="YourProviderClass"  # Explicit selection
+    provider="YourProviderClass",  # Explicit selection
 )
+```

--- a/skills/langextract-usage/README.md
+++ b/skills/langextract-usage/README.md
@@ -1,0 +1,81 @@
+# langextract-usage — Agent Skill
+
+This directory is an [Agent Skill](https://agentskills.io) source that teaches
+AI coding assistants how to use LangExtract correctly. It follows the open
+Agent Skills format (`SKILL.md` with YAML frontmatter, optional
+`references/`, `examples/`).
+
+This directory is **not** auto-discovered by any tool from the `skills/`
+path it lives in here. To use it, copy or symlink the directory into
+whichever path your Agent-Skills-compatible tool reads from.
+
+## Activate
+
+Pick your tool, then install at either project scope (this repo only) or
+user scope (all your projects). Paths below are **canonical examples** per
+each tool's 2026 docs — some tools (Copilot, Codex) scan several paths,
+so any of the documented locations works. Check the linked docs for the
+full list if your tool has moved.
+
+Project-scope paths are relative to your workspace/repo root. Run the copy
+or symlink command from there.
+
+| Tool | Project-scope path (example) | User-scope path (example) |
+|---|---|---|
+| [Google Antigravity](https://antigravity.google/docs/skills) | `.agents/skills/langextract-usage/` | `~/.gemini/antigravity/skills/langextract-usage/` |
+| [Anthropic Claude Code](https://code.claude.com/docs/en/skills) | `.claude/skills/langextract-usage/` | `~/.claude/skills/langextract-usage/` |
+| [OpenAI Codex](https://developers.openai.com/codex/skills) | `.agents/skills/langextract-usage/` | `~/.agents/skills/langextract-usage/` |
+| [GitHub Copilot](https://docs.github.com/en/copilot) | `.github/skills/langextract-usage/` | `~/.copilot/skills/langextract-usage/` |
+
+Notes:
+- **Antigravity** also recognizes legacy `.agent/skills/` (singular) for
+  backward compatibility; new installs should use `.agents/skills/`
+  (plural).
+- **Copilot** also accepts `.claude/skills/` or `.agents/skills/` at project
+  scope, and `~/.claude/skills/` or `~/.agents/skills/` at user scope.
+- **Codex** scans `.agents/skills/` from the current directory up through
+  the repo root, so a project-scope install works from any subdirectory.
+- A project-scope `.agents/skills/langextract-usage/` therefore activates
+  the skill in Antigravity, Codex, and Copilot simultaneously.
+
+### Copy (static install)
+
+```bash
+cp -R skills/langextract-usage <tool-skill-path>
+```
+
+### Symlink (tracks this repo's updates)
+
+```bash
+ln -s "$(pwd)/skills/langextract-usage" <tool-skill-path>
+```
+
+### Other tools
+
+- **Agent-Skills-compatible tools not listed above** — point the tool at
+  this directory as a skill source, following its own docs.
+- **Tools that read their own instruction format** (e.g. Cursor
+  `.cursor/rules/`, Windsurf `.windsurf/rules/`, Aider `CONVENTIONS.md`) —
+  copy the relevant sections of `SKILL.md` / `references/*.md` into that
+  tool's convention. The content is portable; only the activation
+  mechanism differs.
+
+After activating, restart your agent session if the tool does not
+auto-detect changes.
+
+## Contents
+
+- `SKILL.md` — entry point; install, basic usage, key parameters, working with
+  results, common issues
+- `references/providers.md` — Gemini, OpenAI, Ollama, `ModelConfig`, custom
+  provider plugins
+- `references/resolver-params.md` — fuzzy alignment tuning
+- `references/prompt-validation.md` — `PromptValidationLevel` details
+- `examples/` — runnable scripts (`basic_extraction.py`,
+  `relationship_extraction.py`, `multiple_documents.py`)
+
+## Maintenance
+
+When changing user-facing LangExtract APIs (imports, `lx.extract()` kwargs,
+resolver or validation behavior), please update the affected files in this
+subtree in the same PR. If you spot drift, open an issue or PR.

--- a/skills/langextract-usage/SKILL.md
+++ b/skills/langextract-usage/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: langextract-usage
+description: How to use LangExtract to extract structured information from text. Use when writing code that calls lx.extract(), building extraction pipelines, defining examples, or troubleshooting alignment issues.
+---
+
+# LangExtract Usage
+
+LangExtract extracts structured information from unstructured text using LLMs.
+The main entry point is `lx.extract()`. Every extraction needs at least one
+example and input text. `prompt_description` is optional but recommended.
+
+## Install
+
+```bash
+pip install langextract
+
+# For OpenAI model support:
+pip install langextract[openai]
+```
+
+## API keys
+
+```bash
+# Gemini (checks GEMINI_API_KEY then LANGEXTRACT_API_KEY)
+export GEMINI_API_KEY="your_key"
+
+# OpenAI (checks OPENAI_API_KEY then LANGEXTRACT_API_KEY)
+export OPENAI_API_KEY="your_key"
+
+# Ollama: no API key needed, just a running Ollama server
+```
+
+Auto-routing + env-default resolution is tuned for GPT-style model IDs
+(`gpt-4*`, `gpt-5*`). For OpenAI-compatible endpoints or non-GPT IDs,
+pass an explicit `ModelConfig` — see `references/providers.md`.
+
+## Basic extraction
+
+```python
+import langextract as lx
+
+examples = [
+    lx.data.ExampleData(
+        text="Patient takes lisinopril 10mg daily for hypertension.",
+        extractions=[
+            lx.data.Extraction(
+                extraction_class="medication",
+                extraction_text="lisinopril",
+                attributes={"dose": "10mg", "frequency": "daily"},
+            ),
+            lx.data.Extraction(
+                extraction_class="condition",
+                extraction_text="hypertension",
+                attributes={"status": "active"},
+            ),
+        ],
+    )
+]
+
+result = lx.extract(
+    text_or_documents="Patient is prescribed metformin 500mg twice daily.",
+    prompt_description="Extract medications and conditions with attributes.",
+    examples=examples,
+    model_id="gemini-2.5-flash",
+)
+
+for e in result.extractions:
+    print(e.extraction_class, e.extraction_text)
+    print(f"  char_interval: {e.char_interval}")
+    print(f"  attributes: {e.attributes}")
+```
+
+See `examples/basic_extraction.py` for a runnable version and
+`examples/relationship_extraction.py` for using `extraction_class` +
+`attributes` to encode relationships between entities.
+
+## Writing good examples
+
+Examples drive model behavior. Follow these rules:
+
+1. `extraction_text` must be verbatim from the example text, not paraphrased
+2. List extractions in order of appearance in the text
+3. Each `extraction_class` should be consistent across examples
+4. Include attributes that match what you want extracted at runtime
+
+LangExtract can raise prompt-alignment warnings when an example's
+`extraction_text` values don't align cleanly to the example's `text`
+(failed alignment, or fuzzy/lesser rather than exact). The validator does
+not enforce rules 2–4 above — those are guidance to steer the model's
+output, not checked invariants.
+
+To fail fast on alignment issues during development, pass these kwargs
+directly to `lx.extract()` (both default to permissive):
+
+```python
+from langextract.prompt_validation import PromptValidationLevel
+
+result = lx.extract(
+    ...,
+    prompt_validation_level=PromptValidationLevel.ERROR,  # default: WARNING
+    prompt_validation_strict=True,                          # default: False
+)
+```
+
+See `references/prompt-validation.md` for level semantics and strict-mode
+behavior.
+
+## Key parameters
+
+```python
+result = lx.extract(
+    text_or_documents=text,          # str, URL, or list of Documents
+    prompt_description=prompt,        # what to extract (optional)
+    examples=examples,                # few-shot examples (required)
+    model_id="gemini-2.5-flash",     # model to use
+    extraction_passes=1,              # >1 for higher recall (costs more)
+    max_char_buffer=1000,             # chunk size
+    batch_length=10,                  # chunks per batch
+    max_workers=10,                   # parallel workers (provider-dependent)
+    context_window_chars=None,        # cross-chunk context for coreference
+)
+```
+
+- `text_or_documents` accepts a URL string (fetch_urls=True by default).
+- For full parallelism, keep `batch_length >= max_workers`. Parallel
+  processing via `max_workers` is provider-dependent; some providers
+  parallelize batched prompts, while others (such as the current Ollama
+  provider) process them sequentially.
+- `context_window_chars` includes characters from the previous chunk as
+  context for the current one, which helps with coreference and entity
+  continuity across chunk boundaries.
+- For multiple documents, pass a list of `lx.data.Document` — see
+  `examples/multiple_documents.py`.
+
+## Working with results
+
+```python
+# Filter to grounded extractions only (have source positions)
+grounded = [e for e in result.extractions if e.char_interval]
+
+# Access source position
+for e in grounded:
+    start = e.char_interval.start_pos
+    end = e.char_interval.end_pos
+    matched_text = result.text[start:end]
+
+# Save to JSONL
+lx.io.save_annotated_documents(
+    [result], output_name="results.jsonl", output_dir="."
+)
+
+# Visualize from JSONL (shows first document)
+html = lx.visualize("results.jsonl")
+with open("visualization.html", "w") as f:
+    if hasattr(html, "data"):
+        f.write(html.data)  # Jupyter/Colab
+    else:
+        f.write(html)
+
+# Or visualize an AnnotatedDocument directly
+html = lx.visualize(result)
+```
+
+## Provider selection
+
+The default is Gemini. For other providers, see `references/providers.md`,
+which covers:
+
+- OpenAI (JSON mode; fence behavior auto-configured)
+- Ollama (local models, `model_url`)
+- `ModelConfig` for advanced provider_kwargs (custom `base_url`, etc.)
+- Custom provider plugins via `router.register()`
+
+## Common issues
+
+**Extractions with `char_interval=None`**: the extraction could not be
+located in the source text. Common causes include paraphrased output,
+alignment misses, or hallucinated entities. Filter with
+`[e for e in result.extractions if e.char_interval]`. To tune alignment,
+see `references/resolver-params.md`.
+
+**Prompt alignment warnings**: your examples have `extraction_text` that
+doesn't match the example text verbatim. Fix the examples, or see
+`references/prompt-validation.md` to fail fast during development.
+
+**Slow on long documents**: `extraction_passes > 1` multiplies processing
+time. Start with 1 and increase only if recall is insufficient.
+
+**Model selection**: `gemini-2.5-flash` is recommended for most tasks;
+`gemini-2.5-pro` for complex reasoning.
+
+## Further reading
+
+- `references/providers.md` — OpenAI, Ollama, ModelConfig, custom plugins
+- `references/resolver-params.md` — fuzzy alignment tuning
+- `references/prompt-validation.md` — catching example issues early
+- `examples/` — runnable scripts for each scenario above

--- a/skills/langextract-usage/examples/basic_extraction.py
+++ b/skills/langextract-usage/examples/basic_extraction.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extract medications and conditions from a clinical note.
+
+Run: GEMINI_API_KEY=... python basic_extraction.py
+"""
+
+import langextract as lx
+
+examples = [
+    lx.data.ExampleData(
+        text="Patient takes lisinopril 10mg daily for hypertension.",
+        extractions=[
+            lx.data.Extraction(
+                extraction_class="medication",
+                extraction_text="lisinopril",
+                attributes={"dose": "10mg", "frequency": "daily"},
+            ),
+            lx.data.Extraction(
+                extraction_class="condition",
+                extraction_text="hypertension",
+                attributes={"status": "active"},
+            ),
+        ],
+    )
+]
+
+result = lx.extract(
+    text_or_documents="Patient is prescribed metformin 500mg twice daily.",
+    prompt_description="Extract medications and conditions with attributes.",
+    examples=examples,
+    model_id="gemini-2.5-flash",
+)
+
+for e in result.extractions:
+  print(e.extraction_class, e.extraction_text)
+  print(f"  char_interval: {e.char_interval}")
+  print(f"  attributes: {e.attributes}")

--- a/skills/langextract-usage/examples/multiple_documents.py
+++ b/skills/langextract-usage/examples/multiple_documents.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extract from multiple documents in a single call.
+
+Pass a list of Document objects to process them together. Each result
+carries the original `document_id` for downstream joining.
+"""
+
+import langextract as lx
+
+examples = [
+    lx.data.ExampleData(
+        text="Patient reports chest pain on exertion.",
+        extractions=[
+            lx.data.Extraction(
+                extraction_class="symptom",
+                extraction_text="chest pain on exertion",
+                attributes={"trigger": "exertion"},
+            ),
+        ],
+    )
+]
+
+docs = [
+    lx.data.Document(
+        document_id="note-001",
+        text="Patient complains of shortness of breath when climbing stairs.",
+    ),
+    lx.data.Document(
+        document_id="note-002",
+        text="Reports occasional dizziness in the morning.",
+    ),
+]
+
+results = lx.extract(
+    text_or_documents=docs,
+    prompt_description="Extract symptoms with their triggers.",
+    examples=examples,
+    model_id="gemini-2.5-flash",
+)
+
+for doc_result in results:
+  print(f"{doc_result.document_id}: {len(doc_result.extractions)} extractions")
+  for e in doc_result.extractions:
+    print(f"  - {e.extraction_text} {e.attributes}")

--- a/skills/langextract-usage/examples/relationship_extraction.py
+++ b/skills/langextract-usage/examples/relationship_extraction.py
@@ -1,0 +1,67 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extract characters, emotions, and metaphorical relationships from text.
+
+Demonstrates distinct `extraction_class` values (`character`, `emotion`,
+`relationship`) plus `attributes` to encode structured details.
+"""
+
+import langextract as lx
+
+examples = [
+    lx.data.ExampleData(
+        text=(
+            "ROMEO. But soft! What light through yonder window breaks? "
+            "It is the east, and Juliet is the sun."
+        ),
+        extractions=[
+            lx.data.Extraction(
+                extraction_class="character",
+                extraction_text="ROMEO",
+                attributes={"role": "speaker"},
+            ),
+            lx.data.Extraction(
+                extraction_class="emotion",
+                extraction_text="But soft!",
+                attributes={"feeling": "wonder", "character": "Romeo"},
+            ),
+            lx.data.Extraction(
+                extraction_class="relationship",
+                extraction_text="Juliet is the sun",
+                attributes={
+                    "type": "metaphor",
+                    "source": "Romeo",
+                    "target": "Juliet",
+                },
+            ),
+        ],
+    )
+]
+
+result = lx.extract(
+    text_or_documents=(
+        "JULIET. O Romeo, Romeo! wherefore art thou Romeo? "
+        "Deny thy father and refuse thy name."
+    ),
+    prompt_description=(
+        "Extract characters, emotions, and any metaphorical relationships "
+        "between entities."
+    ),
+    examples=examples,
+    model_id="gemini-2.5-flash",
+)
+
+for e in result.extractions:
+  print(f"[{e.extraction_class}] {e.extraction_text} -> {e.attributes}")

--- a/skills/langextract-usage/references/prompt-validation.md
+++ b/skills/langextract-usage/references/prompt-validation.md
@@ -1,0 +1,54 @@
+# Prompt Validation Reference
+
+Prompt validation catches example problems (non-verbatim text, alignment
+mismatches) early, before expensive extraction runs.
+
+## Levels
+
+```python
+from langextract.prompt_validation import PromptValidationLevel
+
+result = lx.extract(
+    text_or_documents=text,
+    examples=examples,
+    prompt_description=prompt,
+    model_id="gemini-2.5-flash",
+    prompt_validation_level=PromptValidationLevel.ERROR,
+    prompt_validation_strict=True,
+)
+```
+
+- **`OFF`** — skip validation entirely.
+- **`WARNING`** (default) — log issues, continue running.
+- **`ERROR`** — raise on validation failure.
+
+## Strict mode
+
+When `prompt_validation_strict=True`, non-exact matches (fuzzy alignment,
+`accept_match_lesser`) also trigger failures in `ERROR` mode. Without strict
+mode, only completely unalignable extractions fail.
+
+## How it aligns with resolver_params
+
+Prompt validation uses the same alignment settings from `resolver_params`.
+So if you've tuned `fuzzy_alignment_threshold` or
+`fuzzy_alignment_algorithm`, validation honors those same values when
+deciding whether an example extraction is aligned.
+
+## When to use each level
+
+- **Development**: `ERROR` + `strict=True` forces you to write clean,
+  verbatim examples.
+- **Staging/CI**: `ERROR` (non-strict) catches truly broken examples
+  without failing on minor fuzzy matches.
+- **Production**: `WARNING` or `OFF` — you've already validated offline and
+  don't want runtime failures over example drift.
+
+## Common fixes
+
+- **"Extraction text not found in example text"**: your `extraction_text`
+  doesn't appear verbatim in the example `text`. Copy-paste the exact
+  substring rather than paraphrasing.
+- **"Extraction text aligned fuzzily"** (strict only): same issue but with
+  minor whitespace/punctuation differences. Fix the example to match
+  exactly.

--- a/skills/langextract-usage/references/providers.md
+++ b/skills/langextract-usage/references/providers.md
@@ -1,0 +1,135 @@
+# Provider Reference
+
+LangExtract ships with three built-in providers (Gemini, OpenAI, Ollama) and
+supports custom providers via a plugin system.
+
+## Gemini (default, recommended)
+
+```python
+result = lx.extract(
+    text_or_documents=text,
+    prompt_description=prompt,
+    examples=examples,
+    model_id="gemini-2.5-flash",  # or "gemini-2.5-pro" for complex reasoning
+)
+```
+
+Env: `GEMINI_API_KEY` (falls back to `LANGEXTRACT_API_KEY`).
+
+## OpenAI
+
+```python
+result = lx.extract(
+    text_or_documents=text,
+    examples=examples,
+    prompt_description=prompt,
+    model_id="gpt-4o",
+)
+```
+
+Env: `OPENAI_API_KEY` (falls back to `LANGEXTRACT_API_KEY`).
+
+The OpenAI provider uses JSON mode (`response_format={"type":"json_object"}`)
+and reports `requires_fence_output=False`. Leave `fence_output` unset —
+`extract()` and the factory/provider layer auto-determine fence behavior
+from the provider's schema. The OpenAI provider parallelizes batched
+prompts with a `ThreadPoolExecutor` when `max_workers > 1`.
+
+The OpenAI provider does not expose a schema class, so
+`use_schema_constraints` is a no-op here. You can omit it (as shown above)
+or leave it at its default.
+
+**Auto-routing scope:** the built-in OpenAI provider only auto-matches
+GPT-style `model_id`s (`^gpt-4`, `^gpt4\.`, `^gpt-5`, `^gpt5\.`), and the
+environment-default API-key lookup keys off `"gpt"` rather than
+`"openai"`. For **OpenAI-compatible endpoints** (LiteLLM, local servers,
+custom base URLs) or **non-GPT model IDs**, use `ModelConfig` with an
+explicit provider and kwargs:
+
+```python
+from langextract.factory import ModelConfig
+
+result = lx.extract(
+    text_or_documents=text,
+    examples=examples,
+    prompt_description=prompt,
+    config=ModelConfig(
+        model_id="my-openai-compatible-model",
+        provider="openai",
+        provider_kwargs={"api_key": "sk-...", "base_url": "https://..."},
+    ),
+)
+```
+
+## Ollama (local)
+
+No API key needed. Requires a running Ollama server.
+
+```python
+result = lx.extract(
+    text_or_documents=text,
+    examples=examples,
+    prompt_description=prompt,
+    model_id="gemma2:2b",
+    model_url="http://localhost:11434",
+)
+```
+
+The Ollama provider exposes `FormatModeSchema` for JSON mode. Leave
+`fence_output` and `use_schema_constraints` unset so `extract()` and the
+factory/provider layer auto-configure from the provider's schema. The
+Ollama provider processes batched prompts sequentially — `max_workers > 1`
+will not parallelize it.
+
+## ModelConfig (advanced)
+
+For provider-specific kwargs (custom base_url, explicit api_key, etc.):
+
+```python
+from langextract.factory import ModelConfig
+
+result = lx.extract(
+    text_or_documents=text,
+    examples=examples,
+    config=ModelConfig(
+        model_id="gpt-4o",
+        provider_kwargs={"api_key": "your_key", "base_url": "https://..."},
+    ),
+)
+```
+
+ModelConfig fields: `model_id`, `provider` (for disambiguation when multiple
+providers match a model_id pattern), `provider_kwargs`.
+
+## Custom provider plugins
+
+Subclass `BaseLanguageModel` and register a regex pattern for the model_ids
+your provider should handle:
+
+```python
+from langextract.core.base_model import BaseLanguageModel
+from langextract.providers import router
+
+@router.register(r"^my-model")
+class MyProvider(BaseLanguageModel):
+    ...
+```
+
+For external packages, declare an entry point in your `pyproject.toml` so
+LangExtract discovers the provider at model-creation time:
+
+```toml
+[project.entry-points."langextract.providers"]
+my-model = "my_package.provider:MyProvider"
+```
+
+Plugin loading is **lazy**: `load_plugins_once()` runs the first time a
+model is created via the factory, not at package import. Once loaded, any
+registered provider whose pattern matches the requested `model_id` is
+selected automatically.
+
+`langextract.inference` and `langextract.providers.registry` still exist
+as backward-compatibility aliases, but new code should import from
+`langextract.core.base_model` and `langextract.providers.router` as shown
+above. A complete working example lives at
+`examples/custom_provider_plugin/` in the repo.

--- a/skills/langextract-usage/references/resolver-params.md
+++ b/skills/langextract-usage/references/resolver-params.md
@@ -1,0 +1,64 @@
+# resolver_params Reference
+
+`resolver_params` is a dict passed to `lx.extract()` to fine-tune how the
+model's output is parsed and aligned to source text. Keys may change across
+versions — check the current `extract()` docstring if in doubt.
+
+## Full example
+
+```python
+result = lx.extract(
+    text_or_documents=text,
+    examples=examples,
+    prompt_description=prompt,
+    model_id="gemini-2.5-flash",
+    resolver_params={
+        "suppress_parse_errors": True,
+        "extraction_index_suffix": "_index",
+        "enable_fuzzy_alignment": True,
+        "fuzzy_alignment_threshold": 0.75,
+        "fuzzy_alignment_algorithm": "lcs",
+        "fuzzy_alignment_min_density": 1 / 3,
+        "accept_match_lesser": True,
+    },
+)
+```
+
+## Key descriptions
+
+- **`suppress_parse_errors`** (default True in `extract()`): on parse or
+  schema errors for a chunk, log a warning and return `[]` for that chunk
+  rather than raising. The chunk is effectively dropped; no partial output
+  is recovered from the malformed response.
+- **`extraction_index_suffix`**: attribute name suffix used to preserve
+  extraction ordering (e.g. `"_index"` looks for attributes like
+  `medication_index` and sorts extractions by that value).
+- **`enable_fuzzy_alignment`** (default True): attempt fuzzy alignment when
+  exact substring match fails.
+- **`fuzzy_alignment_threshold`** (default 0.75): minimum fraction of
+  extraction tokens that must be matched in the source span.
+- **`fuzzy_alignment_algorithm`** (default `"lcs"`): algorithm for fuzzy
+  alignment. `"lcs"` uses longest-common-subsequence DP (O(n*m²)); `"legacy"`
+  uses the older difflib-based approach and is deprecated.
+- **`fuzzy_alignment_min_density`** (default 1/3): minimum ratio of matched
+  tokens to the span length. Filters out sparse matches where only a few
+  tokens align across a very long source span.
+- **`accept_match_lesser`**: accept `MATCH_LESSER` alignments — partial
+  exact matches where the model's `extraction_text` is longer than the span
+  that exactly matched in the source (e.g. the model returned a few extra
+  tokens at the edges). This is distinct from fuzzy alignment: the matched
+  portion is still an exact substring. Use it for truncation or
+  extra-token cases, not as a substitute for lowering
+  `fuzzy_alignment_threshold`.
+
+## When to tune these
+
+- **Too many `char_interval=None` extractions**: lower
+  `fuzzy_alignment_threshold` (e.g. 0.6). Enable `accept_match_lesser`
+  only if the model is returning extraction_text that contains an exact
+  source substring plus extra tokens.
+- **Fuzzy alignment matching the wrong span**: raise
+  `fuzzy_alignment_min_density` (e.g. 0.5) so matches must be denser.
+- **Performance-sensitive pipelines on long documents**: stick with `"lcs"`
+  and consider lowering `max_char_buffer` rather than disabling fuzzy
+  alignment entirely.


### PR DESCRIPTION
## Summary

Adds a distributable [Agent Skill](https://agentskills.io) at `skills/langextract-usage/` that teaches AI coding assistants (Antigravity, Claude Code, Codex, Copilot, …) how to use LangExtract's current API. Users copy or symlink into their tool's skill path — see the skill's `README.md` for per-tool paths.

Also reconciles existing docs so the repo doesn't ship conflicting guidance:

- `README.md`, `langextract/providers/README.md`, and `examples/custom_provider_plugin/` migrated to the current plugin API (`@router.register`, `langextract.core.base_model.BaseLanguageModel`, abstract `requires_raw_output`).
- OpenAI/Ollama snippets no longer require `fence_output` / `use_schema_constraints` — the factory/provider auto-determines fence behavior.
- Dropped stale "coming soon" notes (`model=`/`config=` in `extract()`; community providers list).

13 files changed (8 new + 5 modified), +841 / -93. Backward-compat aliases (`langextract.providers.registry`, `langextract.inference`) remain.

## Test plan

- [x] `pyink --check .` and `isort --check-only` pass
- [x] `pytest tests/ -ra -m "not live_api"` → 445 passed
- [ ] CI on this branch