### PR TITLE
docs: note output_name is not sanitized in save_annotated_documents

### DIFF
--- a/langextract/io.py
+++ b/langextract/io.py
@@ -94,7 +94,10 @@ def save_annotated_documents(
     annotated_documents: Iterator over AnnotatedDocument objects to save.
     output_dir: The directory to which the JSONL file should be written.
       Can be a Path object or a string. Defaults to 'test_output/' if None.
-    output_name: File name for the JSONL file.
+    output_name: File name for the JSONL file. Not sanitized; callers
+      passing untrusted input (e.g. in a hosted service) should validate
+      it first (reject `..`, absolute paths, etc.) to avoid writing
+      outside `output_dir`.
     show_progress: Whether to show a progress bar during saving.
 
   Raises:


### PR DESCRIPTION
## Summary
- Docstring addition only. Notes that `io.save_annotated_documents(output_name=...)` treats the filename as trusted and writes it under `output_dir` as-is.
- Hosted services that accept user input for the destination filename should validate it first (reject `..`, absolute paths, etc.) before calling.

## Rationale
The library is developer-facing and \`output_name\` is typically a developer-controlled literal. Documenting the trust boundary keeps the API simple and is consistent with the opt-in approach used for URL fetching in #449.

## Test plan
- [x] \`tox -e format\` passes.
- [x] \`tox -e lint-src\` passes.
- [x] Existing test suite passes (447 tests).