### PR TITLE
Fix Zenodo record title capitalization

### DIFF
--- a/.github/scripts/zenodo_publish.py
+++ b/.github/scripts/zenodo_publish.py
@@ -54,6 +54,25 @@ except (KeyError, FileNotFoundError) as e:
   sys.exit(1)
 
 
+def display_name() -> str:
+  """Canonical project name for the record title.
+
+  Sourced from CITATION.cff, which is where the project already declares its
+  citation title. The PyPI name cannot be used directly: str.title() on
+  "langextract" yields "Langextract", which is how the v1.6.0 record ended up
+  mis-capitalized. Read with a narrow regex to avoid a YAML dependency in the
+  release workflow.
+  """
+  try:
+    with open("CITATION.cff", encoding="utf-8") as f:
+      for line in f:
+        if m := re.match(r'^title:\s*["\']?([^"\'\n]+)', line):
+          return m.group(1).strip()
+  except FileNotFoundError:
+    pass
+  return PROJECT.replace("-", " ").title()
+
+
 def _check(r: requests.Response, op: str) -> None:
   """raise_for_status with the response body included for debugging."""
   if not r.ok:
@@ -150,7 +169,7 @@ def update_metadata(draft_id: str) -> None:
   for field in ("creators", "description", "publication_date"):
     if not metadata.get(field) and source_metadata.get(field):
       metadata[field] = source_metadata[field]
-  metadata["title"] = f"{PROJECT.replace('-', ' ').title()} v{VERSION}"
+  metadata["title"] = f"{display_name()} v{VERSION}"
   metadata["version"] = VERSION
   if released := release_date():
     metadata["publication_date"] = released


### PR DESCRIPTION
## Summary

Fixes the Zenodo record title, which currently publishes as **"Langextract
v1.6.0"** with a lowercase `e`.

The cause is in `zenodo_publish.py`: the title was derived from the PyPI package
name via `str.title()`, and `"langextract".title()` returns `"Langextract"`.

```python
# before
metadata["title"] = f"{PROJECT.replace('-', ' ').title()} v{VERSION}"
# -> "Langextract v1.6.0"
```

The title is now sourced from `CITATION.cff`, which is where the project already
declares its canonical citation title (`title: "LangExtract"`), giving one
source of truth for the name across the citation surfaces. It is read with a
narrow regex rather than a YAML parser so the release workflow gains no new
dependency, and it falls back to the previous behaviour if `CITATION.cff` is
missing.

```python
# after
metadata["title"] = f"{display_name()} v{VERSION}"
# -> "LangExtract v1.6.0"
```

This corrects the title from the next release onward. The **already-published
v1.6.0 record still needs a one-time manual correction** in the Zenodo UI, along
with adding the maintainer ORCID to its creator entry — the script preserves
`creators` from the previously published version, so once that record is fixed
the ORCID propagates to every subsequent release automatically.

## Tests

```
$ python3 -m py_compile .github/scripts/zenodo_publish.py    # compiles clean

before: Langextract v1.7.0
after : LangExtract v1.7.0
```

The change is confined to title construction; no other metadata field or API
call is touched.
