### PR TITLE
Add How to Cite section and ORCID to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,6 +13,13 @@ authors:
     family-names: Goel
     email: goelak@google.com
     affiliation: Google LLC
+    orcid: "https://orcid.org/0000-0003-4833-9356"
+contact:
+  - given-names: Akshay
+    family-names: Goel
+    email: goelak@google.com
+    affiliation: Google LLC
+    orcid: "https://orcid.org/0000-0003-4833-9356"
 repository-code: "https://github.com/google/langextract"
 url: "https://github.com/google/langextract"
 repository: "https://github.com/google/langextract"
@@ -27,6 +34,11 @@ license: Apache-2.0
 version: 1.6.0
 date-released: 2026-07-02
 
+# The concept DOI here is deliberate: it needs no per-release update and always
+# resolves. Zenodo mints a version DOI only on `release: published`, after the
+# version bump lands, so a pinned version DOI would silently disagree with
+# `version:` above until someone hand-fixed it. The README tells paper authors
+# to cite the version DOI of the release they actually ran.
 doi: "10.5281/zenodo.17015089"
 identifiers:
   - type: doi

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [Community Providers](#community-providers)
 - [Contributing](#contributing)
 - [Testing](#testing)
+- [How to Cite](#how-to-cite)
 - [Disclaimer](#disclaimer)
 
 ## Introduction
@@ -430,7 +431,7 @@ with development, testing, and pull requests. You must sign a
 [Contributor License Agreement](https://cla.developers.google.com/about)
 before submitting patches.
 
-
+Thanks to everyone who has [contributed](https://github.com/google/langextract/graphs/contributors).
 
 ## Testing
 
@@ -497,6 +498,25 @@ pylint --rcfile=.pylintrc langextract tests
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full development guidelines.
+
+## How to Cite
+
+If you use LangExtract in your research, please cite it:
+
+```bibtex
+@software{goel_langextract,
+  author  = {Goel, Akshay},
+  title   = {{LangExtract}},
+  year    = {2026},
+  version = {1.6.0},
+  doi     = {10.5281/zenodo.21126643},
+  url     = {https://github.com/google/langextract}
+}
+```
+
+Cite the version you used — each release has its own DOI on
+[Zenodo](https://doi.org/10.5281/zenodo.17015089). If your style rejects
+`@software`, use `@misc`.
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary

- Add a `## How to Cite` section to the README with a copy-pasteable BibTeX
  entry, linked from the table of contents. Previously the only guidance on
  citing was one sentence in the Disclaimer.
- Add an ORCID iD and a `contact:` block to `CITATION.cff`, so generated
  citations attribute to a persistent identifier rather than a bare name
  string.
- Add a one-line contributor acknowledgment under Contributing.

`CITATION.cff` keeps the **concept** DOI in `doi:`, now with a comment
recording why that is deliberate rather than an oversight. Pinning the
per-release **version** DOI there was considered and rejected: Zenodo mints a
version DOI on `release: published`, i.e. after the version bump merges, and
nothing writes back to the repo — so a pinned version DOI would name vX.Y.Z
while resolving to vX.Y.Z-1 until someone hand-fixed it, and that failure is
silent. The concept DOI always resolves and needs no per-release maintenance.
Version-specific reproducibility guidance lives in the README section instead,
where it actually reaches paper authors.

Follow-up worth doing separately: have `zenodo_publish.py` open a metadata PR
once it holds the newly minted DOI. That would make a pinned version DOI safe.

## Tests

Docs and citation metadata only — no library code touched.

`CITATION.cff` validated against the Citation File Format 1.2.0 schema, and
the generated citation inspected:

```
$ cffconvert --validate -i CITATION.cff
Citation metadata are valid according to schema version 1.2.0.

$ cffconvert -f apalike -i CITATION.cff
Goel A. (2026). LangExtract (version 1.6.0). DOI: 10.5281/zenodo.17015089 URL: https://github.com/google/langextract
```

All README internal anchors re-checked, including the new link to
`#how-to-cite`.
