### PR TITLE
ci(zenodo): surface API errors and add manual re-run trigger

### DIFF
--- a/.github/scripts/zenodo_publish.py
+++ b/.github/scripts/zenodo_publish.py
@@ -49,17 +49,59 @@ except (KeyError, FileNotFoundError) as e:
   sys.exit(1)
 
 
+def _check(r: requests.Response, op: str) -> None:
+  """raise_for_status with the response body included for debugging."""
+  if not r.ok:
+    body = r.text[:2000] if r.text else "<empty>"
+    print(f"❌ Zenodo {op} failed: {r.status_code} {r.reason}", file=sys.stderr)
+    print(f"   URL: {r.request.url}", file=sys.stderr)
+    print(f"   Response body: {body}", file=sys.stderr)
+    r.raise_for_status()
+
+
+def _get_existing_draft(record_id: str):
+  """Return an existing unpublished draft for the record, if any."""
+  r = requests.get(
+      f"{API}/deposit/depositions/{record_id}",
+      headers=HEADERS,
+      timeout=30,
+  )
+  _check(r, "GET deposition")
+  data = r.json()
+  links = data.get("links", {})
+  draft_url = links.get("latest_draft")
+  if draft_url:
+    dr = requests.get(draft_url, headers=HEADERS, timeout=30)
+    _check(dr, "GET latest_draft")
+    draft = dr.json()
+    if draft.get("submitted") is False:
+      return draft
+  return None
+
+
 def new_version_from_record(record_id: str):
-  """Create a new draft that inherits metadata from the latest published record."""
+  """Create a new draft that inherits metadata from the latest published record.
+
+  If newversion fails because an unsubmitted draft already exists, reuse it.
+  """
   r = requests.post(
       f"{API}/deposit/depositions/{record_id}/actions/newversion",
       headers=HEADERS,
       timeout=30,
   )
-  r.raise_for_status()
-  # Zenodo returns a link to the draft, not the draft itself
+  if r.status_code == 400:
+    existing = _get_existing_draft(record_id)
+    if existing is not None:
+      print(
+          f"ℹ️  Reusing existing unsubmitted draft id={existing.get('id')}",
+          file=sys.stderr,
+      )
+      return existing
+  _check(r, "newversion")
   latest_draft_url = r.json()["links"]["latest_draft"]
-  return requests.get(latest_draft_url, headers=HEADERS, timeout=30).json()
+  dr = requests.get(latest_draft_url, headers=HEADERS, timeout=30)
+  _check(dr, "GET latest_draft")
+  return dr.json()
 
 
 def upload_file(bucket_url: str, path: str, dest_name: str = None):
@@ -72,7 +114,7 @@ def upload_file(bucket_url: str, path: str, dest_name: str = None):
         headers={"Authorization": f"Bearer {TOKEN}"},
         timeout=60,
     )
-    r.raise_for_status()
+    _check(r, f"upload {dest}")
 
 
 def main():
@@ -106,7 +148,7 @@ def main():
         json=meta,
         timeout=30,
     )
-    r.raise_for_status()
+    _check(r, "PUT metadata")
 
     # Publish to mint DOI
     r = requests.post(
@@ -114,7 +156,7 @@ def main():
         headers=HEADERS,
         timeout=30,
     )
-    r.raise_for_status()
+    _check(r, "publish")
     record = r.json()
 
     doi = record.get("doi")

--- a/.github/workflows/zenodo-publish.yml
+++ b/.github/workflows/zenodo-publish.yml
@@ -16,6 +16,12 @@ name: Publish to Zenodo
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag to publish (e.g. v1.3.0). Used only when manually re-running.'
+        required: true
+        type: string
 
 concurrency:
   group: zenodo-${{ github.ref }}
@@ -25,7 +31,7 @@ jobs:
   zenodo:
     # Only run on releases from the main repository, not forks
     # Skip pre-releases to avoid creating DOIs for test releases
-    if: ${{ !github.event.release.prerelease && github.repository == 'google/langextract' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease && github.repository == 'google/langextract') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -33,9 +39,14 @@ jobs:
     env:
       ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
       ZENODO_RECORD_ID: ${{ secrets.ZENODO_RECORD_ID }}
-      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
       GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
+      # Note: we deliberately do not check out the input ref. workflow_dispatch
+      # is meant for diagnostic re-runs of the latest release, and we want the
+      # *fixed* script from main, not whatever script existed at the older tag.
+      # The build below uses main's pyproject.toml; this only works correctly
+      # when main's version still matches the tag being republished.
       - uses: actions/checkout@v6
 
       - name: Set up Python


### PR DESCRIPTION
## Why

The Zenodo publish job has been failing on every release since v1.1.0 (Nov 2025) with a bare \`400 Bad Request\` on \`/actions/newversion\`. The current script calls \`raise_for_status()\` without surfacing the response body, so the underlying cause is invisible in CI logs.

## What this changes

- **\`_check()\` helper** — prints status, URL, and up to 2KB of response body before re-raising. Replaces every \`raise_for_status()\`.
- **Draft-reuse fallback** — if \`POST /actions/newversion\` returns 400, fetch the deposition's \`latest_draft\` and reuse it if unsubmitted. This handles the common case where a previous failed run left a draft hanging.
- **\`workflow_dispatch\` trigger** — adds a \`release_tag\` input so we can manually re-run against an already-published release without cutting a new tag. Intentionally does NOT \`checkout\` the input ref: we want the fixed script from \`main\`, not whatever existed at the older tag. Safe for re-running the latest release; not appropriate for older tags whose \`pyproject.toml\` differs.

## Test plan

After merge, manually dispatch:

\`\`\`bash
gh workflow run zenodo-publish.yml -f release_tag=v1.3.0 --repo google/langextract
\`\`\`

CI logs will now show the actual Zenodo error response, which we can act on.

## Risks

- The diagnostic path is only exercised on failure, so this is safe to merge even if Zenodo is still misbehaving — successful runs are unchanged.
- If a future release dispatches with a tag whose \`pyproject.toml\` differs from \`main\`'s, the build artifacts will be wrong. Documented inline.