### PR TITLE
ci: unify formatter tool pins across PR checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.pr_number || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Keep ordinary PR formatting and secure fork formatting on the same
+# pyink/isort versions. The regular format-check job installs lint-imports
+# separately because only that path runs the import-structure check.
+env:
+  FORMATTER_PIP_PACKAGES: pyink==24.3.0 isort==5.13.2
+  IMPORT_LINTER_PIP_PACKAGE: import-linter==2.11
+
 permissions:
   contents: read
 
@@ -64,7 +71,7 @@ jobs:
       - name: Install format tools
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install ${FORMATTER_PIP_PACKAGES} ${IMPORT_LINTER_PIP_PACKAGE}
 
       - name: Check formatting
         id: format-check
@@ -420,7 +427,7 @@ jobs:
       - name: Install format tools
         run: |
           python -m pip install --upgrade pip
-          pip install pyink==24.3.0 isort==5.13.2
+          pip install ${FORMATTER_PIP_PACKAGES}
 
       - name: Validate PR formatting
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@
 
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 6.0.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (import sorting)

--- a/autoformat.sh
+++ b/autoformat.sh
@@ -32,7 +32,9 @@ echo
 # Check for required tools
 check_tool() {
     if ! command -v "$1" &> /dev/null; then
-        echo "Error: $1 not found. Please install with: pip install $1"
+        echo "Error: $1 not found."
+        echo "Install the repo's pinned formatter versions with:"
+        echo "  pip install -e \".[dev]\""
         exit 1
     fi
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,8 @@ dependencies = [
 openai = ["openai>=1.50.0"]
 all = ["openai>=1.50.0"]
 dev = [
-    "pyink~=24.3.0",
-    "isort>=5.13.0",
+    "pyink==24.3.0",
+    "isort==5.13.2",
     "pylint>=3.0.0",
     "pytype>=2024.10.11",
     "tox>=4.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,8 @@ commands =
 [testenv:format]
 skip_install = true
 deps =
-    isort>=5.13.2
-    pyink~=24.3.0
+    isort==5.13.2
+    pyink==24.3.0
 commands =
     isort langextract tests --check-only --diff
     pyink langextract tests --check --diff --config pyproject.toml


### PR DESCRIPTION
This keeps the ordinary PR `format-check` job and the secure fork `test-fork-pr` formatting path on the same `pyink`/`isort` pins.

Why:
- `format-check` was installing `.[dev]`, which pulled a newer `isort` than the secure fork path
- that let ordinary PR CI and secure fork CI disagree on import order for the same PR

What changed:
- add a shared workflow env var for the common `pyink`/`isort` pins
- switch ordinary `format-check` to the same pinned install path
- keep `lint-imports` only on ordinary `format-check`, with an inline comment explaining why

This is a narrow workflow-only follow-up discovered while merging #385.