### PR TITLE
ci: bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/auto-update-pr.yaml
+++ b/.github/workflows/auto-update-pr.yaml
@@ -40,7 +40,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Update PRs that are behind main
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const prNumber = context.payload.inputs?.pr_number;

--- a/.github/workflows/check-infrastructure-changes.yml
+++ b/.github/workflows/check-infrastructure-changes.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check for infrastructure file changes
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check linked issue and community support
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/check-pr-size.yml
+++ b/.github/workflows/check-pr-size.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get PR data for manual trigger
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number
         id: get_pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           result-encoding: string
           script: |
@@ -39,7 +39,7 @@ jobs:
 
       - name: Evaluate PR size
         if: github.event_name == 'pull_request_target' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PR_JSON: ${{ steps.get_pr.outputs.result }}
         with:

--- a/.github/workflows/check-pr-up-to-date.yaml
+++ b/.github/workflows/check-pr-up-to-date.yaml
@@ -32,7 +32,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2  # Sufficient for rev-list comparison
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Comment if PR needs update
         if: ${{ steps.check.outputs.commits_behind != '0' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const behind = ${{ steps.check.outputs.commits_behind }};

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,14 +57,14 @@ jobs:
       issues: write
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Comment on PR if formatting fails
         if: failure() && steps.format-check.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         with:
           script: |
@@ -111,12 +111,12 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -141,12 +141,12 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -179,7 +179,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -203,7 +203,7 @@ jobs:
           exit 0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -227,7 +227,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -249,7 +249,7 @@ jobs:
           exit 0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -303,7 +303,7 @@ jobs:
     steps:
       - name: Resolve secure PR metadata
         id: pr-metadata
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -388,7 +388,7 @@ jobs:
           echo "::notice title=Security::Pinned commit SHA for testing: ${SHA_TO_TEST}"
 
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -420,7 +420,7 @@ jobs:
           STEPS_SHA_PIN_OUTPUTS_SHA_TO_TEST: ${{ steps.sha-pin.outputs.SHA_TO_TEST }}
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -443,7 +443,7 @@ jobs:
           }
 
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -469,7 +469,7 @@ jobs:
           STEPS_SHA_PIN_OUTPUTS_SHA_TO_TEST: ${{ steps.sha-pin.outputs.SHA_TO_TEST }}
 
       - name: Add status comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         env:
           PR_NUMBER: ${{ steps.pr-metadata.outputs.pr_number }}
@@ -503,7 +503,7 @@ jobs:
 
       - name: Report success
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         env:
           PR_NUMBER: ${{ steps.pr-metadata.outputs.pr_number }}
@@ -520,7 +520,7 @@ jobs:
 
       - name: Report failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         continue-on-error: true
         env:
           PR_NUMBER: ${{ steps.pr-metadata.outputs.pr_number }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Detect provider-related changes
         id: provider-changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             langextract/providers/**
@@ -234,7 +234,7 @@ jobs:
 
       - name: Detect file changes
         id: changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             langextract/inference.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,10 +30,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/revalidate-pr.yml
+++ b/.github/workflows/revalidate-pr.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get PR data
         id: pr_data
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({
@@ -40,7 +40,7 @@ jobs:
             return pr;
 
       - name: Create pending status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -54,7 +54,7 @@ jobs:
 
       - name: Validate PR
         id: validate
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = ${{ steps.pr_data.outputs.result }};
@@ -104,7 +104,7 @@ jobs:
 
       - name: Update commit status
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const passed = ${{ steps.validate.outputs.passed }};
@@ -122,7 +122,7 @@ jobs:
 
       - name: Add validation comment
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = ${{ steps.pr_data.outputs.result }};

--- a/.github/workflows/validate-community-providers.yaml
+++ b/.github/workflows/validate-community-providers.yaml
@@ -32,10 +32,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/validate_pr_template.yaml
+++ b/.github/workflows/validate_pr_template.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Check PR author permissions
         id: check
         if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/zenodo-publish.yml
+++ b/.github/workflows/zenodo-publish.yml
@@ -36,10 +36,10 @@ jobs:
       RELEASE_TAG: ${{ github.ref_name }}
       GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary

Resolves the Node.js 20 deprecation warning surfaced on every workflow run since GitHub announced the Node 24 transition (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Without this, runs will be force-migrated to Node 24 on June 2nd, 2026 and Node 20 will be removed Sept 16th, 2026.

| Action | Old | New |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-python` | `@v5` | `@v6` |
| `actions/github-script` | `@v7` | `@v9` |
| `tj-actions/changed-files` | `@v46` | `@v47` |

All target majors run on Node 24.

## Compatibility notes

- `checkout@v6`: no breaking changes for our usage (one internal change persists creds to a separate file).
- `setup-python@v6`: requires GitHub-hosted runner v2.327.1+ (already the case).
- `github-script@v9`: breaking changes are limited to `require('@actions/github')` and `getOctokit` redeclaration. Grepped the workflows — neither pattern is used here.
- `tj-actions/changed-files@v47`: API is unchanged (same inputs/outputs); the major bump is mostly internal dep updates including the move to Node 24.

## Test plan

- [x] All required CI checks pass on this PR (test 3.10/3.11/3.12, format-check, check, size, protect-infrastructure, enforce, live-api-tests)
- [ ] No "Node.js 20 actions are deprecated" warning surfaces on the merged main run