### PR TITLE
Add user-provided output_schema support for Gemini and OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ result = lx.extract(
 )
 ```
 
+For advanced constraints beyond examples, such as enum values on extraction
+attributes, Gemini and OpenAI support `output_schema` with or without
+few-shot examples. See
+[Custom output schemas](docs/examples/output_schema.md).
+
 > **Model Selection**: `gemini-3.5-flash` is the recommended default, offering strong extraction quality for LangExtract's schema-constrained workflows. For high-volume or cost-sensitive workloads, consider the current stable Flash-Lite model, `gemini-3.1-flash-lite`; for highly complex tasks requiring deeper reasoning, evaluate a current Gemini Pro model from the official model documentation. For large-scale or production use, a paid Gemini tier is suggested to increase throughput and avoid rate limits. See the [rate-limit documentation](https://ai.google.dev/gemini-api/docs/rate-limits#usage-tiers) for details.
 >
 > **Model Lifecycle**: Note that Gemini models have a lifecycle with defined retirement dates. Users should consult the [official model version documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions) to stay informed about the latest stable and legacy versions.
@@ -158,7 +163,9 @@ This approach can extract hundreds of entities from full novels while maintainin
 
 ### Vertex AI Batch Processing
 
-Save costs on large-scale tasks by enabling Vertex AI Batch API: `language_model_params={"vertexai": True, "batch": {"enabled": True}}`.
+Save costs on large-scale tasks by enabling Vertex AI Batch API with
+`language_model_params` that include `vertexai=True`, `project`, `location`,
+and a `batch` config.
 
 See an example of the Vertex AI Batch API usage in [this example](docs/examples/batch_api_example.md).
 
@@ -320,7 +327,11 @@ result = lx.extract(
 )
 ```
 
-The OpenAI provider uses JSON mode and auto-determines fence and schema behavior — leave `fence_output` and `use_schema_constraints` unset.
+The OpenAI provider uses structured outputs or JSON mode and auto-determines
+fence behavior — leave `fence_output` and `use_schema_constraints` unset.
+`output_schema` is also supported for OpenAI models that support structured
+outputs; provide a LangExtract output-envelope JSON schema, preferably with the
+`lx.schema` helpers.
 
 For large, non-latency-sensitive OpenAI workloads, enable the OpenAI Batch API
 with `language_model_params`. Batch mode is opt-in and falls back to realtime
@@ -374,7 +385,9 @@ result = lx.extract(
 )
 ```
 
-The Ollama provider exposes `FormatModeSchema` for JSON mode. Leave `fence_output` and `use_schema_constraints` unset so the factory auto-configures from the provider's schema.
+The Ollama provider exposes `FormatModeSchema` for JSON mode. Leave `fence_output`
+and `use_schema_constraints` unset so the factory auto-configures from the provider's
+schema. Ollama does not currently support `output_schema`.
 
 **Quick setup:** Install Ollama from [ollama.com](https://ollama.com/), run `ollama pull gemma2:2b`, then `ollama serve`.
 

--- a/docs/examples/batch_api_example.md
+++ b/docs/examples/batch_api_example.md
@@ -77,6 +77,7 @@ results = lx.extract(
         "batch": batch_config
     }
 )
+```
 
 ## GCS File Structure
 
@@ -101,6 +102,8 @@ LangExtract's batch processing is designed to minimize costs:
     -   **Lifecycle Management**: Use `retention_days` (e.g., 30) to automatically clean up old data and manage storage usage.
 
 ## Analyze Results
+
+```python
 print(f"Extracted {len(results.extractions)} entities.")
 print("First 5 extractions:")
 for extraction in results.extractions[:5]:

--- a/docs/examples/output_schema.md
+++ b/docs/examples/output_schema.md
@@ -1,0 +1,221 @@
+# Custom Output Schema Example
+
+LangExtract usually derives provider schema constraints from examples. For
+advanced cases, pass `output_schema` to constrain the raw model output more
+directly. This example restricts a `status` attribute to the enum values
+`present` and `absent`.
+
+Examples are optional when `output_schema` is provided. When examples are
+included, they still guide the prompt; `output_schema` replaces only the
+provider schema constraint. The schema must describe LangExtract's JSON output
+envelope with a top-level `extractions` array.
+
+Gemini and OpenAI support `output_schema`. Ollama does not currently support
+user-provided output schemas.
+
+The helper emits `additionalProperties: False` so schemas work with OpenAI
+strict structured outputs. Gemini receives user-provided schemas through its
+native JSON Schema field, so JSON Schema keywords such as
+`additionalProperties` are preserved.
+
+## Full Pipeline Example
+
+```python
+import langextract as lx
+
+# Text with one affirmed and one negated condition.
+input_text = "Patient has hypertension. Patient denies diabetes."
+
+# Define extraction prompt.
+prompt_description = """
+Extract medical conditions and classify each condition status as present or
+absent. Use exact text from the input for extraction_text.
+"""
+
+# Define example data. The status values mirror the enum in output_schema.
+examples = [
+    lx.data.ExampleData(
+        text="Patient has asthma. Patient denies fever.",
+        extractions=[
+            lx.data.Extraction(
+                extraction_class="condition",
+                extraction_text="asthma",
+                attributes={"status": "present"},
+            ),
+            lx.data.Extraction(
+                extraction_class="condition",
+                extraction_text="fever",
+                attributes={"status": "absent"},
+            ),
+        ],
+    )
+]
+
+# Build a LangExtract output envelope with an enum-constrained attribute.
+output_schema = lx.schema.extractions_schema(
+    lx.schema.extraction_item_schema(
+        "condition",
+        attributes={
+            "status": {
+                "type": "string",
+                "enum": ["present", "absent"],
+            }
+        },
+    )
+)
+
+result = lx.extract(
+    text_or_documents=input_text,
+    prompt_description=prompt_description,
+    examples=examples,
+    model_id="gemini-3.5-flash",
+    output_schema=output_schema,
+    temperature=0.0,
+)
+
+print(f"Input: {input_text}\n")
+print("Extracted conditions:")
+for extraction in result.extractions:
+    status = extraction.attributes["status"]
+    print(f"• {extraction.extraction_text}: {status}")
+```
+
+This will produce output similar to:
+
+```text
+Input: Patient has hypertension. Patient denies diabetes.
+
+Extracted conditions:
+• hypertension: present
+• diabetes: absent
+```
+
+## Multiple Extraction Classes
+
+For heterogeneous extraction classes, pass multiple item schemas. The helper
+wraps them in `anyOf` under `extractions.items`:
+
+```python
+output_schema = lx.schema.extractions_schema(
+    lx.schema.extraction_item_schema("condition"),
+    lx.schema.extraction_item_schema("medication"),
+)
+```
+
+## Raw Schema Equivalent
+
+For full control, pass a raw JSON schema dictionary. When targeting OpenAI
+strict mode, every object schema must declare `required` fields and
+`additionalProperties: False`.
+
+Attribute objects use the `<extraction_class>_attributes` property name.
+LangExtract's resolver expects that suffix when parsing raw model output.
+Each extraction item should use extraction-class text keys such as
+`condition`; generic fields such as `extraction_class`, `extraction_text`,
+and `attributes` are not resolver output keys. Extraction class names ending
+in `_attributes` are reserved for attribute objects.
+
+The full pipeline example above produces this equivalent envelope:
+
+```python
+output_schema = {
+    "type": "object",
+    "properties": {
+        "extractions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "condition": {"type": "string"},
+                    "condition_attributes": {
+                        "type": "object",
+                        "properties": {
+                            "status": {
+                                "type": "string",
+                                "enum": ["present", "absent"],
+                            }
+                        },
+                        "required": ["status"],
+                        "additionalProperties": False,
+                    },
+                },
+                "required": ["condition", "condition_attributes"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["extractions"],
+    "additionalProperties": False,
+}
+```
+
+Use raw schemas when you need JSON Schema constructs that the helpers do not
+cover directly, such as custom `anyOf` variants. OpenAI strict structured
+outputs support `anyOf`; use `strict=False` only in lower-level provider code
+if you need to experiment with schema features outside OpenAI's strict subset.
+
+## Optional Attributes
+
+The helper marks every supplied attribute as required by default so the schema
+is compatible with OpenAI strict structured outputs. To allow an attribute to
+be absent in practice, make the value nullable while keeping the key required:
+
+```python
+output_schema = lx.schema.extractions_schema(
+    lx.schema.extraction_item_schema(
+        "condition",
+        attributes={
+            "status": {
+                "anyOf": [
+                    {"type": "string", "enum": ["present", "absent"]},
+                    {"type": "null"},
+                ]
+            }
+        },
+    )
+)
+```
+
+If you need a schema where an attribute key may be omitted entirely, use a raw
+schema for that provider-specific shape.
+
+## Errors and Pitfalls
+
+- Invalid envelopes raise `InferenceConfigError` before provider construction.
+- `output_schema` can be passed with either `model_id`/`config` or a
+  preconfigured `model` when the provider supports user schemas.
+- Examples are optional with `output_schema`. When supplied, keep example
+  classes and attribute names aligned with the schema to avoid confusing the
+  model.
+- `output_schema` requires raw JSON provider output. Leave `format_type` unset
+  or set it to `lx.data.FormatType.JSON`, and do not force fences.
+- Keep the resolver's default `"_attributes"` suffix. Custom
+  `attribute_suffix`/`extraction_attributes_suffix` settings are incompatible
+  with the raw schema envelope.
+- Do not combine `output_schema` with provider schema kwargs such as
+  `response_format`, `response_schema`, or `response_json_schema`.
+- When targeting Gemini 2.0 models, add Gemini's `propertyOrdering` keyword
+  to object schemas that need an explicit property order. The LangExtract
+  helpers stay provider-neutral and do not add that Gemini-specific extension.
+- Raw schemas must describe `extractions.items` inline, including each
+  extraction text key and `<extraction_class>_attributes` object. LangExtract
+  does not resolve `$ref` for those resolver keys before provider construction.
+- Use `anyOf`, not `oneOf`, for item unions. Gemini treats `oneOf` like
+  `anyOf`, and OpenAI strict structured outputs reject `oneOf`.
+- `lx.schema.extraction_item_schema(..., additional_properties=False)` applies
+  that setting to both the outer extraction item object and its nested
+  `<extraction_class>_attributes` object.
+- OpenAI uses strict structured outputs by default with LangExtract's default
+  schema name. The lower-level `OpenAISchema.from_schema_dict(...,
+  schema_name=..., strict=False)` constructor is an escape hatch for callers
+  configuring provider models directly.
+- LangExtract validates only the output envelope locally; the provider API
+  validates the JSON schema itself. OpenAI strict mode requires every object
+  to list all properties in `required` and set
+  `additionalProperties: false` — the `lx.schema` helpers emit compliant
+  schemas, and the OpenAI API reports the exact path of any violation in
+  hand-written schemas. Schema size/depth limits, enum limits, and keyword
+  support also vary by provider, model, and endpoint.
+- Avoid `stop`/`stop_sequences` with `output_schema`: stop sequences can
+  truncate schema-constrained JSON mid-document while the response still
+  reports a normal finish reason.

--- a/langextract/core/__init__.py
+++ b/langextract/core/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "base_model",
     "types",
     "exceptions",
+    "output_schema",
     "schema",
     "data",
     "tokenizer",

--- a/langextract/core/base_model.py
+++ b/langextract/core/base_model.py
@@ -22,6 +22,7 @@ from typing import Any, Mapping
 
 import yaml
 
+from langextract.core import exceptions
 from langextract.core import schema
 from langextract.core import types
 
@@ -64,6 +65,54 @@ class BaseLanguageModel(abc.ABC):
     """
     self._schema = schema_instance
 
+  def apply_output_schema(self, output_schema: types.JsonSchema) -> None:
+    """Apply a user-provided LangExtract output schema to this model.
+
+    Args:
+      output_schema: JSON schema for LangExtract's raw output envelope.
+
+    Raises:
+      InferenceConfigError: If this provider cannot consume user schemas, or
+        if the model already has conflicting schema configuration.
+    """
+    schema_class = self.get_schema_class()
+    if schema_class is None:
+      raise exceptions.unsupported_output_schema_error(type(self).__name__)
+    try:
+      schema_instance = schema_class.from_schema_dict(output_schema)
+    except NotImplementedError as e:
+      raise exceptions.unsupported_output_schema_error(
+          type(self).__name__
+      ) from e
+    schema.mark_from_output_schema(schema_instance)
+
+    current_schema = self.schema
+    if current_schema is not None:
+      requested_schema_dict = getattr(schema_instance, 'schema_dict', None)
+      if (
+          getattr(current_schema, 'from_output_schema', False)
+          and requested_schema_dict is not None
+          and getattr(current_schema, 'schema_dict', None)
+          == requested_schema_dict
+      ):
+        return
+      raise exceptions.InferenceConfigError(
+          f'output_schema cannot be applied to {type(self).__name__} because '
+          'the model already has a schema configured. Create the model '
+          'without schema settings, or pass output_schema when the model is '
+          'created.'
+      )
+
+    provider_kwargs = getattr(self, '_extra_kwargs', None) or {}
+    conflicts = sorted(
+        key
+        for key in schema_instance.output_schema_reserved_provider_kwargs()
+        if provider_kwargs.get(key) is not None
+    )
+    if conflicts:
+      raise exceptions.output_schema_provider_kwargs_error(conflicts)
+    self.apply_schema(schema_instance)
+
   @property
   def schema(self) -> schema.BaseSchema | None:
     """The current schema instance if one is configured.
@@ -71,7 +120,7 @@ class BaseLanguageModel(abc.ABC):
     Returns:
       The schema instance or None if no schema is applied.
     """
-    return self._schema
+    return getattr(self, '_schema', None)
 
   def set_fence_output(self, fence_output: bool | None) -> None:
     """Set explicit fence output preference.

--- a/langextract/core/exceptions.py
+++ b/langextract/core/exceptions.py
@@ -32,6 +32,10 @@ __all__ = [
     "SchemaError",
     "FormatError",
     "FormatParseError",
+    "unsupported_output_schema_error",
+    "output_schema_fence_error",
+    "output_schema_format_error",
+    "output_schema_provider_kwargs_error",
 ]
 
 
@@ -54,6 +58,42 @@ class InferenceConfigError(InferenceError):
   This includes missing API keys, invalid model IDs, or other
   configuration-related issues that prevent model instantiation.
   """
+
+
+def unsupported_output_schema_error(target: str) -> InferenceConfigError:
+  """Builds a consistent error for providers without user-schema support."""
+  return InferenceConfigError(
+      f"{target} does not support output_schema. "
+      "Built-in support is available for Gemini and OpenAI."
+  )
+
+
+def output_schema_fence_error() -> InferenceConfigError:
+  """Builds a consistent error for incompatible output schema fences."""
+  return InferenceConfigError(
+      "output_schema uses provider structured output/raw JSON and cannot be "
+      "combined with fence_output=True. Leave fence_output unset or set "
+      "fence_output=False."
+  )
+
+
+def output_schema_format_error() -> InferenceConfigError:
+  """Builds a consistent error for non-JSON explicit output schemas."""
+  return InferenceConfigError(
+      "output_schema uses provider structured output/raw JSON and requires "
+      "format_type=JSON. Leave format_type unset or set format_type=JSON."
+  )
+
+
+def output_schema_provider_kwargs_error(
+    conflicting_keys: list[str],
+) -> InferenceConfigError:
+  """Builds a consistent error for duplicate provider schema controls."""
+  return InferenceConfigError(
+      "output_schema cannot be combined with provider kwargs that configure "
+      f"provider schema output: {', '.join(conflicting_keys)}. Remove those "
+      "provider kwargs and let output_schema configure structured output."
+  )
 
 
 class InferenceRuntimeError(InferenceError):

--- a/langextract/core/output_schema.py
+++ b/langextract/core/output_schema.py
@@ -1,0 +1,322 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for user-provided LangExtract output schemas."""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import copy
+from typing import Any
+
+from langextract.core import data
+from langextract.core import exceptions
+from langextract.core import types as core_types
+
+__all__ = [
+    "extraction_item_schema",
+    "extractions_schema",
+    "validate_output_schema",
+]
+
+_RESERVED_EXTRACTION_ITEM_KEYS = frozenset({
+    "attributes",
+    "extraction_class",
+    "extraction_text",
+})
+
+
+def is_json_format_type(format_type: Any) -> bool:
+  """Returns True when format_type is JSON or unset."""
+  if format_type is None:
+    return True
+  if isinstance(format_type, data.FormatType):
+    return format_type is data.FormatType.JSON
+  if isinstance(format_type, str):
+    return format_type.lower() == data.FormatType.JSON.value
+  return False
+
+
+def validate_output_schema_format_handler(format_handler: Any) -> None:
+  """Rejects resolver output settings that conflict with output_schema.
+
+  output_schema constrains the model to LangExtract's raw JSON envelope, so
+  the resolver must parse unfenced JSON with the default "extractions"
+  wrapper and "_attributes" suffix.
+
+  Args:
+    format_handler: Normalized FormatHandler built from resolver params.
+
+  Raises:
+    InferenceConfigError: If the handler cannot parse the schema envelope.
+  """
+  if format_handler.use_fences:
+    raise exceptions.output_schema_fence_error()
+  if not is_json_format_type(format_handler.format_type):
+    raise exceptions.output_schema_format_error()
+  if (
+      not format_handler.use_wrapper
+      or format_handler.wrapper_key != data.EXTRACTIONS_KEY
+      or getattr(format_handler, "attribute_suffix", data.ATTRIBUTE_SUFFIX)
+      != data.ATTRIBUTE_SUFFIX
+  ):
+    raise exceptions.InferenceConfigError(
+        "output_schema requires LangExtract's default JSON envelope: keep "
+        f"use_wrapper=True, wrapper_key={data.EXTRACTIONS_KEY!r}, and "
+        f"attribute_suffix={data.ATTRIBUTE_SUFFIX!r}."
+    )
+
+
+def _is_string_sequence(value: Any) -> bool:
+  return (
+      isinstance(value, Sequence)
+      and not isinstance(value, str)
+      and all(isinstance(item, str) for item in value)
+  )
+
+
+def _item_schema_branches(items_value: Any) -> list[Mapping[str, Any]]:
+  """Returns object-schema branches from a direct object or anyOf union."""
+  if not isinstance(items_value, Mapping):
+    return []
+  if items_value.get("type") == "object":
+    return [items_value]
+  branches = items_value.get("anyOf")
+  if (
+      isinstance(branches, Sequence)
+      and not isinstance(branches, str)
+      and branches
+      and all(
+          isinstance(branch, Mapping) and branch.get("type") == "object"
+          for branch in branches
+      )
+  ):
+    return list(branches)
+  return []
+
+
+def validate_output_schema(
+    output_schema: core_types.JsonSchema,
+) -> dict[str, Any]:
+  """Validates the LangExtract output envelope and returns an isolated copy.
+
+  LangExtract's resolver parses a top-level JSON object with an "extractions"
+  array whose items are objects keyed by extraction class, optionally with
+  "<class>_attributes" objects. This check only enforces that envelope; the
+  provider API validates the JSON schema itself.
+
+  Args:
+    output_schema: User-provided JSON schema for the raw model output.
+
+  Returns:
+    A deep copy of output_schema.
+
+  Raises:
+    InferenceConfigError: If output_schema cannot describe LangExtract's
+      output envelope.
+  """
+  if not isinstance(output_schema, Mapping):
+    raise exceptions.InferenceConfigError(
+        "output_schema must be a mapping describing a JSON object."
+    )
+
+  schema_dict = copy.deepcopy(dict(output_schema))
+  if not schema_dict:
+    raise exceptions.InferenceConfigError("output_schema must not be empty.")
+  if schema_dict.get("type") != "object":
+    raise exceptions.InferenceConfigError(
+        "output_schema top-level type must be 'object'."
+    )
+
+  required = schema_dict.get("required")
+  if not _is_string_sequence(required) or data.EXTRACTIONS_KEY not in required:
+    raise exceptions.InferenceConfigError(
+        "output_schema top-level required must include 'extractions'."
+    )
+
+  properties = schema_dict.get("properties")
+  if not isinstance(properties, Mapping):
+    raise exceptions.InferenceConfigError(
+        "output_schema top-level properties must be a mapping."
+    )
+
+  extractions_property = properties.get(data.EXTRACTIONS_KEY)
+  if (
+      not isinstance(extractions_property, Mapping)
+      or extractions_property.get("type") != "array"
+  ):
+    raise exceptions.InferenceConfigError(
+        "output_schema must declare 'extractions' as an array property."
+    )
+
+  item_branches = _item_schema_branches(extractions_property.get("items"))
+  if not item_branches:
+    raise exceptions.InferenceConfigError(
+        "output_schema must declare 'extractions.items' as an inline object "
+        "schema or an inline anyOf of object schemas."
+    )
+
+  for branch in item_branches:
+    branch_properties = branch.get("properties")
+    if not isinstance(branch_properties, Mapping) or not branch_properties:
+      raise exceptions.InferenceConfigError(
+          "output_schema extraction items must declare extraction-class "
+          "properties, such as 'condition'."
+      )
+    reserved_keys = sorted(
+        set(branch_properties).intersection(_RESERVED_EXTRACTION_ITEM_KEYS)
+    )
+    if reserved_keys:
+      raise exceptions.InferenceConfigError(
+          "output_schema extraction items use extraction-class keys such as "
+          "'condition', not LangExtract's internal field names: "
+          + ", ".join(reserved_keys)
+      )
+
+  return schema_dict
+
+
+def _copy_schema_mapping(
+    schema_mapping: core_types.JsonSchema,
+    argument_name: str,
+) -> dict[str, Any]:
+  if not isinstance(schema_mapping, Mapping):
+    raise exceptions.InferenceConfigError(
+        f"{argument_name} must be a mapping describing a JSON schema."
+    )
+  return copy.deepcopy(dict(schema_mapping))
+
+
+def extractions_schema(
+    item_schema: core_types.JsonSchema,
+    *additional_item_schemas: core_types.JsonSchema,
+    additional_properties: bool = False,
+) -> dict[str, Any]:
+  """Wraps extraction item schemas in LangExtract's output envelope.
+
+  Args:
+    item_schema: JSON schema for each entry in the "extractions" array. When
+      more than one item schema is provided, the helper wraps them in `anyOf`.
+      Hand-written item schemas are copied as-is and should include any
+      provider-required fields, such as `required` and `additionalProperties`
+      for OpenAI strict mode.
+    *additional_item_schemas: Additional item schemas for heterogeneous
+      extraction classes.
+    additional_properties: Value for the envelope's additionalProperties
+      setting. Defaults to False so helper output works with OpenAI strict
+      structured outputs and Gemini's JSON Schema path.
+
+  Returns:
+    A JSON schema dictionary suitable for `extract(output_schema=...)`.
+  """
+  copied_item_schemas = [
+      _copy_schema_mapping(item_schema, "item_schema"),
+      *[
+          _copy_schema_mapping(
+              schema_mapping, f"additional_item_schemas[{index}]"
+          )
+          for index, schema_mapping in enumerate(additional_item_schemas)
+      ],
+  ]
+  if len(copied_item_schemas) == 1:
+    items_schema = copied_item_schemas[0]
+  else:
+    items_schema = {"anyOf": copied_item_schemas}
+
+  return {
+      "type": "object",
+      "properties": {
+          data.EXTRACTIONS_KEY: {
+              "type": "array",
+              "items": items_schema,
+          }
+      },
+      "required": [data.EXTRACTIONS_KEY],
+      "additionalProperties": additional_properties,
+  }
+
+
+def extraction_item_schema(
+    extraction_class: str,
+    *,
+    attributes: Mapping[str, core_types.JsonSchema] | None = None,
+    additional_properties: bool = False,
+) -> dict[str, Any]:
+  """Builds a schema for one LangExtract extraction object.
+
+  Pair this with `extractions_schema()` to produce the full output envelope.
+
+  Args:
+    extraction_class: Extraction class name, such as "emotion".
+    attributes: Optional mapping from attribute name to JSON schema.
+    additional_properties: Value for each generated object's
+      additionalProperties setting, including both the outer extraction item
+      object and the nested "<extraction_class>_attributes" object.
+
+  Returns:
+    A JSON schema dictionary for an item in the "extractions" array.
+
+  Raises:
+    InferenceConfigError: If arguments cannot describe a valid extraction
+      object schema.
+  """
+  if not isinstance(extraction_class, str) or not extraction_class:
+    raise exceptions.InferenceConfigError(
+        "extraction_class must be a non-empty string."
+    )
+  if extraction_class.endswith(data.ATTRIBUTE_SUFFIX):
+    raise exceptions.InferenceConfigError(
+        "extraction_class must not end with reserved suffix "
+        f"{data.ATTRIBUTE_SUFFIX!r}."
+    )
+  if extraction_class in _RESERVED_EXTRACTION_ITEM_KEYS:
+    raise exceptions.InferenceConfigError(
+        "extraction_class must not use reserved generic key "
+        f"{extraction_class!r}."
+    )
+  if attributes is not None and not isinstance(attributes, Mapping):
+    raise exceptions.InferenceConfigError(
+        "attributes must be a mapping from names to JSON schemas."
+    )
+  if attributes is not None and not attributes:
+    attributes = None
+
+  properties: dict[str, Any] = {extraction_class: {"type": "string"}}
+  required = [extraction_class]
+
+  if attributes is not None:
+    attr_properties = {}
+    for attr_name, attr_schema in attributes.items():
+      if not isinstance(attr_name, str) or not attr_name:
+        raise exceptions.InferenceConfigError(
+            "attribute names must be non-empty strings."
+        )
+      attr_properties[attr_name] = _copy_schema_mapping(
+          attr_schema, f"attributes[{attr_name!r}]"
+      )
+
+    attributes_field = f"{extraction_class}{data.ATTRIBUTE_SUFFIX}"
+    properties[attributes_field] = {
+        "type": "object",
+        "properties": attr_properties,
+        "required": list(attr_properties),
+        "additionalProperties": additional_properties,
+    }
+    required.append(attributes_field)
+
+  return {
+      "type": "object",
+      "properties": properties,
+      "required": required,
+      "additionalProperties": additional_properties,
+  }

--- a/langextract/core/schema.py
+++ b/langextract/core/schema.py
@@ -28,6 +28,7 @@ __all__ = [
     "Constraint",
     "BaseSchema",
     "FormatModeSchema",
+    "mark_from_output_schema",
 ]
 
 # Backward compat re-exports
@@ -47,6 +48,16 @@ class BaseSchema(abc.ABC):
   ) -> BaseSchema:
     """Factory method to build a schema instance from example data."""
 
+  @classmethod
+  def from_schema_dict(cls, output_schema: types.JsonSchema) -> BaseSchema:
+    """Build a schema instance from a LangExtract output envelope schema.
+
+    Providers override this to opt in to user-provided schemas.
+    """
+    raise NotImplementedError(
+        f"{cls.__name__} does not support user-provided output_schema."
+    )
+
   @abc.abstractmethod
   def to_provider_config(self) -> dict[str, Any]:
     """Convert schema to provider-specific configuration.
@@ -55,6 +66,10 @@ class BaseSchema(abc.ABC):
       Dictionary of provider kwargs (e.g., response_schema for Gemini).
       Should be a pure data mapping with no side effects.
     """
+
+  def output_schema_reserved_provider_kwargs(self) -> frozenset[str]:
+    """Provider kwargs that would conflict with explicit output_schema."""
+    return frozenset(self.to_provider_config())
 
   @property
   @abc.abstractmethod
@@ -88,6 +103,16 @@ class BaseSchema(abc.ABC):
     Args:
       kwargs: The effective provider kwargs after merging.
     """
+
+
+def mark_from_output_schema(schema_instance: BaseSchema) -> None:
+  """Mark a schema as coming from a user-authored output_schema when possible."""
+  if getattr(schema_instance, "from_output_schema", False):
+    return
+  try:
+    setattr(schema_instance, "from_output_schema", True)
+  except (AttributeError, TypeError):
+    return
 
 
 class FormatModeSchema(BaseSchema):

--- a/langextract/core/types.py
+++ b/langextract/core/types.py
@@ -15,16 +15,31 @@
 """Core data types for LangExtract."""
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 import dataclasses
 import enum
 import textwrap
+from typing import TypeAlias
 
 __all__ = [
     'ScoredOutput',
     'FormatType',
     'ConstraintType',
     'Constraint',
+    'JsonSchema',
+    'JsonValue',
 ]
+
+JsonValue: TypeAlias = (
+    str
+    | int
+    | float
+    | bool
+    | None
+    | Mapping[str, 'JsonValue']
+    | Sequence['JsonValue']
+)
+JsonSchema: TypeAlias = Mapping[str, JsonValue]
 
 
 class FormatType(enum.Enum):

--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -29,8 +29,17 @@ from langextract import prompting
 from langextract import resolver
 from langextract.core import base_model
 from langextract.core import data
+from langextract.core import exceptions
 from langextract.core import format_handler as fh
+from langextract.core import output_schema as output_schema_lib
 from langextract.core import tokenizer as tokenizer_lib
+from langextract.core import types as core_types
+
+
+def _has_preconfigured_output_schema(model: typing.Any) -> bool:
+  return isinstance(model, base_model.BaseLanguageModel) and getattr(
+      model.schema, "from_output_schema", False
+  )
 
 
 def extract(
@@ -57,6 +66,7 @@ def extract(
     config: typing.Any = None,
     model: typing.Any = None,
     *,
+    output_schema: core_types.JsonSchema | None = None,
     fetch_urls: bool = False,
     prompt_validation_level: pv.PromptValidationLevel = pv.PromptValidationLevel.WARNING,
     prompt_validation_strict: bool = False,
@@ -77,6 +87,7 @@ def extract(
         caveats.
       prompt_description: Instructions for what to extract from the text.
       examples: List of ExampleData objects to guide the extraction.
+        Required unless `output_schema` is provided.
       tokenizer: Optional Tokenizer instance to use for chunking and alignment.
         If None, defaults to RegexTokenizer.
       api_key: API key for Gemini or other LLM services (can also use
@@ -154,6 +165,11 @@ def extract(
         and config are provided, model takes precedence.
       model: Pre-configured language model to use for extraction. Takes
         precedence over all other parameters including config.
+      output_schema: Optional JSON schema for LangExtract's raw JSON output
+        envelope. It replaces example-derived provider constraints, while
+        examples still guide the prompt when supplied. Use `lx.schema` helpers
+        for common schemas. Supported by Gemini and OpenAI; YAML and forced
+        fences are invalid with output_schema.
       fetch_urls: If True, http(s) strings are fetched via `requests.get`
         with no sanitization (SSRF risk: internal metadata, loopback,
         redirects, DNS rebinding, etc.). Default False; all strings are
@@ -172,17 +188,27 @@ def extract(
       iterable of Documents.
 
   Raises:
-      ValueError: If examples is None or empty.
+      ValueError: If examples is None or empty and neither output_schema nor a
+        preconfigured output-schema model is provided.
       ValueError: If no API key is provided or found in environment variables.
       requests.RequestException: If `fetch_urls=True` and the URL download
         fails.
       pv.PromptAlignmentError: If validation fails in ERROR mode.
   """
-  if not examples:
+  schema_active = output_schema is not None or _has_preconfigured_output_schema(
+      model
+  )
+  if not examples and not schema_active:
     raise ValueError(
         "Examples are required for reliable extraction. Please provide at least"
-        " one ExampleData object with sample extractions."
+        " one ExampleData object with sample extractions, or provide"
+        " output_schema."
     )
+  examples = list(examples or [])
+  # Reject before any model mutation so a caller-provided model is not left
+  # with a schema or fence override from a failed call.
+  if schema_active and fence_output is True:
+    raise exceptions.output_schema_fence_error()
 
   if prompt_validation_level is not pv.PromptValidationLevel.OFF:
     policy_kwargs = {}
@@ -236,9 +262,15 @@ def extract(
 
   if model:
     language_model = model
+    if output_schema is not None:
+      if not isinstance(language_model, base_model.BaseLanguageModel):
+        raise exceptions.unsupported_output_schema_error(
+            type(language_model).__name__
+        )
+      language_model.apply_output_schema(output_schema)
     if fence_output is not None:
       language_model.set_fence_output(fence_output)
-    if use_schema_constraints:
+    if use_schema_constraints and not schema_active:
       warnings.warn(
           "'use_schema_constraints' is ignored when 'model' is provided. "
           "The model should already be configured with schema constraints.",
@@ -246,10 +278,10 @@ def extract(
           stacklevel=2,
       )
   elif config:
-    if use_schema_constraints:
+    if use_schema_constraints and output_schema is None:
       warnings.warn(
           "With 'config', schema constraints are still applied via examples. "
-          "Or pass explicit schema in config.provider_kwargs.",
+          "Or pass output_schema=... for an explicit schema.",
           UserWarning,
           stacklevel=2,
       )
@@ -259,6 +291,7 @@ def extract(
         examples=prompt_template.examples if use_schema_constraints else None,
         use_schema_constraints=use_schema_constraints,
         fence_output=fence_output,
+        output_schema=output_schema,
     )
   else:
     if language_model_type is not None:
@@ -301,6 +334,7 @@ def extract(
         examples=prompt_template.examples if use_schema_constraints else None,
         use_schema_constraints=use_schema_constraints,
         fence_output=fence_output,
+        output_schema=output_schema,
     )
 
   format_handler, remaining_params = fh.FormatHandler.from_resolver_params(
@@ -311,6 +345,11 @@ def extract(
       base_use_wrapper=True,
       base_wrapper_key=data.EXTRACTIONS_KEY,
   )
+
+  if output_schema is not None or _has_preconfigured_output_schema(
+      language_model
+  ):
+    output_schema_lib.validate_output_schema_format_handler(format_handler)
 
   if language_model.schema is not None:
     language_model.schema.validate_format(format_handler)

--- a/langextract/factory.py
+++ b/langextract/factory.py
@@ -29,6 +29,9 @@ import warnings
 from langextract import providers
 from langextract.core import base_model
 from langextract.core import exceptions
+from langextract.core import output_schema as output_schema_lib
+from langextract.core import schema as core_schema
+from langextract.core import types as core_types
 from langextract.providers import router
 
 
@@ -106,6 +109,7 @@ def create_model(
     use_schema_constraints: bool = False,
     fence_output: bool | None = None,
     return_fence_output: bool = False,
+    output_schema: core_types.JsonSchema | None = None,
 ) -> base_model.BaseLanguageModel | tuple[base_model.BaseLanguageModel, bool]:
   """Create a language model instance from configuration.
 
@@ -115,6 +119,10 @@ def create_model(
     use_schema_constraints: Whether to apply schema constraints from examples.
     fence_output: Explicit fence output preference. If None, computed from schema.
     return_fence_output: If True, also return computed fence_output value.
+    output_schema: Optional user-provided JSON schema for the raw LangExtract
+      output. When provided, it is used verbatim and example-derived schema
+      generation is skipped, regardless of use_schema_constraints. Cannot be
+      combined with fence_output=True.
 
   Returns:
     An instantiated language model provider.
@@ -125,19 +133,24 @@ def create_model(
     ValueError: If no provider is registered for the model_id.
     InferenceConfigError: If provider instantiation fails.
   """
-  if use_schema_constraints or fence_output is not None:
+  if not config.model_id and not config.provider:
+    raise ValueError("Either model_id or provider must be specified")
+
+  if (
+      use_schema_constraints
+      or fence_output is not None
+      or output_schema is not None
+  ):
     model = _create_model_with_schema(
         config=config,
         examples=examples,
         use_schema_constraints=use_schema_constraints,
         fence_output=fence_output,
+        output_schema=output_schema,
     )
     if return_fence_output:
       return model, model.requires_fence_output
     return model
-
-  if not config.model_id and not config.provider:
-    raise ValueError("Either model_id or provider must be specified")
 
   providers.load_builtins_once()
   providers.load_plugins_once()
@@ -177,6 +190,8 @@ def create_model(
 def create_model_from_id(
     model_id: str | None = None,
     provider: str | None = None,
+    *,
+    output_schema: core_types.JsonSchema | None = None,
     **provider_kwargs: typing.Any,
 ) -> base_model.BaseLanguageModel:
   """Convenience function to create a model.
@@ -184,6 +199,8 @@ def create_model_from_id(
   Args:
     model_id: The model identifier (e.g., "gemini-3.5-flash").
     provider: Optional explicit provider name to disambiguate.
+    output_schema: Optional user-provided JSON schema for the raw LangExtract
+      output.
     **provider_kwargs: Optional provider-specific keyword arguments.
 
   Returns:
@@ -192,7 +209,21 @@ def create_model_from_id(
   config = ModelConfig(
       model_id=model_id, provider=provider, provider_kwargs=provider_kwargs
   )
-  return create_model(config)
+  return create_model(config, output_schema=output_schema)
+
+
+def _unsupported_output_schema_error(
+    config: ModelConfig,
+    provider_class: type[base_model.BaseLanguageModel],
+) -> exceptions.InferenceConfigError:
+  """Build an error naming the model or provider without output_schema support."""
+  if config.model_id:
+    target = f"model_id={config.model_id!r}"
+  elif config.provider:
+    target = f"provider={config.provider!r}"
+  else:
+    target = provider_class.__name__
+  return exceptions.unsupported_output_schema_error(f"Provider for {target}")
 
 
 def _create_model_with_schema(
@@ -200,6 +231,7 @@ def _create_model_with_schema(
     examples: typing.Sequence[typing.Any] | None = None,
     use_schema_constraints: bool = True,
     fence_output: bool | None = None,
+    output_schema: core_types.JsonSchema | None = None,
 ) -> base_model.BaseLanguageModel:
   """Internal helper to create a model with optional schema constraints.
 
@@ -213,10 +245,18 @@ def _create_model_with_schema(
     use_schema_constraints: Whether to generate and apply schema constraints.
     fence_output: Whether to wrap output in markdown fences. If None,
       will be computed based on schema's requires_raw_output.
+    output_schema: Optional user-provided JSON schema for the raw LangExtract
+      output. When provided, it replaces example-derived schema generation.
 
   Returns:
     A model instance with fence_output configured appropriately.
   """
+  if output_schema is not None and fence_output is True:
+    raise exceptions.output_schema_fence_error()
+  if output_schema is not None and not output_schema_lib.is_json_format_type(
+      config.provider_kwargs.get("format_type")
+  ):
+    raise exceptions.output_schema_format_error()
 
   # Must run before resolution regardless of config path.
   providers.load_builtins_once()
@@ -228,14 +268,36 @@ def _create_model_with_schema(
     provider_class = router.resolve(config.model_id)
 
   schema_instance = None
-  if use_schema_constraints and examples:
+  if output_schema is not None:
+    schema_class = provider_class.get_schema_class()
+    if schema_class is None:
+      raise _unsupported_output_schema_error(config, provider_class)
+    try:
+      schema_instance = schema_class.from_schema_dict(output_schema)
+    except NotImplementedError as e:
+      raise _unsupported_output_schema_error(config, provider_class) from e
+    core_schema.mark_from_output_schema(schema_instance)
+  elif use_schema_constraints and examples:
     schema_class = provider_class.get_schema_class()
     if schema_class is not None:
       schema_instance = schema_class.from_examples(examples)
 
   if schema_instance:
     kwargs = schema_instance.to_provider_config()
-    kwargs.update(config.provider_kwargs)
+    provider_kwargs = config.provider_kwargs
+    if output_schema is not None:
+      reserved = schema_instance.output_schema_reserved_provider_kwargs()
+      conflicts = sorted(
+          key for key in reserved if provider_kwargs.get(key) is not None
+      )
+      if conflicts:
+        raise exceptions.output_schema_provider_kwargs_error(conflicts)
+      provider_kwargs = {
+          key: value
+          for key, value in provider_kwargs.items()
+          if value is not None or key not in reserved
+      }
+    kwargs.update(provider_kwargs)
   else:
     kwargs = dict(config.provider_kwargs)
 

--- a/langextract/providers/README.md
+++ b/langextract/providers/README.md
@@ -192,7 +192,7 @@ result = lx.extract(
     text_or_documents="Your document",
     model_id="gemini-3.5-flash",
     prompt_description="Extract key facts",
-    examples=[...],             # Used for few-shot prompting (required)
+    examples=[...],             # Required unless output_schema is provided
     max_workers=4,              # Parallel processing (provider-dependent)
     max_char_buffer=3000,       # Document chunking
 )
@@ -286,6 +286,7 @@ yourprovider = "langextract_yourprovider:YourProviderLanguageModel"
 #### ☐ **4. (Optional) Add Schema Support** (`schema.py`)
 - [ ] Create schema class inheriting from `langextract.core.schema.BaseSchema`
 - [ ] Implement `from_examples()` class method
+- [ ] Implement `from_schema_dict()` if the provider supports `output_schema`
 - [ ] Implement `to_provider_config()` method
 - [ ] Add `get_schema_class()` to provider
 - [ ] Handle schema in provider's `__init__()` and `infer()`
@@ -499,6 +500,18 @@ When users set `use_schema_constraints=True`, LangExtract will:
 3. Call `to_provider_config()` to get provider-specific kwargs
 4. Pass these kwargs to your provider's `__init__()`
 5. Your provider uses the schema for structured output
+
+For user-authored schemas passed as `output_schema=...`, also implement
+`BaseSchema.from_schema_dict()`. If the provider exposes lower-level schema
+kwargs such as `response_schema`, list them in
+`output_schema_reserved_provider_kwargs()` so LangExtract can reject ambiguous
+requests where both `output_schema` and provider-native schema kwargs are set.
+Schemas returned from `from_schema_dict()` should expose
+`from_output_schema=True`; `BaseLanguageModel.apply_output_schema()` marks
+mutable schema instances automatically, but explicit state is safest for
+dataclass or slots-based schemas.
+Providers that store schema state after construction should override
+`apply_schema()` and call `super().apply_schema(schema_instance)`.
 
 ### Option 2: Built-in Provider (Requires Core Team Approval)
 

--- a/langextract/providers/__init__.py
+++ b/langextract/providers/__init__.py
@@ -56,9 +56,6 @@ def load_builtins_once() -> None:
   """
   global _builtins_loaded  # pylint: disable=global-statement
 
-  if _builtins_loaded:
-    return
-
   # Register built-ins lazily so they can be re-registered after a registry.clear()
   # even if their modules were already imported earlier in the test run.
   for config in builtin_registry.BUILTIN_PROVIDERS:

--- a/langextract/providers/gemini.py
+++ b/langextract/providers/gemini.py
@@ -99,6 +99,7 @@ def _has_sdk_retry_options(http_options: Any) -> bool:
 _API_CONFIG_KEYS: Final[set[str]] = {
     'response_mime_type',
     'response_schema',
+    'response_json_schema',
     'safety_settings',
     'system_instruction',
     'tools',
@@ -148,10 +149,19 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
 
     Args:
       schema_instance: The schema instance to apply, or None to clear.
+
+    Raises:
+      InferenceConfigError: If schema_instance belongs to another provider.
     """
+    if schema_instance is not None and not isinstance(
+        schema_instance, schemas.gemini.GeminiSchema
+    ):
+      raise exceptions.InferenceConfigError(
+          'GeminiLanguageModel only accepts GeminiSchema instances; got '
+          f'{type(schema_instance).__name__}.'
+      )
     super().apply_schema(schema_instance)
-    if isinstance(schema_instance, schemas.gemini.GeminiSchema):
-      self.gemini_schema = schema_instance
+    self.gemini_schema = schema_instance
 
   def __init__(
       self,
@@ -215,7 +225,7 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
     self.project = project
     self.location = location
     self.http_options = http_options
-    self.gemini_schema = gemini_schema
+    self.gemini_schema = None
     self.format_type = format_type
     self.temperature = temperature
     self.max_workers = max_workers
@@ -286,6 +296,10 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
     self._extra_kwargs = {
         k: v for k, v in (kwargs or {}).items() if k in _API_CONFIG_KEYS
     }
+    # Route through apply_schema so self._schema stays in sync and
+    # apply_output_schema() can detect the pre-configured schema.
+    if gemini_schema is not None:
+      self.apply_schema(gemini_schema)
 
   def _validate_schema_config(self) -> None:
     """Validate that schema configuration is compatible with format type.
@@ -348,10 +362,8 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
 
         if self.gemini_schema:
           self._validate_schema_config()
-          call_config.setdefault('response_mime_type', 'application/json')
-          call_config.setdefault(
-              'response_schema', self.gemini_schema.schema_dict
-          )
+          for key, value in self.gemini_schema.to_provider_config().items():
+            call_config.setdefault(key, value)
 
         response = self._client.models.generate_content(
             model=self.model_id, contents=prompt, config=call_config
@@ -414,13 +426,17 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
         try:
           if self.gemini_schema:
             self._validate_schema_config()
-          schema_dict = (
-              self.gemini_schema.schema_dict if self.gemini_schema else None
+          schema_config = (
+              self.gemini_schema.to_provider_config()
+              if self.gemini_schema
+              else None
           )
-          # Remove schema fields from config for batch API - they're handled via schema_dict
+          # Remove schema fields from config for batch API - they're handled
+          # via schema_config
           batch_config = dict(config)
           batch_config.pop('response_mime_type', None)
           batch_config.pop('response_schema', None)
+          batch_config.pop('response_json_schema', None)
           # Extract top-level fields that don't belong in generationConfig
           system_instruction = batch_config.pop('system_instruction', None)
           safety_settings = batch_config.pop('safety_settings', None)
@@ -428,7 +444,7 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
               client=self._client,
               model_id=self.model_id,
               prompts=batch_prompts,
-              schema_dict=schema_dict,
+              schema_config=schema_config,
               gen_config=batch_config,
               cfg=self._batch_cfg,
               system_instruction=system_instruction,

--- a/langextract/providers/gemini_batch.py
+++ b/langextract/providers/gemini_batch.py
@@ -258,7 +258,7 @@ def _ensure_bucket_lifecycle(
 
 def _build_request(
     prompt: str,
-    schema_dict: dict | None,
+    schema_config: dict | None,
     gen_config: dict | None,
     system_instruction: str | None = None,
     safety_settings: Sequence[Any] | None = None,
@@ -272,7 +272,10 @@ def _build_request(
 
   Args:
     prompt: The text prompt to send to the model.
-    schema_dict: Optional JSON schema for structured output.
+    schema_config: Optional provider schema config for structured output, as
+        produced by GeminiSchema.to_provider_config(). Supports
+        response_json_schema (JSON Schema) and response_schema
+        (OpenAPI-style) sources.
     gen_config: Optional generation configuration parameters.
     system_instruction: Optional system instruction text.
     safety_settings: Optional safety settings sequence.
@@ -292,11 +295,18 @@ def _build_request(
   if safety_settings:
     request["safetySettings"] = safety_settings
 
-  if schema_dict or gen_config:
+  if schema_config or gen_config:
     generation_config = {}
-    if schema_dict:
-      generation_config["responseMimeType"] = _MIME_TYPE_JSON
-      generation_config["responseSchema"] = schema_dict
+    if schema_config:
+      json_schema = schema_config.get("response_json_schema")
+      response_schema = schema_config.get("response_schema")
+      if json_schema is not None:
+        generation_config["responseJsonSchema"] = json_schema
+      elif response_schema is not None:
+        generation_config["responseSchema"] = response_schema
+      generation_config["responseMimeType"] = schema_config.get(
+          "response_mime_type", _MIME_TYPE_JSON
+      )
     if gen_config:
       for k, v in gen_config.items():
         generation_config[_snake_to_camel(k)] = v
@@ -698,7 +708,7 @@ def infer_batch(
     client: genai.Client,
     model_id: str,
     prompts: Sequence[str],
-    schema_dict: dict | None,
+    schema_config: dict | None,
     gen_config: dict,
     cfg: BatchConfig,
     system_instruction: str | None = None,
@@ -719,7 +729,8 @@ def infer_batch(
         (must have client.vertexai=True).
     model_id: Model identifier (e.g., "gemini-3.5-flash").
     prompts: Sequence of prompts to process in batch.
-    schema_dict: Optional JSON schema for structured output. When provided,
+    schema_config: Optional provider schema config for structured output, as
+        produced by GeminiSchema.to_provider_config(). When provided,
         enables JSON mode with the specified schema constraints.
     gen_config: Generation configuration parameters (temperature, top_p, etc.).
     cfg: Batch configuration including thresholds, timeouts, and error handling.
@@ -786,7 +797,7 @@ def infer_batch(
           "system_instruction": system_instruction,
           "gen_config": gen_config,
           "safety_settings": safety_settings,
-          "schema": schema_dict,
+          "schema": schema_config,
       })
 
     cached_results = cache.get_multi(key_data_list)
@@ -818,7 +829,7 @@ def infer_batch(
     batch_prompts = [p for _, p in batch_items]
     requests = [
         _build_request(
-            p, schema_dict, gen_config, system_instruction, safety_settings
+            p, schema_config, gen_config, system_instruction, safety_settings
         )
         for p in batch_prompts
     ]
@@ -877,7 +888,7 @@ def infer_batch(
           "system_instruction": system_instruction,
           "gen_config": gen_config,
           "safety_settings": safety_settings,
-          "schema": schema_dict,
+          "schema": schema_config,
       }
       upload_list.append((key_data, text))
 

--- a/langextract/providers/schemas/gemini.py
+++ b/langextract/providers/schemas/gemini.py
@@ -18,24 +18,37 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+import copy
 import dataclasses
 from typing import Any
 import warnings
 
 from langextract.core import data
 from langextract.core import format_handler as fh
+from langextract.core import output_schema as output_schema_lib
 from langextract.core import schema
+from langextract.core import types as core_types
 
 
 @dataclasses.dataclass
 class GeminiSchema(schema.BaseSchema):
   """Schema implementation for Gemini structured output.
 
-  Converts ExampleData objects into an OpenAPI/JSON-schema definition
-  that Gemini can interpret via 'response_schema'.
+  Converts ExampleData objects into Gemini's OpenAPI-style
+  `response_schema`. User-authored schemas stay on Gemini's native JSON Schema
+  `response_json_schema` field.
   """
 
   _schema_dict: dict[str, Any]
+  _use_json_schema: bool = False
+  from_output_schema: bool = dataclasses.field(
+      default=False, repr=False, compare=False
+  )
+
+  def __post_init__(self) -> None:
+    # Direct construction should get the same caller-mutation isolation as
+    # from_schema_dict().
+    self._schema_dict = copy.deepcopy(self._schema_dict)
 
   @property
   def schema_dict(self) -> dict[str, Any]:
@@ -45,18 +58,30 @@ class GeminiSchema(schema.BaseSchema):
   @schema_dict.setter
   def schema_dict(self, schema_dict: dict[str, Any]) -> None:
     """Sets the schema dictionary."""
-    self._schema_dict = schema_dict
+    self._schema_dict = copy.deepcopy(schema_dict)
 
   def to_provider_config(self) -> dict[str, Any]:
     """Convert schema to Gemini-specific configuration.
 
     Returns:
-      Dictionary with response_schema and response_mime_type for Gemini API.
+      Dictionary with Gemini response schema config for the provider API.
     """
+    schema_key = (
+        "response_json_schema" if self._use_json_schema else "response_schema"
+    )
     return {
-        "response_schema": self._schema_dict,
+        schema_key: self._schema_dict,
         "response_mime_type": "application/json",
     }
+
+  def output_schema_reserved_provider_kwargs(self) -> frozenset[str]:
+    """Provider kwargs that would override an explicit output_schema."""
+    return frozenset({
+        "gemini_schema",
+        "response_json_schema",
+        "response_mime_type",
+        "response_schema",
+    })
 
   @property
   def requires_raw_output(self) -> bool:
@@ -68,9 +93,8 @@ class GeminiSchema(schema.BaseSchema):
 
     Gemini requires:
     - No fence markers (outputs raw JSON via response_mime_type)
-    - Wrapper with EXTRACTIONS_KEY (built into response_schema)
+    - Wrapper with EXTRACTIONS_KEY (built into LangExtract schemas)
     """
-    # Check for fence usage with raw JSON output
     if format_handler.use_fences:
       warnings.warn(
           "Gemini outputs native JSON via"
@@ -80,7 +104,6 @@ class GeminiSchema(schema.BaseSchema):
           stacklevel=3,
       )
 
-    # Verify wrapper is enabled with correct key
     if (
         not format_handler.use_wrapper
         or format_handler.wrapper_key != data.EXTRACTIONS_KEY
@@ -113,9 +136,8 @@ class GeminiSchema(schema.BaseSchema):
         attributes field name (defaults to "_attributes").
 
     Returns:
-      A GeminiSchema with internal dictionary represents the JSON constraint.
+      A GeminiSchema whose internal dictionary represents the JSON constraint.
     """
-    # Track attribute types for each category
     extraction_categories: dict[str, dict[str, set[type]]] = {}
     for example in examples_data:
       for extraction in example.extractions:
@@ -137,12 +159,10 @@ class GeminiSchema(schema.BaseSchema):
       attributes_field = f"{category}{attribute_suffix}"
       attr_properties = {}
 
-      # Default property for categories without attributes
       if not attrs:
         attr_properties["_unused"] = {"type": "string"}
       else:
         for attr_name, attr_types in attrs.items():
-          # List attributes become arrays
           if list in attr_types:
             attr_properties[attr_name] = {
                 "type": "array",
@@ -171,3 +191,14 @@ class GeminiSchema(schema.BaseSchema):
     }
 
     return cls(_schema_dict=schema_dict)
+
+  @classmethod
+  def from_schema_dict(
+      cls, output_schema: core_types.JsonSchema
+  ) -> GeminiSchema:
+    """Creates a GeminiSchema from a user-provided output schema."""
+    return cls(
+        _schema_dict=output_schema_lib.validate_output_schema(output_schema),
+        _use_json_schema=True,
+        from_output_schema=True,
+    )

--- a/langextract/providers/schemas/openai.py
+++ b/langextract/providers/schemas/openai.py
@@ -20,15 +20,19 @@ from __future__ import annotations
 from collections.abc import Sequence
 import copy
 import dataclasses
+import re
 from typing import Any
 import warnings
 
 from langextract.core import data
 from langextract.core import exceptions
 from langextract.core import format_handler as fh
+from langextract.core import output_schema as output_schema_lib
 from langextract.core import schema
+from langextract.core import types as core_types
 
 DEFAULT_SCHEMA_NAME = "langextract_extractions"
+_SCHEMA_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 JSON_SCHEMA_FORMAT_ERROR = (
     "OpenAI structured output only supports JSON format. "
     "Set format_type=JSON or use_schema_constraints=False."
@@ -162,6 +166,9 @@ class OpenAISchema(schema.BaseSchema):
   schema_dict: dict[str, Any]
   schema_name: str = DEFAULT_SCHEMA_NAME
   strict: bool = True
+  from_output_schema: bool = dataclasses.field(
+      default=False, repr=False, compare=False
+  )
 
   def __post_init__(self) -> None:
     # Copy before publishing the schema to worker threads so caller mutations
@@ -184,6 +191,10 @@ class OpenAISchema(schema.BaseSchema):
     """OpenAI schemas are applied through the provider schema hook."""
     return {}
 
+  def output_schema_reserved_provider_kwargs(self) -> frozenset[str]:
+    """Provider kwargs that would override an explicit output_schema."""
+    return frozenset({"openai_schema", "response_format"})
+
   @property
   def requires_raw_output(self) -> bool:
     """OpenAI structured outputs emit raw JSON without fences."""
@@ -199,7 +210,7 @@ class OpenAISchema(schema.BaseSchema):
     Raises:
       InferenceConfigError: if format_type is not JSON.
     """
-    if format_handler.format_type != data.FormatType.JSON:
+    if not output_schema_lib.is_json_format_type(format_handler.format_type):
       raise exceptions.InferenceConfigError(JSON_SCHEMA_FORMAT_ERROR)
 
     if format_handler.use_fences:
@@ -277,3 +288,42 @@ class OpenAISchema(schema.BaseSchema):
     }
 
     return cls(schema_dict=schema_dict, strict=strict)
+
+  @classmethod
+  def from_schema_dict(
+      cls,
+      output_schema: core_types.JsonSchema,
+      *,
+      schema_name: str = DEFAULT_SCHEMA_NAME,
+      strict: bool = True,
+  ) -> OpenAISchema:
+    """Creates an OpenAISchema from a user-provided output schema.
+
+    Strict mode requirements (every object lists all properties in
+    `required` and sets `additionalProperties: false`) are enforced by the
+    OpenAI API itself; the `lx.schema` helpers emit compliant schemas by
+    default.
+
+    Args:
+      output_schema: JSON schema for LangExtract's raw output object.
+      schema_name: Name sent to OpenAI's response_format payload.
+      strict: Whether OpenAI should enforce strict structured outputs.
+
+    Returns:
+      An OpenAISchema instance ready to apply to the OpenAI provider.
+    """
+    if not isinstance(schema_name, str) or not schema_name:
+      raise exceptions.InferenceConfigError(
+          "schema_name must be a non-empty string."
+      )
+    if not _SCHEMA_NAME_RE.fullmatch(schema_name):
+      raise exceptions.InferenceConfigError(
+          "schema_name must contain only letters, numbers, underscores, "
+          "or dashes, and be at most 64 characters."
+      )
+    return cls(
+        schema_dict=output_schema_lib.validate_output_schema(output_schema),
+        schema_name=schema_name,
+        strict=strict,
+        from_output_schema=True,
+    )

--- a/langextract/schema.py
+++ b/langextract/schema.py
@@ -12,18 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Schema compatibility layer.
+"""Public schema helpers and compatibility layer.
 
-This module provides backward compatibility for the schema module.
-New code should import from langextract.core.schema instead.
+New helper functions return plain JSON schema dictionaries for
+`extract(output_schema=...)`. Older schema classes remain available here with
+deprecation warnings.
 """
 
 from __future__ import annotations
 
-# Re-export core schema items with deprecation warnings
+# pylint: disable=undefined-all-variable
 import warnings
 
 from langextract._compat import schema
+from langextract.core import output_schema as output_schema_lib
+from langextract.core import types as core_types
+
+extraction_item_schema = output_schema_lib.extraction_item_schema
+extractions_schema = output_schema_lib.extractions_schema
+JsonSchema = core_types.JsonSchema
+JsonValue = core_types.JsonValue
+validate_output_schema = output_schema_lib.validate_output_schema
+
+_COMPAT_NAMES = [
+    "ATTRIBUTE_SUFFIX",
+    "BaseSchema",
+    "Constraint",
+    "ConstraintType",
+    "EXTRACTIONS_KEY",
+    "FormatModeSchema",
+    "GeminiSchema",
+]
+
+__all__ = [
+    *_COMPAT_NAMES,
+    "extraction_item_schema",
+    "extractions_schema",
+    "JsonSchema",
+    "JsonValue",
+    "validate_output_schema",
+]
 
 
 def __getattr__(name: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,13 +107,14 @@ openai = "langextract.providers.openai:OpenAILanguageModel"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-python_files = "*_test.py"
+python_files = ["test_*.py", "*_test.py"]
 python_classes = "Test*"
 python_functions = "test_*"
 # Show extra test summary info
 addopts = "-ra"
 markers = [
     "live_api: marks tests as requiring live API access",
+    "vertex_ai: marks live tests that require Vertex AI credentials",
     "requires_pip: marks tests that perform pip install/uninstall operations",
     "integration: marks integration tests that test multiple components together",
 ]

--- a/tests/extract_schema_integration_test.py
+++ b/tests/extract_schema_integration_test.py
@@ -19,8 +19,11 @@ import warnings
 
 from absl.testing import absltest
 
+from langextract import factory
 import langextract as lx
 from langextract.core import data
+from langextract.core import exceptions
+from langextract.providers import gemini
 
 
 class ExtractSchemaIntegrationTest(absltest.TestCase):
@@ -308,6 +311,234 @@ class ExtractSchemaIntegrationTest(absltest.TestCase):
           f"Unexpected format warning found in: {warning_messages}",
       )
 
+    self.assertIsNotNone(result)
+
+
+@mock.patch.dict("os.environ", {"GEMINI_API_KEY": "test_key"})
+class ExtractOutputSchemaTest(absltest.TestCase):
+  """Tests for extract() with user-provided output_schema."""
+
+  def setUp(self):
+    super().setUp()
+    self.output_schema = lx.schema.extractions_schema(
+        lx.schema.extraction_item_schema("condition")
+    )
+    self.test_text = "Patient has hypertension"
+
+  def _patch_infer(self):
+    return mock.patch.object(
+        gemini.GeminiLanguageModel,
+        "infer",
+        autospec=True,
+        return_value=iter(
+            [[mock.Mock(output='{"extractions": [{"condition": "fever"}]}')]]
+        ),
+    )
+
+  def test_extract_with_output_schema_allows_no_examples(self):
+    with self._patch_infer() as mock_infer:
+      result = lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model_id="gemini-3.5-flash",
+          output_schema=self.output_schema,
+      )
+
+    model = mock_infer.call_args[0][0]
+    self.assertEqual(
+        model.schema.to_provider_config()["response_json_schema"],
+        self.output_schema,
+    )
+    self.assertLen(result.extractions, 1)
+    self.assertEqual(result.extractions[0].extraction_class, "condition")
+    self.assertEqual(result.extractions[0].extraction_text, "fever")
+
+  def test_extract_output_schema_overrides_example_schema(self):
+    examples = [
+        data.ExampleData(
+            text="Patient has diabetes",
+            extractions=[
+                data.Extraction(
+                    extraction_class="condition",
+                    extraction_text="diabetes",
+                )
+            ],
+        )
+    ]
+
+    with self._patch_infer() as mock_infer:
+      lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          examples=examples,
+          model_id="gemini-3.5-flash",
+          use_schema_constraints=True,
+          output_schema=self.output_schema,
+      )
+
+    model = mock_infer.call_args[0][0]
+    provider_config = model.schema.to_provider_config()
+    self.assertEqual(
+        provider_config["response_json_schema"], self.output_schema
+    )
+    self.assertNotIn("response_schema", provider_config)
+
+  def test_extract_requires_examples_without_output_schema(self):
+    with self.assertRaisesRegex(ValueError, "output_schema"):
+      lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model_id="gemini-3.5-flash",
+      )
+
+  def test_extract_with_preconfigured_output_schema_model(self):
+    model = factory.create_model_from_id(
+        "gemini-3.5-flash", output_schema=self.output_schema
+    )
+
+    with self._patch_infer():
+      result = lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model=model,
+      )
+
+    self.assertLen(result.extractions, 1)
+
+  def test_extract_applies_output_schema_to_plain_model(self):
+    model = factory.create_model_from_id("gemini-3.5-flash")
+
+    with self._patch_infer():
+      lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model=model,
+          output_schema=self.output_schema,
+      )
+
+    self.assertTrue(model.schema.from_output_schema)
+
+  def test_extract_reapplies_same_output_schema_idempotently(self):
+    model = factory.create_model_from_id(
+        "gemini-3.5-flash", output_schema=self.output_schema
+    )
+
+    with self._patch_infer():
+      result = lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model=model,
+          output_schema=self.output_schema,
+      )
+
+    self.assertIsNotNone(result)
+
+  def test_extract_output_schema_conflicts_with_example_schema_model(self):
+    examples = [
+        data.ExampleData(
+            text="Patient has diabetes",
+            extractions=[
+                data.Extraction(
+                    extraction_class="condition",
+                    extraction_text="diabetes",
+                )
+            ],
+        )
+    ]
+    model = factory.create_model(
+        factory.ModelConfig(model_id="gemini-3.5-flash"),
+        examples=examples,
+        use_schema_constraints=True,
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError, "already has a schema"
+    ):
+      lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model=model,
+          output_schema=self.output_schema,
+      )
+
+  def test_extract_output_schema_rejects_fence_output(self):
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError, "fence_output"
+    ):
+      lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model_id="gemini-3.5-flash",
+          output_schema=self.output_schema,
+          fence_output=True,
+      )
+
+  def test_extract_output_schema_rejects_yaml_format(self):
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError, "format_type=JSON"
+    ):
+      lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model_id="gemini-3.5-flash",
+          output_schema=self.output_schema,
+          format_type=data.FormatType.YAML,
+      )
+
+  def test_extract_output_schema_rejects_fenced_resolver_params(self):
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError, "fence_output"
+    ):
+      lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model_id="gemini-3.5-flash",
+          output_schema=self.output_schema,
+          resolver_params={"fence_output": True},
+      )
+
+  def test_extract_output_schema_rejects_unwrapped_resolver_output(self):
+    with self.assertRaisesRegex(exceptions.InferenceConfigError, "envelope"):
+      lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model_id="gemini-3.5-flash",
+          output_schema=self.output_schema,
+          resolver_params={"require_extractions_key": False},
+      )
+
+  def test_extract_output_schema_rejects_custom_attribute_suffix(self):
+    with self.assertRaisesRegex(exceptions.InferenceConfigError, "envelope"):
+      lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model_id="gemini-3.5-flash",
+          output_schema=self.output_schema,
+          resolver_params={"attribute_suffix": "_props"},
+      )
+
+  def test_extract_fence_conflict_leaves_caller_model_unmodified(self):
+    model = factory.create_model_from_id("gemini-3.5-flash")
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError, "fence_output"
+    ):
+      lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model=model,
+          output_schema=self.output_schema,
+          fence_output=True,
+      )
+
+    self.assertIsNone(model.schema)
+    with self._patch_infer():
+      result = lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          model=model,
+          output_schema=self.output_schema,
+      )
     self.assertIsNotNone(result)
 
 

--- a/tests/factory_schema_test.py
+++ b/tests/factory_schema_test.py
@@ -22,6 +22,7 @@ from langextract import factory
 from langextract import schema
 from langextract.core import base_model
 from langextract.core import data
+from langextract.core import exceptions
 from langextract.providers import schemas
 
 
@@ -272,6 +273,121 @@ class SchemaApplicationTest(absltest.TestCase):
           mock_apply.assert_called_once()
           schema_arg = mock_apply.call_args[0][0]
           self.assertIsInstance(schema_arg, schema.GeminiSchema)
+
+
+@mock.patch.dict(
+    "os.environ",
+    {"GEMINI_API_KEY": "test_key", "OPENAI_API_KEY": "test_key"},
+)
+class FactoryOutputSchemaTest(absltest.TestCase):
+  """Tests for create_model with user-provided output_schema."""
+
+  def setUp(self):
+    super().setUp()
+    self.output_schema = schema.extractions_schema(
+        schema.extraction_item_schema("condition")
+    )
+    self.examples = [
+        data.ExampleData(
+            text="Patient has diabetes",
+            extractions=[
+                data.Extraction(
+                    extraction_class="condition",
+                    extraction_text="diabetes",
+                )
+            ],
+        )
+    ]
+
+  def test_gemini_output_schema_configures_json_schema(self):
+    model = factory.create_model_from_id(
+        "gemini-3.5-flash", output_schema=self.output_schema
+    )
+
+    self.assertIsInstance(model.schema, schemas.gemini.GeminiSchema)
+    self.assertTrue(model.schema.from_output_schema)
+    self.assertEqual(
+        model.schema.to_provider_config()["response_json_schema"],
+        self.output_schema,
+    )
+    self.assertFalse(model.requires_fence_output)
+
+  def test_openai_output_schema_configures_response_format(self):
+    model = factory.create_model_from_id(
+        "gpt-4o", output_schema=self.output_schema
+    )
+
+    self.assertIsInstance(model.schema, schemas.openai.OpenAISchema)
+    self.assertTrue(model.schema.from_output_schema)
+    self.assertEqual(
+        model.schema.response_format["json_schema"]["schema"],
+        self.output_schema,
+    )
+    self.assertFalse(model.requires_fence_output)
+
+  def test_output_schema_overrides_example_schema(self):
+    model = factory.create_model(
+        factory.ModelConfig(model_id="gemini-3.5-flash"),
+        examples=self.examples,
+        use_schema_constraints=True,
+        output_schema=self.output_schema,
+    )
+
+    provider_config = model.schema.to_provider_config()
+    self.assertEqual(
+        provider_config["response_json_schema"], self.output_schema
+    )
+    self.assertNotIn("response_schema", provider_config)
+
+  def test_output_schema_rejects_provider_schema_kwargs(self):
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError, "response_schema"
+    ):
+      factory.create_model_from_id(
+          "gemini-3.5-flash",
+          output_schema=self.output_schema,
+          response_schema={"type": "object"},
+      )
+
+  def test_output_schema_ignores_none_provider_schema_kwargs(self):
+    model = factory.create_model_from_id(
+        "gemini-3.5-flash",
+        output_schema=self.output_schema,
+        response_schema=None,
+    )
+
+    self.assertEqual(
+        model.schema.to_provider_config()["response_mime_type"],
+        "application/json",
+    )
+
+  def test_output_schema_rejects_fence_output(self):
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError, "fence_output"
+    ):
+      factory.create_model(
+          factory.ModelConfig(model_id="gemini-3.5-flash"),
+          output_schema=self.output_schema,
+          fence_output=True,
+      )
+
+  def test_output_schema_rejects_yaml_format(self):
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError, "format_type=JSON"
+    ):
+      factory.create_model_from_id(
+          "gemini-3.5-flash",
+          output_schema=self.output_schema,
+          format_type=data.FormatType.YAML,
+      )
+
+  def test_output_schema_rejects_unsupported_provider(self):
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError, "does not support output_schema"
+    ):
+      factory.create_model_from_id(
+          "gemma2:2b", output_schema=self.output_schema
+      )
 
 
 if __name__ == "__main__":

--- a/tests/provider_schema_test.py
+++ b/tests/provider_schema_test.py
@@ -630,5 +630,115 @@ class SchemaShimTest(absltest.TestCase):
     )
 
 
+class ApplyOutputSchemaTest(absltest.TestCase):
+  """Tests for BaseLanguageModel.apply_output_schema across providers."""
+
+  def setUp(self):
+    super().setUp()
+    self.output_schema = schema.extractions_schema(
+        schema.extraction_item_schema("condition")
+    )
+
+  def test_gemini_output_schema_reaches_generate_config(self):
+    with mock.patch("google.genai.Client", autospec=True) as mock_client:
+      mock_generate = mock.Mock(spec=["return_value"])
+      mock_client.return_value.models.generate_content = mock_generate
+      mock_generate.return_value.text = '{"extractions": []}'
+
+      model = gemini.GeminiLanguageModel(
+          model_id="gemini-3.5-flash", api_key="test_key"
+      )
+      model.apply_output_schema(self.output_schema)
+      list(model.infer(["Test prompt"]))
+
+      config = mock_generate.call_args[1]["config"]
+      self.assertEqual(config["response_json_schema"], self.output_schema)
+      self.assertEqual(config["response_mime_type"], "application/json")
+
+  def test_openai_output_schema_reaches_response_format(self):
+    with mock.patch("openai.OpenAI", autospec=True) as mock_client_cls:
+      mock_client = mock.Mock()
+      mock_client_cls.return_value = mock_client
+      mock_response = mock.Mock()
+      mock_response.choices = [
+          mock.Mock(message=mock.Mock(content='{"extractions": []}'))
+      ]
+      mock_client.chat.completions.create.return_value = mock_response
+
+      model = openai.OpenAILanguageModel(model_id="gpt-4o", api_key="test_key")
+      model.apply_output_schema(self.output_schema)
+      list(model.infer(["Test prompt"]))
+
+      call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+      response_format = call_kwargs["response_format"]
+      self.assertEqual(response_format["type"], "json_schema")
+      self.assertEqual(
+          response_format["json_schema"]["schema"], self.output_schema
+      )
+
+  def test_ollama_apply_output_schema_raises(self):
+    model = ollama.OllamaLanguageModel(model_id="gemma2:2b")
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError, "does not support output_schema"
+    ):
+      model.apply_output_schema(self.output_schema)
+
+  def test_apply_output_schema_rejects_conflicting_schema_kwargs(self):
+    with mock.patch("google.genai.Client", autospec=True):
+      model = gemini.GeminiLanguageModel(
+          model_id="gemini-3.5-flash",
+          api_key="test_key",
+          response_schema={"type": "object"},
+      )
+
+      with self.assertRaisesRegex(
+          exceptions.InferenceConfigError, "response_schema"
+      ):
+        model.apply_output_schema(self.output_schema)
+
+  def test_apply_output_schema_is_idempotent_for_same_schema(self):
+    with mock.patch("google.genai.Client", autospec=True):
+      model = gemini.GeminiLanguageModel(
+          model_id="gemini-3.5-flash", api_key="test_key"
+      )
+
+      model.apply_output_schema(self.output_schema)
+      model.apply_output_schema(self.output_schema)
+
+      self.assertTrue(model.schema.from_output_schema)
+
+  def test_apply_output_schema_rejects_different_schema(self):
+    with mock.patch("google.genai.Client", autospec=True):
+      model = gemini.GeminiLanguageModel(
+          model_id="gemini-3.5-flash", api_key="test_key"
+      )
+      model.apply_output_schema(self.output_schema)
+
+      other_schema = schema.extractions_schema(
+          schema.extraction_item_schema("medication")
+      )
+      with self.assertRaisesRegex(
+          exceptions.InferenceConfigError, "already has a schema"
+      ):
+        model.apply_output_schema(other_schema)
+
+  def test_apply_output_schema_rejects_constructor_gemini_schema(self):
+    with mock.patch("google.genai.Client", autospec=True):
+      example_schema = schemas.gemini.GeminiSchema(
+          _schema_dict={"type": "object", "properties": {}}
+      )
+      model = gemini.GeminiLanguageModel(
+          model_id="gemini-3.5-flash",
+          api_key="test_key",
+          gemini_schema=example_schema,
+      )
+
+      with self.assertRaisesRegex(
+          exceptions.InferenceConfigError, "already has a schema"
+      ):
+        model.apply_output_schema(self.output_schema)
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -25,8 +25,10 @@ import re
 from absl.testing import absltest
 
 from langextract import exceptions
+from langextract import providers as providers_module
 from langextract.core import base_model
 from langextract.core import types
+from langextract.providers import builtin_registry
 from langextract.providers import router
 
 
@@ -130,6 +132,22 @@ class RegistryTest(absltest.TestCase):
     # Should fail after clear
     with self.assertRaises(exceptions.InferenceConfigError):
       router.resolve("temp-model")
+
+  def test_load_builtins_once_deduplicates_and_recovers_after_clear(self):
+    """Built-in lazy registration can be repeated or restored after clear."""
+    providers_module._builtins_loaded = False  # pylint: disable=protected-access
+
+    providers_module.load_builtins_once()
+    first_providers = router.list_providers()
+    providers_module.load_builtins_once()
+
+    self.assertLen(first_providers, len(builtin_registry.BUILTIN_PROVIDERS))
+    self.assertEqual(router.list_providers(), first_providers)
+
+    router.clear()
+    providers_module.load_builtins_once()
+
+    self.assertEqual(router.list_providers(), first_providers)
 
   def test_list_entries(self):
     """Test listing registered entries."""

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -25,6 +25,7 @@ import warnings
 from absl.testing import absltest
 from absl.testing import parameterized
 
+from langextract import schema as lx_schema
 from langextract.core import base_model
 from langextract.core import data
 from langextract.core import exceptions
@@ -759,6 +760,253 @@ class SchemaValidationTest(parameterized.TestCase):
 
       self.assertEmpty(
           w, "FormatModeSchema should not issue validation warnings"
+      )
+
+
+class OutputSchemaHelperTest(parameterized.TestCase):
+  """Tests for the public lx.schema output-schema builders."""
+
+  def test_extraction_item_schema_without_attributes(self):
+    item = lx_schema.extraction_item_schema("condition")
+
+    self.assertEqual(
+        item,
+        {
+            "type": "object",
+            "properties": {"condition": {"type": "string"}},
+            "required": ["condition"],
+            "additionalProperties": False,
+        },
+    )
+
+  def test_extraction_item_schema_with_attributes(self):
+    item = lx_schema.extraction_item_schema(
+        "condition",
+        attributes={"status": {"type": "string", "enum": ["active"]}},
+    )
+
+    self.assertEqual(
+        item["properties"]["condition_attributes"],
+        {
+            "type": "object",
+            "properties": {"status": {"type": "string", "enum": ["active"]}},
+            "required": ["status"],
+            "additionalProperties": False,
+        },
+    )
+    self.assertCountEqual(
+        item["required"], ["condition", "condition_attributes"]
+    )
+
+  def test_extractions_schema_wraps_item_schema(self):
+    item = lx_schema.extraction_item_schema("condition")
+
+    envelope = lx_schema.extractions_schema(item)
+
+    self.assertEqual(
+        envelope["properties"][data.EXTRACTIONS_KEY]["items"], item
+    )
+    self.assertEqual(envelope["required"], [data.EXTRACTIONS_KEY])
+    self.assertIs(envelope["additionalProperties"], False)
+    lx_schema.validate_output_schema(envelope)
+
+  def test_extractions_schema_wraps_multiple_items_in_any_of(self):
+    condition = lx_schema.extraction_item_schema("condition")
+    medication = lx_schema.extraction_item_schema("medication")
+
+    envelope = lx_schema.extractions_schema(condition, medication)
+
+    self.assertEqual(
+        envelope["properties"][data.EXTRACTIONS_KEY]["items"],
+        {"anyOf": [condition, medication]},
+    )
+    lx_schema.validate_output_schema(envelope)
+
+  def test_builders_copy_input_schemas(self):
+    attribute_schema = {"type": "string"}
+
+    item = lx_schema.extraction_item_schema(
+        "condition", attributes={"status": attribute_schema}
+    )
+    attribute_schema["enum"] = ["mutated"]
+
+    status_schema = item["properties"]["condition_attributes"]["properties"][
+        "status"
+    ]
+    self.assertNotIn("enum", status_schema)
+
+  @parameterized.named_parameters(
+      dict(testcase_name="empty_class", extraction_class=""),
+      dict(testcase_name="reserved_suffix", extraction_class="foo_attributes"),
+      dict(testcase_name="reserved_key", extraction_class="extraction_text"),
+  )
+  def test_extraction_item_schema_rejects_invalid_class(self, extraction_class):
+    with self.assertRaises(exceptions.InferenceConfigError):
+      lx_schema.extraction_item_schema(extraction_class)
+
+
+class OutputSchemaValidationTest(parameterized.TestCase):
+  """Tests for validate_output_schema envelope checks."""
+
+  def test_accepts_envelope_and_returns_isolated_copy(self):
+    envelope = lx_schema.extractions_schema(
+        lx_schema.extraction_item_schema("condition")
+    )
+
+    validated = lx_schema.validate_output_schema(envelope)
+
+    self.assertEqual(validated, envelope)
+    validated["properties"]["extra"] = {"type": "string"}
+    self.assertNotIn("extra", envelope["properties"])
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="not_a_mapping",
+          output_schema=["extractions"],
+          error_regex="must be a mapping",
+      ),
+      dict(
+          testcase_name="empty",
+          output_schema={},
+          error_regex="must not be empty",
+      ),
+      dict(
+          testcase_name="non_object_root",
+          output_schema={"type": "array"},
+          error_regex="top-level type",
+      ),
+      dict(
+          testcase_name="missing_required_extractions",
+          output_schema={
+              "type": "object",
+              "properties": {
+                  "extractions": {
+                      "type": "array",
+                      "items": {
+                          "type": "object",
+                          "properties": {"condition": {"type": "string"}},
+                      },
+                  }
+              },
+          },
+          error_regex="required must include 'extractions'",
+      ),
+      dict(
+          testcase_name="extractions_not_array",
+          output_schema={
+              "type": "object",
+              "required": ["extractions"],
+              "properties": {"extractions": {"type": "object"}},
+          },
+          error_regex="array property",
+      ),
+      dict(
+          testcase_name="items_not_object_schema",
+          output_schema={
+              "type": "object",
+              "required": ["extractions"],
+              "properties": {
+                  "extractions": {
+                      "type": "array",
+                      "items": {"type": "string"},
+                  }
+              },
+          },
+          error_regex="inline object schema",
+      ),
+      dict(
+          testcase_name="items_without_properties",
+          output_schema={
+              "type": "object",
+              "required": ["extractions"],
+              "properties": {
+                  "extractions": {
+                      "type": "array",
+                      "items": {"type": "object"},
+                  }
+              },
+          },
+          error_regex="extraction-class properties",
+      ),
+      dict(
+          testcase_name="reserved_item_keys",
+          output_schema={
+              "type": "object",
+              "required": ["extractions"],
+              "properties": {
+                  "extractions": {
+                      "type": "array",
+                      "items": {
+                          "type": "object",
+                          "properties": {
+                              "extraction_class": {"type": "string"},
+                              "extraction_text": {"type": "string"},
+                          },
+                      },
+                  }
+              },
+          },
+          error_regex="extraction_class, extraction_text",
+      ),
+  )
+  def test_rejects_invalid_envelopes(self, output_schema, error_regex):
+    with self.assertRaisesRegex(exceptions.InferenceConfigError, error_regex):
+      lx_schema.validate_output_schema(output_schema)
+
+
+class FromSchemaDictTest(absltest.TestCase):
+  """Tests for provider from_schema_dict implementations."""
+
+  def setUp(self):
+    super().setUp()
+    self.envelope = lx_schema.extractions_schema(
+        lx_schema.extraction_item_schema(
+            "condition",
+            attributes={
+                "status": {"type": "string", "enum": ["active", "resolved"]}
+            },
+        )
+    )
+
+  def test_base_schema_rejects_user_schemas_by_default(self):
+    with self.assertRaises(NotImplementedError):
+      schema.FormatModeSchema.from_schema_dict(self.envelope)
+
+  def test_gemini_from_schema_dict_targets_json_schema_field(self):
+    gemini_schema = schemas.gemini.GeminiSchema.from_schema_dict(self.envelope)
+
+    provider_config = gemini_schema.to_provider_config()
+
+    self.assertEqual(provider_config["response_json_schema"], self.envelope)
+    self.assertEqual(provider_config["response_mime_type"], "application/json")
+    self.assertTrue(gemini_schema.from_output_schema)
+    self.assertTrue(gemini_schema.requires_raw_output)
+
+  def test_gemini_from_schema_dict_validates_envelope(self):
+    with self.assertRaisesRegex(
+        exceptions.InferenceConfigError, "array property"
+    ):
+      schemas.gemini.GeminiSchema.from_schema_dict({
+          "type": "object",
+          "required": ["extractions"],
+          "properties": {"extractions": {"type": "object"}},
+      })
+
+  def test_openai_from_schema_dict_builds_response_format(self):
+    openai_schema = schemas.openai.OpenAISchema.from_schema_dict(self.envelope)
+
+    response_format = openai_schema.response_format
+
+    self.assertEqual(response_format["type"], "json_schema")
+    self.assertEqual(response_format["json_schema"]["schema"], self.envelope)
+    self.assertIs(response_format["json_schema"]["strict"], True)
+    self.assertTrue(openai_schema.from_output_schema)
+    self.assertTrue(openai_schema.requires_raw_output)
+
+  def test_openai_from_schema_dict_rejects_invalid_schema_name(self):
+    with self.assertRaisesRegex(exceptions.InferenceConfigError, "schema_name"):
+      schemas.openai.OpenAISchema.from_schema_dict(
+          self.envelope, schema_name="bad name!"
       )
 
 

--- a/tests/test_gemini_batch_api.py
+++ b/tests/test_gemini_batch_api.py
@@ -194,20 +194,19 @@ class TestGeminiBatchAPI(absltest.TestCase):
     mock_client.batches.create.return_value = create_mock_batch_job()
     mock_client.batches.get.return_value = create_mock_batch_job()
 
-    mock_schema = mock.create_autospec(
-        schemas.gemini.GeminiSchema, instance=True
+    gemini_schema = schemas.gemini.GeminiSchema(
+        _schema_dict={
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        }
     )
-    mock_schema.schema_dict = {
-        "type": "object",
-        "properties": {"name": {"type": "string"}},
-    }
 
     model = gemini.GeminiLanguageModel(
         model_id="gemini-3.5-flash",
         vertexai=True,
         project="p",
         location="l",
-        gemini_schema=mock_schema,
+        gemini_schema=gemini_schema,
         batch={
             "enabled": True,
             "threshold": 1,
@@ -235,7 +234,7 @@ class TestGeminiBatchAPI(absltest.TestCase):
               ],
               "generationConfig": {
                   "responseMimeType": "application/json",
-                  "responseSchema": mock_schema.schema_dict,
+                  "responseSchema": gemini_schema.schema_dict,
                   "temperature": 0.0,
               },
           }],
@@ -245,7 +244,7 @@ class TestGeminiBatchAPI(absltest.TestCase):
           "l",  # location
       )
 
-    self.assertEqual(model.gemini_schema.schema_dict, mock_schema.schema_dict)
+    self.assertEqual(model.gemini_schema.schema_dict, gemini_schema.schema_dict)
 
   @mock.patch.object(genai, "Client", autospec=True)
   def test_batch_error_handling(self, mock_client_cls):
@@ -456,7 +455,7 @@ class EmptyAndPaddingTest(absltest.TestCase):
         client=mock_client_cls.return_value,
         model_id="m",
         prompts=[],
-        schema_dict=None,
+        schema_config=None,
         gen_config={},
         cfg=gb.BatchConfig(
             enabled=True,
@@ -497,7 +496,7 @@ class EmptyAndPaddingTest(absltest.TestCase):
           client=mock_client,
           model_id="m",
           prompts=["p1", "p2"],
-          schema_dict=None,
+          schema_config=None,
           gen_config={},
           cfg=cfg,
       )
@@ -537,7 +536,7 @@ class GCSBatchCachingTest(absltest.TestCase):
         client=mock_client,
         model_id="m",
         prompts=["p1"],
-        schema_dict=None,
+        schema_config=None,
         gen_config={},
         cfg=cfg,
     )
@@ -598,7 +597,7 @@ class GCSBatchCachingTest(absltest.TestCase):
           client=mock_client,
           model_id="m",
           prompts=["cached_prompt", "new_prompt"],
-          schema_dict=None,
+          schema_config=None,
           gen_config={},
           cfg=cfg,
       )
@@ -707,6 +706,99 @@ class GCSBatchCachingTest(absltest.TestCase):
     self.assertEqual(
         cache._compute_hash(with_complex_types), cache._compute_hash(normalized)
     )
+
+
+class BatchOutputSchemaRequestTest(absltest.TestCase):
+  """Tests for lowering provider schema config into batch REST requests."""
+
+  def test_build_request_lowers_json_schema_config(self):
+    schema_config = {
+        "response_json_schema": {"type": "object", "properties": {}},
+        "response_mime_type": "application/json",
+    }
+
+    request = gb._build_request("prompt", schema_config, None)
+
+    generation_config = request["generationConfig"]
+    self.assertEqual(
+        generation_config["responseJsonSchema"],
+        schema_config["response_json_schema"],
+    )
+    self.assertEqual(generation_config["responseMimeType"], "application/json")
+    self.assertNotIn("responseSchema", generation_config)
+
+  def test_build_request_lowers_response_schema_config(self):
+    schema_config = {
+        "response_schema": {"type": "object", "properties": {}},
+        "response_mime_type": "application/json",
+    }
+
+    request = gb._build_request("prompt", schema_config, None)
+
+    generation_config = request["generationConfig"]
+    self.assertEqual(
+        generation_config["responseSchema"], schema_config["response_schema"]
+    )
+    self.assertNotIn("responseJsonSchema", generation_config)
+
+  @mock.patch.object(genai, "Client", autospec=True)
+  def test_batch_with_output_schema_uses_json_schema_field(
+      self, mock_client_cls
+  ):
+    """User output_schema flows to batch requests as responseJsonSchema."""
+    mock_client = mock_client_cls.return_value
+    mock_client.vertexai = True
+
+    with mock.patch.object(gb.storage, "Client", autospec=True) as storage_cls:
+      bucket = storage_cls.return_value.bucket.return_value
+      output_blob = mock.create_autospec(gb.storage.Blob, instance=True)
+      output_blob.name = f"output{gb._EXT_JSONL}"
+      output_blob.open.return_value.__enter__.return_value = io.StringIO(
+          _create_batch_response(0, {"extractions": []})
+      )
+      bucket.list_blobs.return_value = [output_blob]
+
+      mock_client.batches.create.return_value = create_mock_batch_job()
+      mock_client.batches.get.return_value = create_mock_batch_job()
+
+      output_schema = {
+          "type": "object",
+          "properties": {
+              "extractions": {
+                  "type": "array",
+                  "items": {
+                      "type": "object",
+                      "properties": {"condition": {"type": "string"}},
+                  },
+              }
+          },
+          "required": ["extractions"],
+      }
+      model = gemini.GeminiLanguageModel(
+          model_id="gemini-3.5-flash",
+          vertexai=True,
+          project="p",
+          location="l",
+          batch={
+              "enabled": True,
+              "threshold": 1,
+              "enable_caching": False,
+              "retention_days": None,
+          },
+      )
+      model.apply_output_schema(output_schema)
+
+      with mock.patch.object(gb, "_submit_file", autospec=True) as mock_submit:
+        mock_submit.return_value = create_mock_batch_job()
+
+        list(model.infer(["test prompt"]))
+
+        request = mock_submit.call_args[0][2][0]
+        generation_config = request["generationConfig"]
+        self.assertEqual(generation_config["responseJsonSchema"], output_schema)
+        self.assertEqual(
+            generation_config["responseMimeType"], "application/json"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -1182,3 +1182,78 @@ class TestLiveAPIOpenAI(unittest.TestCase):
 
     assert result is not None
     self.assertIsInstance(result, lx.data.AnnotatedDocument)
+
+
+class TestLiveAPIOutputSchema(unittest.TestCase):
+  """Live tests for user-provided output_schema support."""
+
+  _OUTPUT_SCHEMA = {
+      "type": "object",
+      "properties": {
+          "extractions": {
+              "type": "array",
+              "items": {
+                  "type": "object",
+                  "properties": {
+                      "condition": {"type": "string"},
+                      "condition_attributes": {
+                          "type": "object",
+                          "properties": {
+                              "status": {
+                                  "type": "string",
+                                  "enum": ["active", "resolved"],
+                              }
+                          },
+                          "required": ["status"],
+                          "additionalProperties": False,
+                      },
+                  },
+                  "required": ["condition", "condition_attributes"],
+                  "additionalProperties": False,
+              },
+          }
+      },
+      "required": ["extractions"],
+      "additionalProperties": False,
+  }
+  _INPUT_TEXT = "Patient has active hypertension and a resolved infection."
+
+  def _assert_schema_constrained_extractions(self, result):
+    self.assertIsInstance(result, lx.data.AnnotatedDocument)
+    self.assertTrue(result.extractions)
+    for extraction in result.extractions:
+      self.assertEqual(extraction.extraction_class, "condition")
+      if extraction.attributes:
+        self.assertIn(
+            extraction.attributes.get("status"), ("active", "resolved")
+        )
+
+  @skip_if_no_gemini
+  @live_api
+  def test_gemini_extract_with_output_schema(self):
+    result = lx.extract(
+        text_or_documents=self._INPUT_TEXT,
+        prompt_description=(
+            "Extract medical conditions with their status attribute."
+        ),
+        model_id=DEFAULT_GEMINI_MODEL,
+        api_key=GEMINI_API_KEY,
+        output_schema=self._OUTPUT_SCHEMA,
+    )
+
+    self._assert_schema_constrained_extractions(result)
+
+  @skip_if_no_openai
+  @live_api
+  def test_openai_extract_with_output_schema(self):
+    result = lx.extract(
+        text_or_documents=self._INPUT_TEXT,
+        prompt_description=(
+            "Extract medical conditions with their status attribute."
+        ),
+        model_id=DEFAULT_OPENAI_MODEL,
+        api_key=OPENAI_API_KEY,
+        output_schema=self._OUTPUT_SCHEMA,
+    )
+
+    self._assert_schema_constrained_extractions(result)

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -20,6 +20,8 @@ import requests
 
 import langextract as lx
 
+pytestmark = pytest.mark.integration
+
 
 def _ollama_available():
   """Check if Ollama is running on localhost:11434."""

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
 deps =
     .[openai,dev,test]
 commands =
-    pytest -ra -m "not live_api and not requires_pip"
+    pytest -ra -m "not live_api and not requires_pip and not integration"
 
 [testenv:format]
 skip_install = true
@@ -50,9 +50,12 @@ basepython = python3.11
 passenv =
     GEMINI_API_KEY
     LANGEXTRACT_API_KEY
+    LANGEXTRACT_RUN_OPENAI_BATCH_LIVE_TESTS
     OPENAI_API_KEY
     GOOGLE_APPLICATION_CREDENTIALS
     GOOGLE_CLOUD_PROJECT
+    VERTEX_LOCATION
+    VERTEX_PROJECT
 deps = .[all,dev,test]
 commands =
     pytest tests/test_live_api.py -v -m live_api --maxfail=1


### PR DESCRIPTION
Fixes #128.

## Summary

- Add an `output_schema` parameter to `lx.extract()` and the factory that constrains raw model output with a user-provided JSON schema instead of example-derived constraints; examples become optional when it is set.
- Add `lx.schema.extractions_schema()` / `lx.schema.extraction_item_schema()` helpers that emit envelope schemas compatible with OpenAI strict structured outputs and Gemini's native JSON Schema field.
- Support Gemini (`response_json_schema`, including Vertex batch) and OpenAI (`response_format` with `json_schema`); unsupported providers raise a clear error, and conflicting options (forced fences, YAML, provider schema kwargs) are rejected early. Batch cache keys now include the schema config, so cached batch results recompute once.
- Fix pytest collection of `test_*.py` suites (previously dormant) and make built-in provider registration recover after `registry.clear()`.
- Add usage docs in `docs/examples/output_schema.md`.

## Tests

- `.venv/bin/python -m pytest tests -ra -m "not live_api and not requires_pip and not integration"`
- `.venv/bin/python -m pytest tests/test_live_api.py::TestLiveAPIOutputSchema -v -m live_api`
- `.venv/bin/python -m tox -e format`
- `.venv/bin/python -m tox -e lint-src`
- `.venv/bin/python -m tox -e lint-tests`
