### PR TITLE
feat: Add CJK-friendly substring fallback alignment and unaligned extractions visualization

### DIFF
--- a/langextract/core/data.py
+++ b/langextract/core/data.py
@@ -45,6 +45,8 @@ class AlignmentStatus(enum.Enum):
   MATCH_GREATER = "match_greater"
   MATCH_LESSER = "match_lesser"
   MATCH_FUZZY = "match_fuzzy"
+  # Fallback alignment when token-based matching fails but raw substring match succeeds.
+  MATCH_SUBSTRING = "match_substring"
 
 
 @dataclasses.dataclass

--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -1022,6 +1022,63 @@ class WordAligner:
               extraction.extraction_text,
           )
 
+    # Substring fallback alignment (Chinese/CJK-friendly).
+    # If token-based exact+fuzzy alignment fails because the tokenizer groups
+    # multiple CJK words into a single token, try aligning via raw substring.
+    occupied: list[tuple[int, int]] = []
+    for e in aligned_extractions:
+      if (
+          e.char_interval
+          and e.char_interval.start_pos is not None
+          and e.char_interval.end_pos is not None
+      ):
+        occupied.append((e.char_interval.start_pos - char_offset, e.char_interval.end_pos - char_offset))
+
+    def _overlaps(a: tuple[int, int], b: tuple[int, int]) -> bool:
+      return a[0] < b[1] and b[0] < a[1]
+
+    def _find_non_overlapping_span(needle: str) -> tuple[int, int] | None:
+      if not needle:
+        return None
+      start = 0
+      while True:
+        idx = source_text.find(needle, start)
+        if idx == -1:
+          return None
+        span = (idx, idx + len(needle))
+        if not any(_overlaps(span, used) for used in occupied):
+          return span
+        start = idx + 1
+
+    substring_aligned = 0
+    still_unaligned = []
+    for extraction, _ in index_to_extraction_group.values():
+      if extraction in aligned_extractions:
+        continue
+      still_unaligned.append(extraction)
+
+    for extraction in still_unaligned:
+      span = _find_non_overlapping_span(extraction.extraction_text)
+      if span is None:
+        continue
+      start_pos, end_pos = span
+      extraction.char_interval = data.CharInterval(
+          start_pos=char_offset + start_pos,
+          end_pos=char_offset + end_pos,
+      )
+      extraction.token_interval = None
+      extraction.alignment_status = data.AlignmentStatus.MATCH_SUBSTRING
+      aligned_extractions.append(extraction)
+      occupied.append(span)
+      substring_aligned += 1
+
+    still_unaligned_post = []
+    for extraction, _ in index_to_extraction_group.values():
+      if extraction not in aligned_extractions:
+        still_unaligned_post.append(extraction)
+    # NOTE: Intentionally no logging here; alignment failures will surface as
+    # missing char_interval, which visualization can handle.
+
     for extraction, group_index in index_to_extraction_group.values():
       aligned_extraction_groups[group_index].append(extraction)
 


### PR DESCRIPTION
## Summary

This PR adds a substring-based fallback alignment mechanism for CJK text (Chinese, Japanese, Korean) and a visualization panel for unaligned extractions.

## Problem

When extracting from CJK text, the tokenizer often groups multiple characters into a single token. This causes token-based exact and fuzzy alignment to fail, leaving extractions without valid  values and making them invisible in the visualization output.

## Changes

### `langextract/core/data.py`
- Add `MATCH_SUBSTRING` enum value to `AlignmentStatus` for fallback substring matching

### `langextract/resolver.py`
- Implement substring fallback alignment in `WordAligner` after token-based alignment
- Non-overlapping span detection to prevent duplicate highlights
- Tracks occupied spans to avoid collisions with already-aligned extractions

### `langextract/visualization.py`
- Add `_build_unaligned_extractions_html()` to display extractions lacking valid `char_interval`
- New CSS styles for the unaligned extractions panel
- Integrates unaligned panel into the attributes sidebar

## Testing

Tested with Chinese text extraction where tokenizer groups characters into single tokens. Substring fallback successfully aligns previously-unaligned extractions and the visualization correctly shows any remaining unaligned items.