### PR TITLE
Add OpenAI structured output schema support

### DIFF
--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import concurrent.futures
 import dataclasses
 from typing import Any, Iterator, Sequence
+import warnings
 
 from langextract.core import base_model
 from langextract.core import data
@@ -28,6 +29,7 @@ from langextract.core import schema
 from langextract.core import types as core_types
 from langextract.providers import patterns
 from langextract.providers import router
+from langextract.providers import schemas
 
 
 @router.register(
@@ -42,6 +44,9 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
   api_key: str | None = None
   base_url: str | None = None
   organization: str | None = None
+  openai_schema: schemas.openai.OpenAISchema | None = dataclasses.field(
+      default=None, repr=False, compare=False
+  )
   format_type: data.FormatType = data.FormatType.JSON
   temperature: float | None = None
   max_workers: int = 10
@@ -50,10 +55,46 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
       default_factory=dict, repr=False, compare=False
   )
 
+  @classmethod
+  def get_schema_class(cls) -> type[schema.BaseSchema] | None:
+    """Return the OpenAISchema class for structured output support."""
+    return schemas.openai.OpenAISchema
+
+  def apply_schema(self, schema_instance: schema.BaseSchema | None) -> None:
+    """Applies an OpenAI schema instance to this provider.
+
+    Args:
+      schema_instance: An OpenAISchema to enforce, or None to clear.
+
+    Raises:
+      InferenceConfigError: if schema_instance is a non-OpenAI BaseSchema
+        subclass, or if applying an OpenAI schema would conflict with a
+        non-JSON format_type.
+    """
+    if schema_instance is None:
+      self.openai_schema = None
+    elif isinstance(schema_instance, schemas.openai.OpenAISchema):
+      if self.format_type != data.FormatType.JSON:
+        raise exceptions.InferenceConfigError(
+            schemas.openai.JSON_SCHEMA_FORMAT_ERROR
+        )
+      self.openai_schema = schema_instance
+    else:
+      raise exceptions.InferenceConfigError(
+          'OpenAILanguageModel only accepts OpenAISchema instances; got '
+          f'{type(schema_instance).__name__}. Use the matching provider '
+          'for this schema or construct an OpenAISchema via '
+          'OpenAISchema.from_examples.'
+      )
+    super().apply_schema(schema_instance)
+
   @property
   def requires_fence_output(self) -> bool:
-    """OpenAI JSON mode returns raw JSON without fences."""
-    if self.format_type == data.FormatType.JSON:
+    """OpenAI JSON mode returns raw JSON unless callers override fences."""
+    if (
+        self._fence_output_override is None
+        and self.format_type == data.FormatType.JSON
+    ):
       return False
     return super().requires_fence_output
 
@@ -63,6 +104,7 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
       api_key: str | None = None,
       base_url: str | None = None,
       organization: str | None = None,
+      openai_schema: schemas.openai.OpenAISchema | None = None,
       format_type: data.FormatType = data.FormatType.JSON,
       temperature: float | None = None,
       max_workers: int = 10,
@@ -75,13 +117,13 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
       api_key: API key for OpenAI service.
       base_url: Base URL for OpenAI service.
       organization: Optional OpenAI organization ID.
+      openai_schema: Optional schema for structured output.
       format_type: Output format (JSON or YAML).
       temperature: Sampling temperature.
       max_workers: Maximum number of parallel API calls.
       **kwargs: Ignored extra parameters so callers can pass a superset of
-        arguments shared across back-ends without raising ``TypeError``.
+        arguments shared across back-ends without raising TypeError.
     """
-    # Lazy import: OpenAI package required
     try:
       # pylint: disable=import-outside-toplevel
       import openai
@@ -91,33 +133,46 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
           'Install with: pip install langextract[openai]'
       ) from e
 
+    # Constructor-provided schemas use BaseLanguageModel state when applied.
+    super().__init__(
+        constraint=schema.Constraint(constraint_type=schema.ConstraintType.NONE)
+    )
+
     self.model_id = model_id
     self.api_key = api_key
     self.base_url = base_url
     self.organization = organization
+    self.openai_schema = None
     self.format_type = format_type
     self.temperature = temperature
     self.max_workers = max_workers
+    self._extra_kwargs = kwargs or {}
 
     if not self.api_key:
       raise exceptions.InferenceConfigError('API key not provided.')
 
-    # Initialize the OpenAI client
+    if openai_schema is not None:
+      self.apply_schema(openai_schema)
+
+    # Keep SDK initialization after schema validation so LangExtract reports
+    # configuration errors before any client-side transport checks.
     self._client = openai.OpenAI(
         api_key=self.api_key,
         base_url=self.base_url,
         organization=self.organization,
     )
 
-    super().__init__(
-        constraint=schema.Constraint(constraint_type=schema.ConstraintType.NONE)
-    )
-    self._extra_kwargs = kwargs or {}
+  def _validate_schema_config(self) -> None:
+    """Rejects schema settings the OpenAI API cannot honor."""
+    if self.openai_schema and self.format_type != data.FormatType.JSON:
+      raise exceptions.InferenceConfigError(
+          schemas.openai.JSON_SCHEMA_FORMAT_ERROR
+      )
 
   def _process_single_prompt(
       self, prompt: str, config: dict
   ) -> core_types.ScoredOutput:
-    """Process a single prompt and return a ScoredOutput."""
+    """Sends one prompt while preserving provider-specific error types."""
     try:
       normalized_config = config.copy()
 
@@ -145,8 +200,23 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
       if temp is not None:
         api_params['temperature'] = temp
 
-      if self.format_type == data.FormatType.JSON:
-        api_params.setdefault('response_format', {'type': 'json_object'})
+      runtime_response_format = normalized_config.get('response_format')
+      if self.openai_schema and runtime_response_format is None:
+        self._validate_schema_config()
+        api_params['response_format'] = self.openai_schema.response_format
+      elif runtime_response_format is not None:
+        if self.openai_schema:
+          # Advanced callers may deliberately override response_format at
+          # runtime; warn because that bypasses the configured schema.
+          warnings.warn(
+              'openai_schema is set but a runtime response_format kwarg '
+              'was provided; the schema is bypassed for this call.',
+              UserWarning,
+              stacklevel=3,
+          )
+        api_params['response_format'] = runtime_response_format
+      elif self.format_type == data.FormatType.JSON:
+        api_params['response_format'] = {'type': 'json_object'}
 
       if (v := normalized_config.get('max_output_tokens')) is not None:
         api_params['max_tokens'] = v
@@ -160,18 +230,18 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
           'logprobs',
           'top_logprobs',
           'reasoning_effort',
-          'response_format',
       ]:
         if (v := normalized_config.get(key)) is not None:
           api_params[key] = v
 
       response = self._client.chat.completions.create(**api_params)
 
-      # Extract the response text using the v1.x response format
       output_text = response.choices[0].message.content
 
       return core_types.ScoredOutput(score=1.0, output=output_text)
 
+    except exceptions.InferenceConfigError:
+      raise
     except Exception as e:
       raise exceptions.InferenceRuntimeError(
           f'OpenAI API error: {str(e)}', original=e
@@ -233,6 +303,8 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):
           index = future_to_index[future]
           try:
             results[index] = future.result()
+          except exceptions.InferenceConfigError:
+            raise
           except Exception as e:
             raise exceptions.InferenceRuntimeError(
                 f'Parallel inference error: {str(e)}', original=e

--- a/langextract/providers/schemas/__init__.py
+++ b/langextract/providers/schemas/__init__.py
@@ -16,7 +16,9 @@
 from __future__ import annotations
 
 from langextract.providers.schemas import gemini
+from langextract.providers.schemas import openai
 
 GeminiSchema = gemini.GeminiSchema  # Backward compat
+OpenAISchema = openai.OpenAISchema
 
-__all__ = ["GeminiSchema"]
+__all__ = ["GeminiSchema", "OpenAISchema"]

--- a/langextract/providers/schemas/openai.py
+++ b/langextract/providers/schemas/openai.py
@@ -1,0 +1,279 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenAI provider schema implementation."""
+# pylint: disable=duplicate-code
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import copy
+import dataclasses
+from typing import Any
+import warnings
+
+from langextract.core import data
+from langextract.core import exceptions
+from langextract.core import format_handler as fh
+from langextract.core import schema
+
+DEFAULT_SCHEMA_NAME = "langextract_extractions"
+JSON_SCHEMA_FORMAT_ERROR = (
+    "OpenAI structured output only supports JSON format. "
+    "Set format_type=JSON or use_schema_constraints=False."
+)
+
+
+def _nullable(schema_dict: dict[str, Any]) -> dict[str, Any]:
+  """Allows optional LangExtract fields under OpenAI strict mode.
+
+  Strict mode requires every object key to be listed as required. A null
+  branch preserves LangExtract's optional-attribute semantics.
+  """
+  return {"anyOf": [schema_dict, {"type": "null"}]}
+
+
+def _attribute_value_schema(attr_types: set[type]) -> dict[str, Any]:
+  """Maps example-observed Python values into a strict JSON-Schema union.
+
+  OpenAI strict mode requires declared object keys to be present, so null
+  is always included. Unknown value types fall back to strings because the
+  examples are a guide for model output, not a full Python type system.
+
+  Args:
+    attr_types: Python types observed for this attribute across all
+      examples. May be empty if the attribute was declared but never
+      assigned a concrete value.
+
+  Returns:
+    A JSON-Schema anyOf fragment.
+  """
+  options: list[dict[str, Any]] = []
+  if list in attr_types:
+    options.append({"type": "array", "items": {"type": "string"}})
+  if bool in attr_types:
+    options.append({"type": "boolean"})
+  if int in attr_types:
+    options.append({"type": "integer"})
+  if float in attr_types:
+    options.append({"type": "number"})
+  recognized_scalars = {bool, int, float, str, list}
+  needs_string_fallback = (
+      not attr_types or str in attr_types or attr_types - recognized_scalars
+  )
+  if needs_string_fallback:
+    options.append({"type": "string"})
+  options.append({"type": "null"})
+  return {"anyOf": options}
+
+
+def _collect_extraction_categories(
+    examples_data: Sequence[data.ExampleData],
+) -> dict[str, dict[str, set[type]]]:
+  """Keeps schema variants aligned with the examples' extraction classes.
+
+  Args:
+    examples_data: Example extractions to inspect.
+
+  Returns:
+    A nested mapping from category to attribute name to observed Python
+    value types.
+  """
+  extraction_categories: dict[str, dict[str, set[type]]] = {}
+  for example in examples_data:
+    for extraction in example.extractions:
+      category = extraction.extraction_class
+      if category not in extraction_categories:
+        extraction_categories[category] = {}
+
+      if extraction.attributes:
+        for attr_name, attr_value in extraction.attributes.items():
+          if attr_name not in extraction_categories[category]:
+            extraction_categories[category][attr_name] = set()
+          extraction_categories[category][attr_name].add(type(attr_value))
+  return extraction_categories
+
+
+def _build_extraction_variant(
+    category: str,
+    attrs: dict[str, set[type]],
+    attribute_suffix: str,
+) -> dict[str, Any]:
+  """Creates the shape OpenAI must enforce for one extraction class.
+
+  Each variant has two top-level keys: category for extracted text and
+  category plus suffix for attributes. Both keys are required so OpenAI
+  strict mode accepts the shape; the attributes object is wrapped in a
+  null union so the model may omit it.
+
+  Args:
+    category: The extraction class name, used as the literal property key.
+    attrs: Mapping from attribute name to observed Python value types.
+    attribute_suffix: Suffix appended to category to form the attributes
+      object property key.
+
+  Returns:
+    A JSON-Schema object fragment.
+  """
+  properties: dict[str, Any] = {category: {"type": "string"}}
+
+  # Null unions preserve optional attributes while satisfying OpenAI strict
+  # mode's required-key rule.
+  attr_properties = {
+      attr_name: _attribute_value_schema(attr_types)
+      for attr_name, attr_types in attrs.items()
+  }
+  attributes_field = f"{category}{attribute_suffix}"
+  properties[attributes_field] = _nullable({
+      "type": "object",
+      "properties": attr_properties,
+      "required": list(attr_properties),
+      "additionalProperties": False,
+  })
+
+  return {
+      "type": "object",
+      "properties": properties,
+      "required": list(properties),
+      "additionalProperties": False,
+  }
+
+
+@dataclasses.dataclass(frozen=True)
+class OpenAISchema(schema.BaseSchema):
+  """Schema implementation for OpenAI structured outputs.
+
+  Converts ExampleData objects into a JSON-Schema that OpenAI's Chat
+  Completions API accepts via response_format. Instances are frozen because
+  parallel inference shares one schema across worker threads.
+  """
+
+  schema_dict: dict[str, Any]
+  schema_name: str = DEFAULT_SCHEMA_NAME
+  strict: bool = True
+
+  def __post_init__(self) -> None:
+    # Copy before publishing the schema to worker threads so caller mutations
+    # cannot change in-flight requests.
+    object.__setattr__(self, "schema_dict", copy.deepcopy(self.schema_dict))
+
+  @property
+  def response_format(self) -> dict[str, Any]:
+    """Per-call Chat Completions response_format payload."""
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": self.schema_name,
+            "schema": copy.deepcopy(self.schema_dict),
+            "strict": self.strict,
+        },
+    }
+
+  def to_provider_config(self) -> dict[str, Any]:
+    """OpenAI schemas are applied through the provider schema hook."""
+    return {}
+
+  @property
+  def requires_raw_output(self) -> bool:
+    """OpenAI structured outputs emit raw JSON without fences."""
+    return True
+
+  def validate_format(self, format_handler: fh.FormatHandler) -> None:
+    """Validates OpenAI structured output format compatibility.
+
+    Args:
+      format_handler: Format handler describing the caller's desired
+        output shape (format type, fence usage, wrapper key).
+
+    Raises:
+      InferenceConfigError: if format_type is not JSON.
+    """
+    if format_handler.format_type != data.FormatType.JSON:
+      raise exceptions.InferenceConfigError(JSON_SCHEMA_FORMAT_ERROR)
+
+    if format_handler.use_fences:
+      warnings.warn(
+          "OpenAI structured outputs emit native JSON via response_format. "
+          "Using fence_output=True may cause parsing issues. Set "
+          "fence_output=False.",
+          UserWarning,
+          stacklevel=3,
+      )
+
+    if (
+        not format_handler.use_wrapper
+        or format_handler.wrapper_key != data.EXTRACTIONS_KEY
+    ):
+      warnings.warn(
+          "OpenAI's response_format schema expects"
+          f" wrapper_key='{data.EXTRACTIONS_KEY}'. Current settings:"
+          f" use_wrapper={format_handler.use_wrapper},"
+          f" wrapper_key='{format_handler.wrapper_key}'",
+          UserWarning,
+          stacklevel=3,
+      )
+
+  @classmethod
+  def from_examples(
+      cls,
+      examples_data: Sequence[data.ExampleData],
+      attribute_suffix: str = data.ATTRIBUTE_SUFFIX,
+      strict: bool = True,
+  ) -> OpenAISchema:
+    """Creates an OpenAISchema from example extractions.
+
+    Builds a JSON schema with a top-level extractions array whose items are
+    an anyOf union of one strict-mode object variant per extraction class.
+
+    Args:
+      examples_data: A sequence of ExampleData objects containing
+        extraction classes and attributes.
+      attribute_suffix: String appended to each class name to form the
+        attributes-object key. Defaults to "_attributes".
+      strict: Whether to emit the schema under OpenAI strict mode. Defaults
+        to True. Set to False for schemas OpenAI rejects in strict mode. The
+        generated schema shape remains constrained in either mode.
+
+    Returns:
+      An OpenAISchema instance ready to pass to a provider.
+    """
+    extraction_categories = _collect_extraction_categories(examples_data)
+    variants = [
+        _build_extraction_variant(category, attrs, attribute_suffix)
+        for category, attrs in extraction_categories.items()
+    ]
+
+    if variants:
+      extraction_item_schema = {"anyOf": variants}
+    else:
+      extraction_item_schema = {
+          "type": "object",
+          "properties": {},
+          "required": [],
+          "additionalProperties": False,
+      }
+
+    schema_dict = {
+        "type": "object",
+        "properties": {
+            data.EXTRACTIONS_KEY: {
+                "type": "array",
+                "items": extraction_item_schema,
+            }
+        },
+        "required": [data.EXTRACTIONS_KEY],
+        "additionalProperties": False,
+    }
+
+    return cls(schema_dict=schema_dict, strict=strict)

--- a/tests/factory_schema_test.py
+++ b/tests/factory_schema_test.py
@@ -22,6 +22,7 @@ from langextract import factory
 from langextract import schema
 from langextract.core import base_model
 from langextract.core import data
+from langextract.providers import schemas
 
 
 class FactorySchemaIntegrationTest(absltest.TestCase):
@@ -88,6 +89,39 @@ class FactorySchemaIntegrationTest(absltest.TestCase):
       self.assertEqual(call_kwargs["format"], "json")
 
       self.assertFalse(model.requires_fence_output)
+
+  def test_openai_with_schema_returns_false_fence(self):
+    """OpenAI schema constraints use raw JSON by default."""
+    config = factory.ModelConfig(
+        model_id="gpt-4o-mini", provider_kwargs={"api_key": "test_key"}
+    )
+
+    with mock.patch("openai.OpenAI", autospec=True):
+      model = factory._create_model_with_schema(
+          config=config,
+          examples=self.examples,
+          use_schema_constraints=True,
+          fence_output=None,
+      )
+
+      self.assertIsInstance(model.schema, schemas.openai.OpenAISchema)
+      self.assertIs(model.requires_fence_output, False)
+
+  def test_openai_explicit_fence_output_respected(self):
+    """Explicit OpenAI fence_output overrides schema defaults."""
+    config = factory.ModelConfig(
+        model_id="gpt-4o-mini", provider_kwargs={"api_key": "test_key"}
+    )
+
+    with mock.patch("openai.OpenAI", autospec=True):
+      model = factory._create_model_with_schema(
+          config=config,
+          examples=self.examples,
+          use_schema_constraints=True,
+          fence_output=True,
+      )
+
+      self.assertIs(model.requires_fence_output, True)
 
   def test_explicit_fence_output_respected(self):
     """Test that explicit fence_output is not overridden."""

--- a/tests/provider_schema_test.py
+++ b/tests/provider_schema_test.py
@@ -50,13 +50,13 @@ class ProviderSchemaDiscoveryTest(absltest.TestCase):
         msg="OllamaLanguageModel should return FormatModeSchema class",
     )
 
-  def test_openai_returns_none(self):
-    """Test that OpenAILanguageModel returns None (no schema support yet)."""
-    # OpenAI imports dependencies in __init__, not at module level
+  def test_openai_returns_openai_schema(self):
+    """OpenAILanguageModel advertises OpenAISchema support."""
     schema_class = openai.OpenAILanguageModel.get_schema_class()
-    self.assertIsNone(
+    self.assertIs(
         schema_class,
-        msg="OpenAILanguageModel should return None (no schema support)",
+        schemas.openai.OpenAISchema,
+        msg="OpenAILanguageModel should return OpenAISchema class",
     )
 
 

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -18,6 +18,7 @@ Note: This file contains test helper classes that intentionally have
 few public methods. The too-few-public-methods warnings are expected.
 """
 
+import dataclasses
 from unittest import mock
 import warnings
 
@@ -26,9 +27,27 @@ from absl.testing import parameterized
 
 from langextract.core import base_model
 from langextract.core import data
+from langextract.core import exceptions
 from langextract.core import format_handler as fh
 from langextract.core import schema
 from langextract.providers import schemas
+
+
+def _openai_extraction_items(openai_schema):
+  return openai_schema.schema_dict["properties"][data.EXTRACTIONS_KEY]["items"]
+
+
+def _openai_variant(openai_schema, extraction_class):
+  for variant in _openai_extraction_items(openai_schema)["anyOf"]:
+    if extraction_class in variant["properties"]:
+      return variant
+  raise AssertionError(f"Missing OpenAI schema variant for {extraction_class}")
+
+
+def _openai_attribute_properties(openai_schema, extraction_class):
+  variant = _openai_variant(openai_schema, extraction_class)
+  attributes_key = f"{extraction_class}{data.ATTRIBUTE_SUFFIX}"
+  return variant["properties"][attributes_key]["anyOf"][0]["properties"]
 
 
 class BaseSchemaTest(absltest.TestCase):
@@ -279,6 +298,380 @@ class GeminiSchemaTest(parameterized.TestCase):
 
     gemini_schema = schemas.gemini.GeminiSchema.from_examples(examples_data)
     self.assertTrue(gemini_schema.requires_raw_output)
+
+
+class OpenAISchemaTest(parameterized.TestCase):
+  """Tests for OpenAI structured output schema generation."""
+
+  def test_response_format_returns_json_schema_response_format(self):
+    """OpenAI schema exposes Chat Completions structured outputs."""
+    examples_data = [
+        data.ExampleData(
+            text="Patient has diabetes.",
+            extractions=[
+                data.Extraction(
+                    extraction_text="diabetes",
+                    extraction_class="condition",
+                    attributes={"chronicity": "chronic"},
+                )
+            ],
+        )
+    ]
+
+    openai_schema = schemas.openai.OpenAISchema.from_examples(examples_data)
+
+    response_format = openai_schema.response_format
+    self.assertEqual(
+        response_format,
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "langextract_extractions",
+                "schema": openai_schema.schema_dict,
+                "strict": True,
+            },
+        },
+    )
+    self.assertIsNot(
+        response_format["json_schema"]["schema"], openai_schema.schema_dict
+    )
+
+  def test_to_provider_config_uses_provider_schema_hook(self):
+    """OpenAI schema state is applied after provider construction."""
+    openai_schema = schemas.openai.OpenAISchema.from_examples([])
+
+    provider_config = openai_schema.to_provider_config()
+
+    self.assertEmpty(provider_config)
+
+  def test_from_examples_constructs_strict_openai_schema(self):
+    """OpenAI schema uses strict-compatible extraction variants."""
+    examples_data = [
+        data.ExampleData(
+            text="Patient has diabetes.",
+            extractions=[
+                data.Extraction(
+                    extraction_text="diabetes",
+                    extraction_class="condition",
+                    attributes={"chronicity": "chronic"},
+                ),
+                data.Extraction(
+                    extraction_text="metformin",
+                    extraction_class="medication",
+                    attributes={"route": "oral"},
+                ),
+            ],
+        )
+    ]
+
+    openai_schema = schemas.openai.OpenAISchema.from_examples(examples_data)
+
+    self.assertEqual(
+        openai_schema.schema_dict,
+        {
+            "type": "object",
+            "properties": {
+                data.EXTRACTIONS_KEY: {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "condition": {"type": "string"},
+                                    "condition_attributes": {
+                                        "anyOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "chronicity": {
+                                                        "anyOf": [
+                                                            {"type": "string"},
+                                                            {"type": "null"},
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["chronicity"],
+                                                "additionalProperties": False,
+                                            },
+                                            {"type": "null"},
+                                        ]
+                                    },
+                                },
+                                "required": [
+                                    "condition",
+                                    "condition_attributes",
+                                ],
+                                "additionalProperties": False,
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "medication": {"type": "string"},
+                                    "medication_attributes": {
+                                        "anyOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "route": {
+                                                        "anyOf": [
+                                                            {"type": "string"},
+                                                            {"type": "null"},
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["route"],
+                                                "additionalProperties": False,
+                                            },
+                                            {"type": "null"},
+                                        ]
+                                    },
+                                },
+                                "required": [
+                                    "medication",
+                                    "medication_attributes",
+                                ],
+                                "additionalProperties": False,
+                            },
+                        ]
+                    },
+                }
+            },
+            "required": [data.EXTRACTIONS_KEY],
+            "additionalProperties": False,
+        },
+    )
+
+  def test_from_examples_preserves_list_attribute_schema(self):
+    """OpenAI schema accepts list attributes from examples."""
+    examples_data = [
+        data.ExampleData(
+            text="Patient has diabetes with fatigue.",
+            extractions=[
+                data.Extraction(
+                    extraction_text="diabetes",
+                    extraction_class="condition",
+                    attributes={"symptoms": ["fatigue"]},
+                )
+            ],
+        )
+    ]
+
+    openai_schema = schemas.openai.OpenAISchema.from_examples(examples_data)
+
+    self.assertEqual(
+        _openai_attribute_properties(openai_schema, "condition")["symptoms"],
+        {
+            "anyOf": [
+                {"type": "array", "items": {"type": "string"}},
+                {"type": "null"},
+            ]
+        },
+    )
+
+  def test_from_examples_empty_examples_allow_empty_extraction_objects(self):
+    """OpenAI schema handles empty example sets deterministically."""
+    openai_schema = schemas.openai.OpenAISchema.from_examples([])
+
+    self.assertEqual(
+        _openai_extraction_items(openai_schema),
+        {
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": False,
+        },
+    )
+
+  def test_validate_format_rejects_yaml(self):
+    """OpenAI structured outputs are JSON-only."""
+    openai_schema = schemas.openai.OpenAISchema.from_examples([])
+    format_handler = fh.FormatHandler(format_type=data.FormatType.YAML)
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError,
+        "OpenAI structured output only supports JSON format",
+    ):
+      openai_schema.validate_format(format_handler)
+
+  def test_requires_raw_output_returns_true(self):
+    """OpenAI structured outputs emit raw JSON without fences."""
+    openai_schema = schemas.openai.OpenAISchema.from_examples([])
+
+    self.assertTrue(openai_schema.requires_raw_output)
+
+  def test_validate_format_warns_when_fences_enabled(self):
+    """OpenAI schema warns when raw JSON would be wrapped in fences."""
+    openai_schema = schemas.openai.OpenAISchema.from_examples([])
+    format_handler = fh.FormatHandler(
+        format_type=data.FormatType.JSON,
+        use_fences=True,
+    )
+
+    with self.assertWarnsRegex(
+        UserWarning, "OpenAI structured outputs emit native JSON"
+    ):
+      openai_schema.validate_format(format_handler)
+
+  def test_validate_format_warns_with_wrong_wrapper_key(self):
+    """OpenAI schema warns when resolver wrapper settings drift."""
+    openai_schema = schemas.openai.OpenAISchema.from_examples([])
+    format_handler = fh.FormatHandler(
+        format_type=data.FormatType.JSON,
+        use_fences=False,
+        wrapper_key="items",
+    )
+
+    with self.assertWarnsRegex(
+        UserWarning,
+        f"response_format schema expects wrapper_key='{data.EXTRACTIONS_KEY}'",
+    ):
+      openai_schema.validate_format(format_handler)
+
+  def test_from_examples_preserves_scalar_attribute_types(self):
+    """Scalar attribute types map to their JSON-Schema equivalents.
+
+    Regression test: prior to this, every non-list attribute was
+    coerced to a string-only union, which forced OpenAI strict mode to
+    return scalars as strings even when examples used numbers/bools.
+    """
+    examples_data = [
+        data.ExampleData(
+            text="Aspirin 81 mg, daily, OTC.",
+            extractions=[
+                data.Extraction(
+                    extraction_text="aspirin",
+                    extraction_class="medication",
+                    attributes={
+                        "dose_mg": 81,
+                        "doses_per_day": 1.0,
+                        "otc": True,
+                        "route": "oral",
+                    },
+                )
+            ],
+        )
+    ]
+
+    openai_schema = schemas.openai.OpenAISchema.from_examples(examples_data)
+
+    self.assertEqual(
+        _openai_attribute_properties(openai_schema, "medication"),
+        {
+            "dose_mg": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
+            "doses_per_day": {"anyOf": [{"type": "number"}, {"type": "null"}]},
+            "otc": {"anyOf": [{"type": "boolean"}, {"type": "null"}]},
+            "route": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        },
+    )
+
+  def test_from_examples_preserves_mixed_numeric_attribute_types(self):
+    """Mixed numeric-like examples keep each observed JSON type."""
+    examples_data = [
+        data.ExampleData(
+            text="Medication flag.",
+            extractions=[
+                data.Extraction(
+                    extraction_text="flag",
+                    extraction_class="medication",
+                    attributes={"dose_or_flag": True},
+                )
+            ],
+        ),
+        data.ExampleData(
+            text="Medication count.",
+            extractions=[
+                data.Extraction(
+                    extraction_text="count",
+                    extraction_class="medication",
+                    attributes={"dose_or_flag": 1},
+                )
+            ],
+        ),
+        data.ExampleData(
+            text="Medication dose.",
+            extractions=[
+                data.Extraction(
+                    extraction_text="dose",
+                    extraction_class="medication",
+                    attributes={"dose_or_flag": 1.5},
+                )
+            ],
+        ),
+    ]
+
+    openai_schema = schemas.openai.OpenAISchema.from_examples(examples_data)
+
+    self.assertEqual(
+        _openai_attribute_properties(openai_schema, "medication")[
+            "dose_or_flag"
+        ],
+        {
+            "anyOf": [
+                {"type": "boolean"},
+                {"type": "integer"},
+                {"type": "number"},
+                {"type": "null"},
+            ]
+        },
+    )
+
+  def test_from_examples_allows_none_attribute_values(self):
+    """None-valued example attributes keep the strict-mode null branch."""
+    examples_data = [
+        data.ExampleData(
+            text="Medication status is unspecified.",
+            extractions=[
+                data.Extraction(
+                    extraction_text="Medication",
+                    extraction_class="medication",
+                    attributes={"status": None},
+                )
+            ],
+        )
+    ]
+
+    openai_schema = schemas.openai.OpenAISchema.from_examples(examples_data)
+
+    self.assertEqual(
+        _openai_attribute_properties(openai_schema, "medication")["status"],
+        {"anyOf": [{"type": "string"}, {"type": "null"}]},
+    )
+
+  def test_from_examples_strict_false_emits_non_strict_response_format(self):
+    """The strict kwarg threads through to response_format."""
+    openai_schema = schemas.openai.OpenAISchema.from_examples([], strict=False)
+
+    self.assertFalse(openai_schema.response_format["json_schema"]["strict"])
+
+  def test_response_format_returns_isolated_schema_dict(self):
+    """response_format callers cannot mutate the provider's schema."""
+    openai_schema = schemas.openai.OpenAISchema.from_examples([])
+    response_format = openai_schema.response_format
+
+    response_format["json_schema"]["schema"]["required"].append("extra")
+
+    self.assertEqual(
+        openai_schema.schema_dict["required"], [data.EXTRACTIONS_KEY]
+    )
+
+  def test_instance_is_frozen_and_dict_is_isolated(self):
+    """Frozen contract + deep-copy isolate the schema from caller mutation."""
+    source = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "required": ["x"],
+        "additionalProperties": False,
+    }
+    openai_schema = schemas.openai.OpenAISchema(schema_dict=source)
+
+    with self.assertRaises(dataclasses.FrozenInstanceError):
+      openai_schema.schema_dict = {}  # pylint: disable=attribute-defined-outside-init
+
+    source["properties"]["x"]["type"] = "integer"
+    self.assertEqual(
+        openai_schema.schema_dict["properties"]["x"], {"type": "string"}
+    )
 
 
 class SchemaValidationTest(parameterized.TestCase):

--- a/tests/test_kwargs_passthrough.py
+++ b/tests/test_kwargs_passthrough.py
@@ -20,24 +20,45 @@ import warnings
 
 from absl.testing import parameterized
 
+from langextract import factory
+from langextract.core import data
+from langextract.core import exceptions
 from langextract.providers import ollama
 from langextract.providers import openai
+from langextract.providers import schemas
+
+
+def _configure_openai_mock(mock_openai_class, content='{"result": "test"}'):
+  mock_client = mock.Mock()
+  mock_openai_class.return_value = mock_client
+  mock_response = mock.Mock()
+  mock_response.choices = [mock.Mock(message=mock.Mock(content=content))]
+  mock_client.chat.completions.create.return_value = mock_response
+  return mock_client
+
+
+def _condition_examples(attributes=None):
+  extraction_kwargs = {
+      'extraction_text': 'diabetes',
+      'extraction_class': 'condition',
+  }
+  if attributes is not None:
+    extraction_kwargs['attributes'] = attributes
+  return [
+      data.ExampleData(
+          text='Patient has diabetes.',
+          extractions=[data.Extraction(**extraction_kwargs)],
+      )
+  ]
 
 
 class TestOpenAIKwargsPassthrough(unittest.TestCase):
   """Test OpenAI provider's enhanced kwargs handling."""
 
-  @mock.patch('openai.OpenAI')
+  @mock.patch('openai.OpenAI', autospec=True)
   def test_reasoning_effort_passed_as_top_level(self, mock_openai_class):
     """reasoning_effort is passed as a top-level Chat Completions parameter."""
-    mock_client = mock.Mock()
-    mock_openai_class.return_value = mock_client
-
-    mock_response = mock.Mock()
-    mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
-    ]
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client = _configure_openai_mock(mock_openai_class)
 
     model = openai.OpenAILanguageModel(
         model_id='gpt-4o-mini',
@@ -51,17 +72,10 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
     self.assertEqual(call_args.kwargs.get('reasoning_effort'), 'low')
     self.assertNotIn('reasoning', call_args.kwargs)
 
-  @mock.patch('openai.OpenAI')
+  @mock.patch('openai.OpenAI', autospec=True)
   def test_runtime_reasoning_effort_override(self, mock_openai_class):
     """Runtime reasoning_effort overrides constructor value."""
-    mock_client = mock.Mock()
-    mock_openai_class.return_value = mock_client
-
-    mock_response = mock.Mock()
-    mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
-    ]
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client = _configure_openai_mock(mock_openai_class)
 
     model = openai.OpenAILanguageModel(
         model_id='o4-mini',
@@ -74,17 +88,10 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
     call_args = mock_client.chat.completions.create.call_args
     self.assertEqual(call_args.kwargs.get('reasoning_effort'), 'high')
 
-  @mock.patch('openai.OpenAI')
+  @mock.patch('openai.OpenAI', autospec=True)
   def test_runtime_kwargs_override_stored(self, mock_openai_class):
     """Runtime parameters should override constructor parameters."""
-    mock_client = mock.Mock()
-    mock_openai_class.return_value = mock_client
-
-    mock_response = mock.Mock()
-    mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
-    ]
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client = _configure_openai_mock(mock_openai_class)
 
     model = openai.OpenAILanguageModel(
         model_id='gpt-4o-mini',
@@ -96,21 +103,18 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
     list(model.infer(['test prompt'], temperature=0.3, seed=42))
 
     call_args = mock_client.chat.completions.create.call_args
-    self.assertEqual(call_args.kwargs.get('temperature'), 0.3)
-    self.assertEqual(call_args.kwargs.get('top_p'), 0.9)
-    self.assertEqual(call_args.kwargs.get('seed'), 42)
+    self.assertEqual(
+        {
+            key: call_args.kwargs.get(key)
+            for key in ('temperature', 'top_p', 'seed')
+        },
+        {'temperature': 0.3, 'top_p': 0.9, 'seed': 42},
+    )
 
-  @mock.patch('openai.OpenAI')
+  @mock.patch('openai.OpenAI', autospec=True)
   def test_falsy_values_preserved(self, mock_openai_class):
     """Falsy values like 0 should be preserved, not filtered as None."""
-    mock_client = mock.Mock()
-    mock_openai_class.return_value = mock_client
-
-    mock_response = mock.Mock()
-    mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
-    ]
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client = _configure_openai_mock(mock_openai_class)
 
     model = openai.OpenAILanguageModel(
         model_id='gpt-4o',
@@ -122,20 +126,18 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
     list(model.infer(['test prompt']))
 
     call_args = mock_client.chat.completions.create.call_args
-    self.assertEqual(call_args.kwargs.get('temperature'), 0)
-    self.assertEqual(call_args.kwargs.get('top_logprobs'), 0)
+    self.assertEqual(
+        {
+            key: call_args.kwargs.get(key)
+            for key in ('temperature', 'top_logprobs')
+        },
+        {'temperature': 0, 'top_logprobs': 0},
+    )
 
-  @mock.patch('openai.OpenAI')
+  @mock.patch('openai.OpenAI', autospec=True)
   def test_reasoning_effort_not_nested(self, mock_openai_class):
     """reasoning_effort should not be converted to a nested reasoning dict."""
-    mock_client = mock.Mock()
-    mock_openai_class.return_value = mock_client
-
-    mock_response = mock.Mock()
-    mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
-    ]
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client = _configure_openai_mock(mock_openai_class)
 
     model = openai.OpenAILanguageModel(
         model_id='o4-mini',
@@ -149,17 +151,10 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
     self.assertEqual(call_args.kwargs.get('reasoning_effort'), 'medium')
     self.assertNotIn('reasoning', call_args.kwargs)
 
-  @mock.patch('openai.OpenAI')
+  @mock.patch('openai.OpenAI', autospec=True)
   def test_custom_response_format(self, mock_openai_class):
     """Custom response_format should override default JSON format."""
-    mock_client = mock.Mock()
-    mock_openai_class.return_value = mock_client
-
-    mock_response = mock.Mock()
-    mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
-    ]
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client = _configure_openai_mock(mock_openai_class)
 
     model = openai.OpenAILanguageModel(
         model_id='gpt-4o',
@@ -180,17 +175,234 @@ class TestOpenAIKwargsPassthrough(unittest.TestCase):
         {'type': 'text', 'schema': 'custom'},
     )
 
-  @mock.patch('openai.OpenAI')
+  @mock.patch('openai.OpenAI', autospec=True)
+  def test_schema_response_format_passed_to_chat_completion(
+      self, mock_openai_class
+  ):
+    """OpenAI schema constraints use structured output response_format."""
+    mock_client = _configure_openai_mock(
+        mock_openai_class, content='{"extractions": []}'
+    )
+
+    config = factory.ModelConfig(
+        model_id='gpt-4o-mini', provider_kwargs={'api_key': 'test-key'}
+    )
+    model = factory.create_model(
+        config,
+        examples=_condition_examples(attributes={'chronicity': 'chronic'}),
+        use_schema_constraints=True,
+        fence_output=None,
+    )
+    self.assertIsInstance(model.schema, schemas.openai.OpenAISchema)
+    self.assertIs(model.openai_schema, model.schema)
+
+    list(model.infer(['test prompt']))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(
+        call_args.kwargs.get('response_format'),
+        {
+            'type': 'json_schema',
+            'json_schema': {
+                'name': 'langextract_extractions',
+                'strict': True,
+                'schema': mock.ANY,
+            },
+        },
+    )
+
+  @mock.patch('openai.OpenAI', autospec=True)
+  def test_runtime_response_format_overrides_schema(self, mock_openai_class):
+    """Runtime response_format wins over schema defaults."""
+    mock_client = _configure_openai_mock(
+        mock_openai_class, content='{"extractions": []}'
+    )
+
+    config = factory.ModelConfig(
+        model_id='gpt-4o-mini', provider_kwargs={'api_key': 'test-key'}
+    )
+    model = factory.create_model(
+        config,
+        examples=_condition_examples(),
+        use_schema_constraints=True,
+        fence_output=None,
+    )
+
+    with self.assertWarnsRegex(UserWarning, 'schema is bypassed for this call'):
+      list(
+          model.infer(['test prompt'], response_format={'type': 'json_object'})
+      )
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(
+        call_args.kwargs.get('response_format'), {'type': 'json_object'}
+    )
+
+  @mock.patch('openai.OpenAI', autospec=True)
+  def test_apply_schema_rejects_non_openai_schema(self, mock_openai_class):
+    """apply_schema rejects foreign BaseSchema subclasses explicitly."""
+    mock_openai_class.return_value = mock.Mock()
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-4o-mini', api_key='test-key'
+    )
+    gemini_schema = schemas.gemini.GeminiSchema.from_examples([])
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError,
+        'only accepts OpenAISchema instances',
+    ):
+      model.apply_schema(gemini_schema)
+
+    self.assertIsNone(model.openai_schema)
+    self.assertIsNone(model.schema)
+
+  @mock.patch('openai.OpenAI', autospec=True)
+  def test_apply_schema_rejection_preserves_prior_schema(
+      self, mock_openai_class
+  ):
+    """Rejected foreign schemas leave the active OpenAI schema unchanged."""
+    mock_openai_class.return_value = mock.Mock()
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-4o-mini', api_key='test-key'
+    )
+    openai_schema = schemas.openai.OpenAISchema.from_examples([])
+    model.apply_schema(openai_schema)
+    gemini_schema = schemas.gemini.GeminiSchema.from_examples([])
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError,
+        'only accepts OpenAISchema instances',
+    ):
+      model.apply_schema(gemini_schema)
+
+    self.assertIs(model.openai_schema, openai_schema)
+    self.assertIs(model.schema, openai_schema)
+
+  @mock.patch('openai.OpenAI', autospec=True)
+  def test_apply_schema_none_clears_response_format(self, mock_openai_class):
+    """Clearing an OpenAI schema falls back to regular JSON mode."""
+    mock_client = _configure_openai_mock(
+        mock_openai_class, content='{"extractions": []}'
+    )
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-4o-mini', api_key='test-key'
+    )
+    model.apply_schema(schemas.openai.OpenAISchema.from_examples([]))
+    model.apply_schema(None)
+    self.assertIsNone(model.openai_schema)
+    self.assertIsNone(model.schema)
+
+    list(model.infer(['test prompt']))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(
+        call_args.kwargs.get('response_format'), {'type': 'json_object'}
+    )
+
+  @mock.patch('openai.OpenAI', autospec=True)
+  def test_factory_schema_clear_removes_response_format(
+      self, mock_openai_class
+  ):
+    """Clearing a factory-created schema falls back to regular JSON mode."""
+    mock_client = _configure_openai_mock(
+        mock_openai_class, content='{"extractions": []}'
+    )
+
+    config = factory.ModelConfig(
+        model_id='gpt-4o-mini', provider_kwargs={'api_key': 'test-key'}
+    )
+    model = factory.create_model(
+        config,
+        examples=_condition_examples(),
+        use_schema_constraints=True,
+        fence_output=None,
+    )
+    model.apply_schema(None)
+    self.assertIsNone(model.openai_schema)
+    self.assertIsNone(model.schema)
+
+    list(model.infer(['test prompt']))
+
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(
+        call_args.kwargs.get('response_format'), {'type': 'json_object'}
+    )
+
+  @mock.patch('openai.OpenAI', autospec=True)
+  def test_apply_schema_none_preserves_explicit_fence_output(
+      self, mock_openai_class
+  ):
+    """Schema clearing does not erase the caller's fence preference."""
+    mock_openai_class.return_value = mock.Mock()
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-4o-mini', api_key='test-key'
+    )
+    model.apply_schema(schemas.openai.OpenAISchema.from_examples([]))
+    model.set_fence_output(True)
+
+    model.apply_schema(None)
+
+    self.assertIs(model.requires_fence_output, True)
+
+  @mock.patch('openai.OpenAI', autospec=True)
+  def test_apply_schema_rejects_yaml_format(self, mock_openai_class):
+    """OpenAI structured outputs fail fast for YAML format."""
+    mock_openai_class.return_value = mock.Mock()
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-4o-mini',
+        api_key='test-key',
+        format_type=data.FormatType.YAML,
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError,
+        'OpenAI structured output only supports JSON format',
+    ):
+      model.apply_schema(schemas.openai.OpenAISchema.from_examples([]))
+    self.assertIsNone(model.schema)
+    self.assertIsNone(model.openai_schema)
+
+  @mock.patch('openai.OpenAI', autospec=True)
+  def test_constructor_schema_populates_public_schema(self, mock_openai_class):
+    """Constructor schema support matches apply_schema state."""
+    mock_openai_class.return_value = mock.Mock()
+
+    openai_schema = schemas.openai.OpenAISchema.from_examples([])
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-4o-mini',
+        api_key='test-key',
+        openai_schema=openai_schema,
+    )
+
+    self.assertIs(model.openai_schema, openai_schema)
+    self.assertIs(model.schema, openai_schema)
+
+  @mock.patch('openai.OpenAI', autospec=True)
+  def test_inference_preserves_schema_config_error(self, mock_openai_class):
+    """Late schema configuration errors keep their config exception type."""
+    mock_openai_class.return_value = mock.Mock()
+
+    model = openai.OpenAILanguageModel(
+        model_id='gpt-4o-mini', api_key='test-key'
+    )
+    model.apply_schema(schemas.openai.OpenAISchema.from_examples([]))
+    model.format_type = data.FormatType.YAML
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError,
+        'OpenAI structured output only supports JSON format',
+    ):
+      list(model.infer(['test prompt']))
+
+  @mock.patch('openai.OpenAI', autospec=True)
   def test_reasoning_not_in_chat_completions(self, mock_openai_class):
     """reasoning dict is not forwarded to Chat Completions API."""
-    mock_client = mock.Mock()
-    mock_openai_class.return_value = mock_client
-
-    mock_response = mock.Mock()
-    mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
-    ]
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client = _configure_openai_mock(mock_openai_class)
 
     model = openai.OpenAILanguageModel(
         model_id='o4-mini',

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -42,7 +42,7 @@ from langextract.providers import gemini_batch as gb
 
 dotenv.load_dotenv(override=True)
 
-DEFAULT_GEMINI_MODEL = "gemini-2.5-flash"
+DEFAULT_GEMINI_MODEL = "gemini-2.5-flash-lite"
 DEFAULT_OPENAI_MODEL = "gpt-4o"
 
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY") or os.environ.get(
@@ -762,8 +762,6 @@ class TestLiveAPIGemini(unittest.TestCase):
 
     self.assertLess(duration2, 10.0, "Second run took too long for cache hit")
 
-    self.assertLess(duration2, 10.0, "Second run took too long for cache hit")
-
     print("\nVerifying GCS cache content...")
     bucket_name = gb._get_bucket_name(VERTEX_PROJECT, VERTEX_LOCATION)
     print(f"Checking bucket: {bucket_name}")
@@ -911,6 +909,86 @@ class TestLiveAPIOpenAI(unittest.TestCase):
         ),
         f"No PO/oral route found in: {route_texts}",
     )
+
+  @skip_if_no_openai
+  @live_api
+  @retry_on_transient_errors(max_retries=2)
+  def test_medication_extraction_with_schema_constraints(self):
+    """Strict OpenAI outputs enforce the example-derived extraction shape."""
+    prompt = textwrap.dedent("""\
+        Extract conditions and medications in the order they appear in the text.
+        Use exact text for extractions. For condition attributes, include status
+        and symptoms as a list when symptoms are available.""")
+    examples = [
+        lx.data.ExampleData(
+            text="Patient has diabetes with fatigue and takes Metformin.",
+            extractions=[
+                lx.data.Extraction(
+                    extraction_class=_CLASS_CONDITION,
+                    extraction_text="diabetes",
+                    attributes={
+                        "status": "present",
+                        "symptoms": ["fatigue"],
+                    },
+                ),
+                lx.data.Extraction(
+                    extraction_class=_CLASS_MEDICATION,
+                    extraction_text="Metformin",
+                    attributes={"status": "current"},
+                ),
+            ],
+        )
+    ]
+    input_text = (
+        "Patient has headache with fatigue and chills and took 400 mg PO "
+        "Ibuprofen."
+    )
+
+    result = lx.extract(
+        text_or_documents=input_text,
+        prompt_description=prompt,
+        examples=examples,
+        model_id="gpt-4o-mini",
+        api_key=OPENAI_API_KEY,
+        use_schema_constraints=True,
+        fence_output=False,
+        language_model_params={
+            **OPENAI_MODEL_PARAMS,
+            "max_output_tokens": 512,
+        },
+    )
+
+    self.assertIsInstance(result, lx.data.AnnotatedDocument)
+    self.assertGreater(len(result.extractions), 0)
+    allowed_classes = {_CLASS_CONDITION, _CLASS_MEDICATION}
+    extraction_classes = {
+        extraction.extraction_class for extraction in result.extractions
+    }
+    self.assertSetEqual(extraction_classes, allowed_classes)
+    allowed_attribute_keys = {
+        _CLASS_CONDITION: {"status", "symptoms"},
+        _CLASS_MEDICATION: {"status"},
+    }
+    for extraction in result.extractions:
+      if isinstance(extraction.attributes, dict):
+        self.assertLessEqual(
+            set(extraction.attributes),
+            allowed_attribute_keys[extraction.extraction_class],
+        )
+    condition_extractions = [
+        extraction
+        for extraction in result.extractions
+        if extraction.extraction_class == _CLASS_CONDITION
+    ]
+    self.assertTrue(
+        any(
+            isinstance(extraction.attributes, dict)
+            and isinstance(extraction.attributes.get("symptoms"), list)
+            for extraction in condition_extractions
+        ),
+        f"Expected list-valued symptoms attribute. Got: {result.extractions}",
+    )
+    assert_valid_char_intervals(self, result)
 
   @skip_if_no_openai
   @live_api


### PR DESCRIPTION
Fixes #59

## Summary

- Add an OpenAI provider schema that maps examples to OpenAI Chat Completions
  `response_format={"type": "json_schema", ...}` payloads.
- Wire OpenAI schema constraints through the provider/factory path while keeping
  runtime `response_format` overrides explicit and warned.
- Enforce JSON-only structured outputs for OpenAI, with clear errors for YAML.
- Add unit and live coverage for OpenAI schema generation, schema application,
  runtime overrides, schema clearing, YAML rejection, and strict structured
  output behavior.

## Testing

- `tox -e format`
- `tox -e lint-src`
- `tox -e lint-tests`
- `pytest tests/ -ra -m 'not live_api'`
- `pytest tests/test_kwargs_passthrough.py tests/schema_test.py tests/factory_schema_test.py tests/provider_schema_test.py -q`
- `tox -e live-api`
