### PR TITLE
fix: apply additional_context to Documents in the document path of extract()

### DIFF
--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -362,7 +362,23 @@ def extract(
     )
     return result
   else:
-    documents = cast(Iterable[data.Document], text_or_documents)
+    raw_documents = cast(Iterable[data.Document], text_or_documents)
+    if additional_context is not None:
+      documents = []
+      for doc in raw_documents:
+        if doc.additional_context is None:
+          new_doc = data.Document(
+              text=doc.text,
+              document_id=doc._document_id,
+              additional_context=additional_context,
+          )
+          if doc._tokenized_text is not None:
+            new_doc.tokenized_text = doc._tokenized_text
+          documents.append(new_doc)
+        else:
+          documents.append(doc)
+    else:
+      documents = raw_documents
     result = annotator.annotate_documents(
         documents=documents,
         resolver=res,

--- a/tests/extract_precedence_test.py
+++ b/tests/extract_precedence_test.py
@@ -275,5 +275,248 @@ class ExtractParameterPrecedenceTest(absltest.TestCase):
     self.assertEqual(result, "ok")
 
 
+class ExtractAdditionalContextTest(absltest.TestCase):
+  """Tests for additional_context propagation in the document path of extract()."""
+
+  def setUp(self):
+    super().setUp()
+    self.examples = [
+        data.ExampleData(
+            text="example",
+            extractions=[
+                data.Extraction(
+                    extraction_class="entity",
+                    extraction_text="example",
+                )
+            ],
+        )
+    ]
+    self.description = "description"
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.extraction.factory.create_model")
+  def test_additional_context_applied_to_documents_without_own_context(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    """Global additional_context is applied to Documents that have none set."""
+    mock_model = mock.MagicMock()
+    mock_model.requires_fence_output = False
+    mock_create_model.return_value = mock_model
+    mock_annotator = mock_annotator_cls.return_value
+    mock_annotator.annotate_documents.return_value = iter([])
+
+    docs = [
+        data.Document(text="first document"),
+        data.Document(text="second document"),
+    ]
+    global_context = "Important disambiguation rule: treat X as a brand name."
+
+    lx.extract(
+        text_or_documents=docs,
+        prompt_description=self.description,
+        examples=self.examples,
+        model=mock_model,
+        additional_context=global_context,
+        use_schema_constraints=False,
+    )
+
+    _, kwargs = mock_annotator.annotate_documents.call_args
+    passed_docs = list(kwargs["documents"])
+    self.assertLen(passed_docs, 2)
+    for doc in passed_docs:
+      self.assertEqual(doc.additional_context, global_context)
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.extraction.factory.create_model")
+  def test_document_own_context_takes_precedence_over_global(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    """Per-document additional_context is not overwritten by the global value."""
+    mock_model = mock.MagicMock()
+    mock_model.requires_fence_output = False
+    mock_create_model.return_value = mock_model
+    mock_annotator = mock_annotator_cls.return_value
+    mock_annotator.annotate_documents.return_value = iter([])
+
+    per_doc_context = "Document-specific context."
+    global_context = "Global context."
+
+    docs = [
+        data.Document(
+            text="doc with own context", additional_context=per_doc_context
+        ),
+        data.Document(text="doc without context"),
+    ]
+
+    lx.extract(
+        text_or_documents=docs,
+        prompt_description=self.description,
+        examples=self.examples,
+        model=mock_model,
+        additional_context=global_context,
+        use_schema_constraints=False,
+    )
+
+    _, kwargs = mock_annotator.annotate_documents.call_args
+    passed_docs = list(kwargs["documents"])
+    self.assertLen(passed_docs, 2)
+    self.assertEqual(passed_docs[0].additional_context, per_doc_context)
+    self.assertEqual(passed_docs[1].additional_context, global_context)
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.extraction.factory.create_model")
+  def test_no_additional_context_leaves_documents_unchanged(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    """When additional_context is None, documents are passed through as-is."""
+    mock_model = mock.MagicMock()
+    mock_model.requires_fence_output = False
+    mock_create_model.return_value = mock_model
+    mock_annotator = mock_annotator_cls.return_value
+    mock_annotator.annotate_documents.return_value = iter([])
+
+    docs = [
+        data.Document(text="doc one"),
+        data.Document(text="doc two"),
+    ]
+    original_docs = list(docs)
+
+    lx.extract(
+        text_or_documents=docs,
+        prompt_description=self.description,
+        examples=self.examples,
+        model=mock_model,
+        additional_context=None,
+        use_schema_constraints=False,
+    )
+
+    _, kwargs = mock_annotator.annotate_documents.call_args
+    passed_docs = list(kwargs["documents"])
+    self.assertLen(passed_docs, 2)
+    for passed, original in zip(passed_docs, original_docs):
+      self.assertIs(passed, original)
+      self.assertIsNone(passed.additional_context)
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.extraction.factory.create_model")
+  def test_document_ids_preserved_when_applying_global_context(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    """Document IDs are not lost when global additional_context is applied."""
+    mock_model = mock.MagicMock()
+    mock_model.requires_fence_output = False
+    mock_create_model.return_value = mock_model
+    mock_annotator = mock_annotator_cls.return_value
+    mock_annotator.annotate_documents.return_value = iter([])
+
+    docs = [
+        data.Document(text="doc one", document_id="custom-id-1"),
+        data.Document(text="doc two", document_id="custom-id-2"),
+    ]
+
+    lx.extract(
+        text_or_documents=docs,
+        prompt_description=self.description,
+        examples=self.examples,
+        model=mock_model,
+        additional_context="context",
+        use_schema_constraints=False,
+    )
+
+    _, kwargs = mock_annotator.annotate_documents.call_args
+    passed_docs = list(kwargs["documents"])
+    self.assertLen(passed_docs, 2)
+    self.assertEqual(passed_docs[0].document_id, "custom-id-1")
+    self.assertEqual(passed_docs[1].document_id, "custom-id-2")
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.extraction.factory.create_model")
+  def test_generator_input_works_with_additional_context(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    """Generator inputs are fully consumed when additional_context is applied."""
+    mock_model = mock.MagicMock()
+    mock_model.requires_fence_output = False
+    mock_create_model.return_value = mock_model
+    mock_annotator = mock_annotator_cls.return_value
+    mock_annotator.annotate_documents.return_value = iter([])
+
+    def doc_generator():
+      yield data.Document(text="gen doc one")
+      yield data.Document(text="gen doc two")
+
+    lx.extract(
+        text_or_documents=doc_generator(),
+        prompt_description=self.description,
+        examples=self.examples,
+        model=mock_model,
+        additional_context="global context",
+        use_schema_constraints=False,
+    )
+
+    _, kwargs = mock_annotator.annotate_documents.call_args
+    passed_docs = list(kwargs["documents"])
+    self.assertLen(passed_docs, 2)
+    for doc in passed_docs:
+      self.assertEqual(doc.additional_context, "global context")
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.extraction.factory.create_model")
+  def test_caller_documents_not_mutated_by_global_context(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    """Original Document objects are not mutated when global context is applied."""
+    mock_model = mock.MagicMock()
+    mock_model.requires_fence_output = False
+    mock_create_model.return_value = mock_model
+    mock_annotator = mock_annotator_cls.return_value
+    mock_annotator.annotate_documents.return_value = iter([])
+
+    docs = [
+        data.Document(text="doc one"),
+        data.Document(text="doc two"),
+    ]
+
+    lx.extract(
+        text_or_documents=docs,
+        prompt_description=self.description,
+        examples=self.examples,
+        model=mock_model,
+        additional_context="injected context",
+        use_schema_constraints=False,
+    )
+
+    for original in docs:
+      self.assertIsNone(original.additional_context)
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.extraction.factory.create_model")
+  def test_empty_string_additional_context_applied_to_docs(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    """Empty string additional_context is treated like any non-None value."""
+    mock_model = mock.MagicMock()
+    mock_model.requires_fence_output = False
+    mock_create_model.return_value = mock_model
+    mock_annotator = mock_annotator_cls.return_value
+    mock_annotator.annotate_documents.return_value = iter([])
+
+    docs = [data.Document(text="doc one")]
+
+    lx.extract(
+        text_or_documents=docs,
+        prompt_description=self.description,
+        examples=self.examples,
+        model=mock_model,
+        additional_context="",
+        use_schema_constraints=False,
+    )
+
+    _, kwargs = mock_annotator.annotate_documents.call_args
+    passed_docs = list(kwargs["documents"])
+    self.assertLen(passed_docs, 1)
+    self.assertEqual(passed_docs[0].additional_context, "")
+
+
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
## Description

When calling `extract()` with an iterable of `Document` objects, the top-level
`additional_context` parameter was silently ignored.

**Root cause:** `extract()` has two code paths:
- **String path** (working): wraps the string in `Document(additional_context=additional_context)`, then calls `annotate_text()`.
- **Document path** (broken): called `annotate_documents()` directly, never forwarding `additional_context`.

## Fix

When a global `additional_context` is provided alongside a document iterable,
new `Document` instances are created for any document that has no per-document
context set. Per-document context always takes precedence over the global
value, and original caller objects are not mutated.

Key implementation notes:
- The iterable is **only materialized** when `additional_context is not None`;
  when it is `None`, the raw iterable is forwarded unchanged to preserve
  streaming behaviour for large inputs.
- Copied Documents preserve `_document_id` and `_tokenized_text` from the
  originals to avoid regenerating IDs or discarding cached tokenization.

Fixes #445

## How Has This Been Tested?

Added 7 new unit tests to `tests/extract_precedence_test.py` covering:
- Global context applied to documents with no per-document context
- Per-document context takes precedence over the global value
- `None` additional_context leaves documents and iterable unchanged
- Explicit document IDs are preserved on copied documents
- Generator/lazy-iterable inputs work correctly
- Original caller Documents are not mutated
- Empty-string additional_context is treated as a non-None value

All 525 existing tests pass (excluding pre-existing env-dependent plugin test).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have self-reviewed my own code
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests passed locally with my changes (`pytest tests/`)
- [x] I have run `./autoformat.sh` on changed files