### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/skills/langextract-usage/SKILL.md
+++ b/skills/langextract-usage/SKILL.md
@@ -15,7 +15,7 @@ example and input text. `prompt_description` is optional but recommended.
 pip install langextract
 
 # For OpenAI model support:
-pip install langextract[openai]
+pip install 'langextract[openai]'
 ```
 
 ## API keys


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `skills/langextract-usage/SKILL.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`