### PR TITLE
Skip OpenAI Batch live test by default

### DIFF
--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -50,6 +50,9 @@ GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY") or os.environ.get(
     "LANGEXTRACT_API_KEY"
 )
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+RUN_OPENAI_BATCH_LIVE_TESTS = (
+    os.environ.get("LANGEXTRACT_RUN_OPENAI_BATCH_LIVE_TESTS") == "1"
+)
 
 VERTEX_PROJECT = os.environ.get("VERTEX_PROJECT") or os.environ.get(
     "GOOGLE_CLOUD_PROJECT"
@@ -78,6 +81,13 @@ skip_if_no_gemini = pytest.mark.skipif(
 skip_if_no_openai = pytest.mark.skipif(
     not OPENAI_API_KEY,
     reason="OpenAI API key not available (set OPENAI_API_KEY)",
+)
+skip_if_openai_batch_live_disabled = pytest.mark.skipif(
+    not RUN_OPENAI_BATCH_LIVE_TESTS,
+    reason=(
+        "OpenAI Batch API live test not enabled "
+        "(set LANGEXTRACT_RUN_OPENAI_BATCH_LIVE_TESTS=1)"
+    ),
 )
 skip_if_no_vertex = pytest.mark.skipif(
     not has_vertex_ai_credentials(),
@@ -848,6 +858,7 @@ class TestLiveAPIOpenAI(unittest.TestCase):
   """Tests using real OpenAI API."""
 
   @skip_if_no_openai
+  @skip_if_openai_batch_live_disabled
   @live_api
   @retry_on_transient_errors(max_retries=1)
   @mock.patch.object(


### PR DESCRIPTION
## Summary
- Make the OpenAI Batch API live test opt-in with `LANGEXTRACT_RUN_OPENAI_BATCH_LIVE_TESTS=1`
- Keep the rest of the OpenAI live API coverage enabled by default

## Testing
- `.venv/bin/python -m pytest tests/test_live_api.py::TestLiveAPIOpenAI::test_batch_extraction_uses_openai_batch_api -q -rs`
- `.venv/bin/python -m tox -e format`
- `.venv/bin/python -m tox -e lint-tests`