### PR TITLE
Prepare v1.6.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,8 +24,8 @@ keywords:
   - machine-learning
   - python
 license: Apache-2.0
-version: 1.5.0
-date-released: 2026-05-20
+version: 1.6.0
+date-released: 2026-07-02
 
 doi: "10.5281/zenodo.17015089"
 identifiers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langextract"
-version = "1.5.0"
+version = "1.6.0"
 description = "LangExtract: A library for extracting structured data from language models"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare the LangExtract v1.6.0 release metadata.

This PR only updates package/citation metadata:

- `pyproject.toml`: `1.5.0` -> `1.6.0`
- `CITATION.cff`: `1.5.0` -> `1.6.0`, release date `2026-07-02`

## Release highlights

- Add user-provided `output_schema` support for Gemini and OpenAI.
- Add Ollama GPT-OSS JSON chat support.

## Verification

- Post-merge `main` CI for #483 passed, including `live-api-tests`: https://github.com/google/langextract/actions/runs/28569183177
- `tox -e format`
