### PR TITLE
Route MiniMax-M3 and MiniMax-M2.7 to the OpenAI provider

### DIFF
--- a/langextract/providers/patterns.py
+++ b/langextract/providers/patterns.py
@@ -28,6 +28,7 @@ OPENAI_PATTERNS = (
     r'^gpt4\.',
     r'^gpt-5',
     r'^gpt5\.',
+    r'^MiniMax-M2\.7$',
     r'^MiniMax-M3$',
 )
 OPENAI_PRIORITY = 10

--- a/langextract/providers/patterns.py
+++ b/langextract/providers/patterns.py
@@ -28,6 +28,7 @@ OPENAI_PATTERNS = (
     r'^gpt4\.',
     r'^gpt-5',
     r'^gpt5\.',
+    r'^MiniMax-M3$',
 )
 OPENAI_PRIORITY = 10
 

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -149,6 +149,17 @@ class RegistryTest(absltest.TestCase):
 
     self.assertEqual(router.list_providers(), first_providers)
 
+  def test_minimax_models_resolve_to_openai_provider(self):
+    """MiniMax model IDs use the existing OpenAI provider routing."""
+    providers_module._builtins_loaded = False  # pylint: disable=protected-access
+    providers_module.load_builtins_once()
+
+    for model_id in ("MiniMax-M3", "MiniMax-M2.7"):
+      with self.subTest(model_id=model_id):
+        self.assertEqual(
+            router.resolve(model_id).__name__, "OpenAILanguageModel"
+        )
+
   def test_list_entries(self):
     """Test listing registered entries."""
     router.register_lazy(r"^test1", target="fake:Target1", priority=5)


### PR DESCRIPTION
# Description

Add exact model-ID routing for `MiniMax-M3` and `MiniMax-M2.7` through the existing OpenAI-compatible provider. Both IDs now resolve to `OpenAILanguageModel`; the change does not add a new API client, protocol adapter, endpoint field, model metadata, or credential handling. Callers continue to provide their OpenAI-compatible base URL through the existing provider configuration.

The code change is limited to:

- `langextract/providers/patterns.py`: register the two exact model IDs.
- `tests/registry_test.py`: verify that both IDs resolve to the existing OpenAI provider.

This repository requires a linked issue with community discussion and at least five unique thumbs-up reactions. No qualifying issue is currently available for this change, so that repository policy remains outstanding.

# How Has This Been Tested?

- `python3 -m py_compile langextract/providers/patterns.py`
- `python3 -m py_compile tests/registry_test.py`
- A dependency-free assertion that both exact model IDs match `OPENAI_PATTERNS`
- `git diff HEAD^ HEAD --check`
- GitHub Actions: `format-check`, `test (3.10)`, `test (3.11)`, `test (3.12)`, `plugin-integration-test`, and `ollama-integration-test`

The targeted registry test could not start locally because the environment does not provide `absl` or `pytest`. It passed in the hosted Python jobs with project dependencies installed.

# Checklist

- [x] I have read the contribution guidelines and kept the change focused.
- [ ] The Google CLA check is passing.
- [ ] The change is linked to a qualifying issue with the required community support.
- [x] No documentation changes are needed because the existing provider configuration remains unchanged.
- [x] A focused registry test covers both model IDs.
- [x] The changed Python files compile and the committed diff passes whitespace checks.
