### PR TITLE
Route OpenAI reasoning and GPT-3.5 models

### DIFF
--- a/langextract/factory.py
+++ b/langextract/factory.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import dataclasses
 import os
+import re
 import typing
 import warnings
 
@@ -32,6 +33,7 @@ from langextract.core import exceptions
 from langextract.core import output_schema as output_schema_lib
 from langextract.core import schema as core_schema
 from langextract.core import types as core_types
+from langextract.providers import patterns
 from langextract.providers import router
 
 
@@ -69,13 +71,17 @@ def _kwargs_with_environment_defaults(
 
   if "api_key" not in resolved and not resolved.get("vertexai", False):
     model_lower = model_id.lower()
-    env_vars_by_provider = {
+    env_vars_by_model_pattern = {
         "gemini": ("GEMINI_API_KEY", "LANGEXTRACT_API_KEY"),
         "gpt": ("OPENAI_API_KEY", "LANGEXTRACT_API_KEY"),
+        patterns.OPENAI_REASONING_PATTERN: (
+            "OPENAI_API_KEY",
+            "LANGEXTRACT_API_KEY",
+        ),
     }
 
-    for provider_prefix, env_vars in env_vars_by_provider.items():
-      if provider_prefix in model_lower:
+    for model_pattern, env_vars in env_vars_by_model_pattern.items():
+      if re.search(model_pattern, model_lower):
         found_keys = []
         for env_var in env_vars:
           key_val = os.getenv(env_var)

--- a/langextract/providers/patterns.py
+++ b/langextract/providers/patterns.py
@@ -24,10 +24,12 @@ GEMINI_PRIORITY = 10
 
 # OpenAI provider patterns
 OPENAI_PATTERNS = (
+    r'^gpt-3\.5',  # gpt-3.5-turbo, gpt-3.5-turbo-16k, etc.
     r'^gpt-4',
     r'^gpt4\.',
     r'^gpt-5',
     r'^gpt5\.',
+    r'^o[1-9]',  # reasoning models: o1, o3, o3-mini, o4-mini, etc.
 )
 OPENAI_PRIORITY = 10
 

--- a/langextract/providers/patterns.py
+++ b/langextract/providers/patterns.py
@@ -23,11 +23,14 @@ GEMINI_PATTERNS = (r'^gemini',)
 GEMINI_PRIORITY = 10
 
 # OpenAI provider patterns
+OPENAI_REASONING_PATTERN = r'^o[1-9]'
 OPENAI_PATTERNS = (
+    r'^gpt-3\.5',
     r'^gpt-4',
     r'^gpt4\.',
     r'^gpt-5',
     r'^gpt5\.',
+    OPENAI_REASONING_PATTERN,
 )
 OPENAI_PRIORITY = 10
 

--- a/skills/langextract-usage/references/providers.md
+++ b/skills/langextract-usage/references/providers.md
@@ -29,21 +29,24 @@ result = lx.extract(
 
 Env: `OPENAI_API_KEY` (falls back to `LANGEXTRACT_API_KEY`).
 
-The OpenAI provider uses JSON mode (`response_format={"type":"json_object"}`)
-and reports `requires_fence_output=False`. Leave `fence_output` unset —
+The OpenAI provider uses JSON Schema constraints by default. For models
+without JSON Schema support, such as `gpt-3.5-turbo`, set
+`use_schema_constraints=False` to use JSON mode
+(`response_format={"type":"json_object"}`). Leave `fence_output` unset —
 `extract()` and the factory/provider layer auto-determine fence behavior
 from the provider's schema. The OpenAI provider parallelizes batched
 prompts with a `ThreadPoolExecutor` when `max_workers > 1`.
 
-The OpenAI provider does not expose a schema class, so
-`use_schema_constraints` is a no-op here. You can omit it (as shown above)
-or leave it at its default.
+**Auto-routing scope:** the built-in OpenAI provider matches GPT-3.5,
+GPT-4, GPT-5, and o-series model IDs (`^gpt-3\.5`, `^gpt-4`, `^gpt4\.`,
+`^gpt-5`, `^gpt5\.`, `^o[1-9]`). Both GPT and o-series IDs use the
+environment API keys above. Routing does not guarantee that a model
+supports every request option: o-series models currently require omitting
+`max_output_tokens`, which this provider maps to the unsupported
+`max_tokens` parameter.
 
-**Auto-routing scope:** the built-in OpenAI provider only auto-matches
-GPT-style `model_id`s (`^gpt-4`, `^gpt4\.`, `^gpt-5`, `^gpt5\.`), and the
-environment-default API-key lookup keys off `"gpt"` rather than
-`"openai"`. For **OpenAI-compatible endpoints** (LiteLLM, local servers,
-custom base URLs) or **non-GPT model IDs**, use `ModelConfig` with an
+For **OpenAI-compatible endpoints** (LiteLLM, local servers, custom base
+URLs) or model IDs outside these families, use `ModelConfig` with an
 explicit provider and kwargs:
 
 ```python

--- a/tests/factory_test.py
+++ b/tests/factory_test.py
@@ -23,12 +23,120 @@ import os
 from unittest import mock
 
 from absl.testing import absltest
+from absl.testing import parameterized
+import openai as openai_sdk
+from openai.resources import chat as chat_resources
+from openai.types import chat
 
 from langextract import exceptions
 from langextract import factory
+from langextract import providers
+import langextract as lx
 from langextract.core import base_model
+from langextract.core import data
 from langextract.core import types
 from langextract.providers import router
+
+
+class OpenAIRoutingExtractionTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    router.clear()
+    self.addCleanup(router.clear)
+    self.enter_context(
+        mock.patch.object(providers, "load_plugins_once", autospec=True)
+    )
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="fallback",
+          env={"LANGEXTRACT_API_KEY": "fallback"},
+          kwargs={},
+          expected="fallback",
+      ),
+      dict(
+          testcase_name="provider_precedence",
+          env={"OPENAI_API_KEY": "provider", "LANGEXTRACT_API_KEY": "fallback"},
+          kwargs={},
+          expected="provider",
+      ),
+      dict(
+          testcase_name="explicit_precedence",
+          env={"OPENAI_API_KEY": "env"},
+          kwargs={"api_key": "explicit"},
+          expected="explicit",
+      ),
+  )
+  def test_reasoning_model_key_precedence(self, env, kwargs, expected):
+    with mock.patch.dict(os.environ, env, clear=True):
+      result = factory._kwargs_with_environment_defaults("o3-mini", kwargs)
+
+    self.assertEqual(result["api_key"], expected)
+
+  @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True)
+  def test_unrelated_o_prefix_does_not_receive_openai_key(self):
+    result = factory._kwargs_with_environment_defaults("openchat", {})
+
+    self.assertNotIn("api_key", result)
+
+  @parameterized.named_parameters(
+      dict(testcase_name="o1", model_id="o1"),
+      dict(testcase_name="o3_mini", model_id="o3-mini"),
+      dict(testcase_name="o4_mini", model_id="o4-mini"),
+      dict(testcase_name="gpt35", model_id="gpt-3.5-turbo"),
+  )
+  @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True)
+  @mock.patch.object(openai_sdk, "OpenAI", autospec=True)
+  def test_extract_with_environment_key(self, mock_client_class, model_id):
+    client = mock_client_class.return_value
+    client.chat = chat_resources.Chat(client)
+    mock_create = self.enter_context(
+        mock.patch.object(chat_resources.Completions, "create", autospec=True)
+    )
+    mock_create.return_value = chat.ChatCompletion(
+        id="test",
+        created=0,
+        model=model_id,
+        object="chat.completion",
+        choices=[{
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {
+                "role": "assistant",
+                "content": '{"extractions": [{"person": "Bob"}]}',
+            },
+        }],
+    )
+
+    result = lx.extract(
+        text_or_documents="Bob arrived.",
+        prompt_description="Extract person names.",
+        examples=[
+            data.ExampleData(
+                text="Alice arrived.",
+                extractions=[
+                    data.Extraction(
+                        extraction_class="person", extraction_text="Alice"
+                    )
+                ],
+            )
+        ],
+        model_id=model_id,
+        use_schema_constraints=False,
+        show_progress=False,
+    )
+
+    self.assertLen(result.extractions, 1)
+    extraction = result.extractions[0]
+    self.assertEqual(extraction.extraction_class, "person")
+    self.assertEqual(extraction.extraction_text, "Bob")
+    self.assertEqual(extraction.char_interval, data.CharInterval(0, 3))
+    self.assertEqual(mock_client_class.call_args.kwargs["api_key"], "test-key")
+    mock_create.assert_called_once()
+    request = mock_create.call_args.kwargs
+    self.assertEqual(request["model"], model_id)
+    self.assertNotIn("temperature", request)
 
 
 class FakeGeminiProvider(base_model.BaseLanguageModel):
@@ -70,9 +178,7 @@ class FactoryTest(absltest.TestCase):  # pylint: disable=too-many-public-methods
   def setUp(self):
     super().setUp()
     router.clear()
-    import langextract.providers as providers_module  # pylint: disable=import-outside-toplevel
-
-    providers_module._plugins_loaded = True
+    self.enter_context(mock.patch.object(providers, "_plugins_loaded", True))
     # Use direct registration for test providers to avoid module path issues
     router.register(r"^gemini", priority=100)(FakeGeminiProvider)
     router.register(r"^gpt", r"^o1", priority=100)(FakeOpenAIProvider)
@@ -80,9 +186,6 @@ class FactoryTest(absltest.TestCase):  # pylint: disable=too-many-public-methods
   def tearDown(self):
     super().tearDown()
     router.clear()
-    import langextract.providers as providers_module  # pylint: disable=import-outside-toplevel
-
-    providers_module._plugins_loaded = False
 
   def test_create_model_basic(self):
     """Test basic model creation."""

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -149,6 +149,20 @@ class RegistryTest(absltest.TestCase):
 
     self.assertEqual(router.list_providers(), first_providers)
 
+  def test_openai_patterns_cover_reasoning_and_gpt35_models(self):
+    """OpenAI o-series and gpt-3.5 model IDs resolve to the OpenAI provider."""
+    providers_module._builtins_loaded = False  # pylint: disable=protected-access
+    providers_module.load_builtins_once()
+
+    for model_id in ("o1", "o3-mini", "o4-mini", "gpt-3.5-turbo", "gpt-4o"):
+      with self.subTest(model_id=model_id):
+        resolved = router.resolve(model_id)
+        self.assertEqual(resolved.__name__, "OpenAILanguageModel")
+
+    # The o-series pattern must not swallow other o-prefixed model IDs.
+    with self.assertRaises(exceptions.InferenceConfigError):
+      router.resolve("openchat")
+
   def test_list_entries(self):
     """Test listing registered entries."""
     router.register_lazy(r"^test1", target="fake:Target1", priority=5)

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -29,6 +29,7 @@ from langextract import providers as providers_module
 from langextract.core import base_model
 from langextract.core import types
 from langextract.providers import builtin_registry
+from langextract.providers import openai
 from langextract.providers import router
 
 
@@ -148,6 +149,20 @@ class RegistryTest(absltest.TestCase):
     providers_module.load_builtins_once()
 
     self.assertEqual(router.list_providers(), first_providers)
+
+  def test_openai_patterns_cover_reasoning_and_gpt35_models(self):
+    providers_module.load_builtins_once()
+
+    for model_id in ("o1", "o3-mini", "o4-mini", "gpt-3.5-turbo", "gpt-4o"):
+      with self.subTest(model_id=model_id):
+        resolved = router.resolve(model_id)
+        self.assertIs(resolved, openai.OpenAILanguageModel)
+
+  def test_openai_patterns_do_not_capture_unrelated_o_prefix(self):
+    providers_module.load_builtins_once()
+
+    with self.assertRaises(exceptions.InferenceConfigError):
+      router.resolve("openchat")
 
   def test_list_entries(self):
     """Test listing registered entries."""


### PR DESCRIPTION
# Description

Fixes #492.

Route OpenAI o-series and GPT-3.5 model IDs to the OpenAI provider. Reasoning models also load `OPENAI_API_KEY`, with the existing explicit-key precedence and `LANGEXTRACT_API_KEY` fallback.

Tests cover provider selection, key precedence, and source-grounded extraction. Provider documentation now describes the routing and compatibility limits: GPT-3.5 needs `use_schema_constraints=False`; reasoning-model token-budget support remains a separate follow-up.

# How Has This Been Tested?

- `tox -p auto -e py310,py311,py313,format,lint-src,lint-tests`: 838 unit tests pass per Python version; formatting and lint pass.
- `pytest tests/factory_test.py tests/registry_test.py -q`: 46 tests pass with minimum SDK versions.
- Live extraction: `o3-mini` with default settings; `gpt-3.5-turbo` with schema constraints disabled. Both return correctly grounded text.

# Checklist

- [x] Tests cover the routing and API-key behavior.
- [x] Formatting, lint, and local tests pass.
- [x] Provider documentation reflects compatibility limits.
