### PR TITLE
Prepare v1.4.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,8 +24,8 @@ keywords:
   - machine-learning
   - python
 license: Apache-2.0
-version: 1.3.0
-date-released: 2026-04-28
+version: 1.4.0
+date-released: 2026-05-15
 
 doi: "10.5281/zenodo.17015089"
 identifiers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langextract"
-version = "1.3.0"
+version = "1.4.0"
 description = "LangExtract: A library for extracting structured data from language models"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare the LangExtract v1.4.0 release metadata.

This PR only updates package/citation metadata:

- `pyproject.toml`: `1.3.0` -> `1.4.0`
- `CITATION.cff`: `1.3.0` -> `1.4.0`, release date `2026-05-15`

## Verification

- Post-merge `main` CI for #468 passed, including `live-api-tests`: https://github.com/google/langextract/actions/runs/25905320770
- `tox -e format`
- `python -m build /Users/goelak/Developer/langextract --outdir /tmp/langextract-release-build-v1.4.0.LRvCqE`
- `twine check /tmp/langextract-release-build-v1.4.0.LRvCqE/*`