### PR TITLE
Update RadExtract demo link to direct app URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ LangExtract excels at extracting structured medical information from clinical te
 
 Explore RadExtract, a live interactive demo on HuggingFace Spaces that shows how LangExtract can automatically structure radiology reports. Try it directly in your browser with no setup required.
 
-**[View RadExtract Demo →](https://huggingface.co/spaces/google/radextract)**
+**[View RadExtract Demo →](https://google-radextract.hf.space/)**
 
 ## Community Providers
 


### PR DESCRIPTION
## Summary

Points the RadExtract demo link at the app itself rather than its Space landing
page, so a reader lands directly in the running demo:

- before: `https://huggingface.co/spaces/google/radextract`
- after: `https://google-radextract.hf.space/`

This also matches the form of the LangExtract demo link added in #500.

Uses `https` rather than `http`; both resolve, and https avoids a redirect and
keeps the README's links consistent.

## Tests

Docs only.

```
https://google-radextract.hf.space/   -> HTTP 200  ("Radiology Report Structuring")
http://google-radextract.hf.space/    -> HTTP 200
```

No other references to the old Spaces URL remain in the repo.
