### PR TITLE
Fix visualization HTML charset handling

### DIFF
--- a/langextract/visualization.py
+++ b/langextract/visualization.py
@@ -175,6 +175,8 @@ _VISUALIZATION_CSS = textwrap.dedent("""\
     .lx-gif-optimized .lx-current-highlight { text-decoration-thickness: 4px; }
     </style>""")
 
+_HTML_CHARSET_META = '<meta charset="UTF-8">\n'
+
 
 def _assign_colors(extractions: list[data.Extraction]) -> dict[str, str]:
   """Assigns a background colour to each extraction class.
@@ -600,7 +602,7 @@ def visualize(
         '<div class="lx-animated-wrapper"><p>No valid extractions to'
         ' animate.</p></div>'
     )
-    full_html = _VISUALIZATION_CSS + empty_html
+    full_html = _HTML_CHARSET_META + _VISUALIZATION_CSS + empty_html
     if HTML is not None and _is_jupyter():
       return HTML(full_html)
     return full_html
@@ -615,7 +617,7 @@ def visualize(
       show_legend,
   )
 
-  full_html = _VISUALIZATION_CSS + visualization_html
+  full_html = _HTML_CHARSET_META + _VISUALIZATION_CSS + visualization_html
 
   # Apply GIF optimizations if requested
   if gif_optimized:

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -22,6 +22,7 @@ from langextract import visualization
 from langextract.core import data
 
 _PALETTE = visualization._PALETTE
+_HTML_CHARSET_META = visualization._HTML_CHARSET_META
 _VISUALIZATION_CSS = visualization._VISUALIZATION_CSS
 
 
@@ -134,6 +135,7 @@ class VisualizationTest(absltest.TestCase):
 
     actual_html = visualization.visualize(doc)
 
+    self.assertTrue(actual_html.startswith(_HTML_CHARSET_META))
     # Verify expected components appear in output
     for component in expected_components:
       self.assertIn(component, actual_html)
@@ -149,7 +151,7 @@ class VisualizationTest(absltest.TestCase):
         " animate.</p></div>"
     )
     css_html = _VISUALIZATION_CSS
-    expected_html = css_html + body_html
+    expected_html = _HTML_CHARSET_META + css_html + body_html
 
     actual_html = visualization.visualize(doc)
 


### PR DESCRIPTION
Fixes #234

## Description

Saved visualization HTML should always be interpreted as UTF-8. Without an explicit charset, some browsers can guess a different encoding based on the user’s system settings that might cause non-ASCII text to render incorrectly.

This change adds a UTF-8 charset meta tag to the HTML returned by `visualize()`, so saved visualization files render consistently across browsers.

## How Has This Been Tested?

- Ran `pyink langextract/visualization.py tests/visualization_test.py --config pyproject.toml`
- Ran `pytest tests/visualization_test.py` (`5 passed`)
- Ran `pytest tests`; the visualization tests passed, but the full suite still has unrelated local failures from the missing optional `openai` package and one pip-install plugin discovery test

## Checklist

- [x] My code follows the style guidelines
- [x] I have self-reviewed my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests passed locally with my changes