### PR TITLE
Move concept animation into Introduction and restore logo header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 <p align="center">
   <a href="https://github.com/google/langextract">
-    <picture>
-      <source media="(prefers-reduced-motion: reduce)" srcset="https://raw.githubusercontent.com/google/langextract/main/docs/_static/langextract_concept_still.png" />
-      <img src="https://raw.githubusercontent.com/google/langextract/main/docs/_static/langextract_concept.gif" alt="LangExtract: unstructured text is chunked, extracted in parallel by an LLM, and every extracted value is grounded back to its exact character span in the source" width="880" />
-    </picture>
+    <img src="https://raw.githubusercontent.com/google/langextract/main/docs/_static/logo.svg" alt="LangExtract Logo" width="128" />
   </a>
 </p>
 
@@ -37,6 +34,13 @@
 ## Introduction
 
 LangExtract is a Python library that uses LLMs to extract structured information from unstructured text documents based on user-defined instructions. It processes materials such as clinical notes or reports, identifying and organizing key details while ensuring the extracted data corresponds to the source text.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-reduced-motion: reduce)" srcset="https://raw.githubusercontent.com/google/langextract/main/docs/_static/langextract_concept_still.png" />
+    <img src="https://raw.githubusercontent.com/google/langextract/main/docs/_static/langextract_concept.gif" alt="LangExtract end to end: unstructured text is chunked, extracted in parallel by an LLM, and every extracted value is grounded back to its exact character span in the source" width="880" />
+  </picture>
+</p>
 
 ## Why LangExtract?
 


### PR DESCRIPTION
## Summary

Moves the end-to-end concept animation from the README header into the
Introduction, and restores the logo at the top.

The animation is explanatory content, so it belongs beside the prose it
illustrates — the Introduction paragraph describes exactly what the loop shows
(unstructured text in, structured extractions out, each grounded to its exact
source span). The header goes back to being an identifier.

This also fixes a practical problem with the previous placement: a GIF restarts
at frame 0 on every page load, and frame 0 is the input-text beat, so the header
showed a clinical note rather than any branding for the first three seconds. The
logo does that job properly.

The `<picture>` wrapper and the `prefers-reduced-motion` still move with the
animation, so motion-sensitive readers still get a static equivalent.

## Tests

Docs only — no library code or assets changed; this PR only moves existing
markup. Both image URLs already resolve on `main` (HTTP 200), added in #497.
