### PR TITLE
feat(openai): add Azure OpenAI client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,28 @@ result = lx.extract(
 )
 ```
 
+For Azure OpenAI, use the OpenAI provider with Azure client settings in
+`provider_kwargs`. Use your Azure deployment name as `model_id`.
+
+```python
+from langextract.factory import ModelConfig
+
+result = lx.extract(
+    text_or_documents=input_text,
+    prompt_description=prompt,
+    examples=examples,
+    config=ModelConfig(
+        model_id="my-azure-deployment",
+        provider="openai",
+        provider_kwargs={
+            "api_key": "azure-api-key",
+            "azure_endpoint": "https://example.openai.azure.com",
+            "api_version": "2024-10-21",
+        },
+    ),
+)
+```
+
 ## Using Local LLMs with Ollama
 LangExtract supports local inference using Ollama, allowing you to run models without API keys:
 

--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -109,6 +109,11 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
       api_key: str | None = None,
       base_url: str | None = None,
       organization: str | None = None,
+      azure_endpoint: str | None = None,
+      api_version: str | None = None,
+      azure_ad_token: str | None = None,
+      azure_ad_token_provider: Any | None = None,
+      azure_deployment: str | None = None,
       openai_schema: schemas.openai.OpenAISchema | None = None,
       format_type: data.FormatType = data.FormatType.JSON,
       temperature: float | None = None,
@@ -122,6 +127,11 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
       api_key: API key for OpenAI service.
       base_url: Base URL for OpenAI service.
       organization: Optional OpenAI organization ID.
+      azure_endpoint: Azure OpenAI endpoint URL.
+      api_version: Azure OpenAI API version.
+      azure_ad_token: Azure Active Directory token for Azure OpenAI.
+      azure_ad_token_provider: Callable provider for Azure AD tokens.
+      azure_deployment: Azure OpenAI deployment name.
       openai_schema: Optional schema for structured output.
       format_type: Output format (JSON or YAML).
       temperature: Sampling temperature.
@@ -148,6 +158,11 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
     self.api_key = api_key
     self.base_url = base_url
     self.organization = organization
+    self.azure_endpoint = azure_endpoint
+    self.api_version = api_version
+    self.azure_ad_token = azure_ad_token
+    self.azure_ad_token_provider = azure_ad_token_provider
+    self.azure_deployment = azure_deployment
     self.openai_schema = None
     self.format_type = format_type
     self.temperature = temperature
@@ -164,11 +179,28 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
 
     # Keep SDK initialization after schema validation so LangExtract reports
     # configuration errors before any client-side transport checks.
-    self._client = openai.OpenAI(
-        api_key=self.api_key,
-        base_url=self.base_url,
-        organization=self.organization,
-    )
+    if (
+        self.azure_endpoint
+        or self.api_version
+        or self.azure_ad_token
+        or self.azure_ad_token_provider
+        or self.azure_deployment
+    ):
+      self._client = openai.AzureOpenAI(
+          api_key=self.api_key,
+          azure_endpoint=self.azure_endpoint,
+          api_version=self.api_version,
+          azure_ad_token=self.azure_ad_token,
+          azure_ad_token_provider=self.azure_ad_token_provider,
+          azure_deployment=self.azure_deployment,
+          organization=self.organization,
+      )
+    else:
+      self._client = openai.OpenAI(
+          api_key=self.api_key,
+          base_url=self.base_url,
+          organization=self.organization,
+      )
 
   def _validate_schema_config(self) -> None:
     """Rejects schema settings the OpenAI API cannot honor."""

--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -46,6 +46,13 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
   api_key: str | None = None
   base_url: str | None = None
   organization: str | None = None
+  azure_endpoint: str | None = None
+  api_version: str | None = None
+  azure_ad_token: str | None = None
+  azure_ad_token_provider: Any | None = dataclasses.field(
+      default=None, repr=False, compare=False
+  )
+  azure_deployment: str | None = None
   openai_schema: schemas.openai.OpenAISchema | None = dataclasses.field(
       default=None, repr=False, compare=False
   )
@@ -171,7 +178,19 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
     self._batch_cfg = openai_batch.BatchConfig.from_dict(batch_cfg_dict)
     self._extra_kwargs = kwargs or {}
 
-    if not self.api_key:
+    use_azure_client = any((
+        self.azure_endpoint,
+        self.api_version,
+        self.azure_ad_token,
+        self.azure_ad_token_provider,
+        self.azure_deployment,
+    ))
+
+    if not (
+        self.api_key
+        or (use_azure_client and self.azure_ad_token)
+        or (use_azure_client and self.azure_ad_token_provider)
+    ):
       raise exceptions.InferenceConfigError('API key not provided.')
 
     if openai_schema is not None:
@@ -179,13 +198,7 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
 
     # Keep SDK initialization after schema validation so LangExtract reports
     # configuration errors before any client-side transport checks.
-    if (
-        self.azure_endpoint
-        or self.api_version
-        or self.azure_ad_token
-        or self.azure_ad_token_provider
-        or self.azure_deployment
-    ):
+    if use_azure_client:
       self._client = openai.AzureOpenAI(
           api_key=self.api_key,
           azure_endpoint=self.azure_endpoint,

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -908,6 +908,59 @@ class TestOpenAILanguageModel(absltest.TestCase):
     self.assertNotIn("api_version", call_args.kwargs)
     self.assertNotIn("azure_deployment", call_args.kwargs)
 
+  @mock.patch("openai.AzureOpenAI")
+  @mock.patch("openai.OpenAI")
+  def test_openai_azure_client_accepts_ad_token_without_api_key(
+      self, mock_openai_class, mock_azure_openai_class
+  ):
+    """Azure OpenAI can authenticate with an AAD token instead of an API key."""
+    mock_client = mock.Mock()
+    mock_azure_openai_class.return_value = mock_client
+
+    openai.OpenAILanguageModel(
+        azure_endpoint="https://example.openai.azure.com",
+        api_version="2024-10-21",
+        azure_ad_token="test-token",
+    )
+
+    mock_openai_class.assert_not_called()
+    mock_azure_openai_class.assert_called_once_with(
+        api_key=None,
+        azure_endpoint="https://example.openai.azure.com",
+        api_version="2024-10-21",
+        azure_ad_token="test-token",
+        azure_ad_token_provider=None,
+        azure_deployment=None,
+        organization=None,
+    )
+
+  @mock.patch("openai.AzureOpenAI")
+  @mock.patch("openai.OpenAI")
+  def test_openai_azure_client_accepts_ad_token_provider_without_api_key(
+      self, mock_openai_class, mock_azure_openai_class
+  ):
+    """Azure OpenAI can authenticate with an AAD token provider."""
+    mock_client = mock.Mock()
+    mock_azure_openai_class.return_value = mock_client
+    token_provider = mock.Mock(return_value="test-token")
+
+    openai.OpenAILanguageModel(
+        azure_endpoint="https://example.openai.azure.com",
+        api_version="2024-10-21",
+        azure_ad_token_provider=token_provider,
+    )
+
+    mock_openai_class.assert_not_called()
+    mock_azure_openai_class.assert_called_once_with(
+        api_key=None,
+        azure_endpoint="https://example.openai.azure.com",
+        api_version="2024-10-21",
+        azure_ad_token=None,
+        azure_ad_token_provider=token_provider,
+        azure_deployment=None,
+        organization=None,
+    )
+
   @mock.patch("openai.OpenAI")
   def test_openai_runtime_kwargs_override(self, mock_openai_class):
     """Test that runtime kwargs override stored kwargs."""

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -869,6 +869,45 @@ class TestOpenAILanguageModel(absltest.TestCase):
     self.assertEqual(call_args.kwargs["presence_penalty"], 0.7)
     self.assertEqual(call_args.kwargs["seed"], 42)
 
+  @mock.patch("openai.AzureOpenAI")
+  @mock.patch("openai.OpenAI")
+  def test_openai_azure_client_used(
+      self, mock_openai_class, mock_azure_openai_class
+  ):
+    """Azure OpenAI kwargs initialize an Azure client, not request kwargs."""
+    mock_client = mock.Mock()
+    mock_azure_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [
+        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+    ]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    model = openai.OpenAILanguageModel(
+        api_key="test-key",
+        azure_endpoint="https://example.openai.azure.com",
+        api_version="2024-10-21",
+        azure_deployment="deployment-name",
+    )
+
+    list(model.infer(["test prompt"]))
+
+    mock_openai_class.assert_not_called()
+    mock_azure_openai_class.assert_called_once_with(
+        api_key="test-key",
+        azure_endpoint="https://example.openai.azure.com",
+        api_version="2024-10-21",
+        azure_ad_token=None,
+        azure_ad_token_provider=None,
+        azure_deployment="deployment-name",
+        organization=None,
+    )
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertNotIn("azure_endpoint", call_args.kwargs)
+    self.assertNotIn("api_version", call_args.kwargs)
+    self.assertNotIn("azure_deployment", call_args.kwargs)
+
   @mock.patch("openai.OpenAI")
   def test_openai_runtime_kwargs_override(self, mock_openai_class):
     """Test that runtime kwargs override stored kwargs."""


### PR DESCRIPTION
# Description

Fixes #49. Related to #99.

Feature

Adds native Azure OpenAI client initialization to the existing OpenAI provider.
When callers provide Azure OpenAI client kwargs such as `azure_endpoint`,
`api_version`, `azure_ad_token`, `azure_ad_token_provider`, or
`azure_deployment`, `OpenAILanguageModel` now initializes `openai.AzureOpenAI`
instead of the standard `openai.OpenAI` client. These Azure-specific kwargs are
kept as client configuration and are not forwarded as chat completions request
parameters.

This preserves the existing OpenAI-compatible `base_url` path when Azure kwargs
are not provided. It also allows Azure OpenAI authentication with either an API
key, an Azure AD token, or an Azure AD token provider.

# How Has This Been Tested?

```
$ uv run --extra openai --extra test pytest tests/inference_test.py::TestOpenAILanguageModel -q
$ uv run --extra dev pyink langextract/providers/openai.py tests/inference_test.py --check --diff --config pyproject.toml
$ uv run --extra dev pylint --rcfile=.pylintrc langextract/providers/openai.py
$ uv run --extra dev pylint --rcfile=tests/.pylintrc tests/inference_test.py
```

Additional local verification: I installed `langextract` from this PR branch in
a downstream sample project and ran an Azure OpenAI extraction smoke check,
verifying a successful Azure OpenAI response with exact text alignment.

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [ ] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.
