### PR TITLE
Fix abstract schemas generated by provider plugin script

### DIFF
--- a/scripts/create_provider_plugin.py
+++ b/scripts/create_provider_plugin.py
@@ -301,13 +301,13 @@ def create_schema(
                 }}
 
             @property
-            def supports_strict_mode(self) -> bool:
-                """Whether this schema guarantees valid structured output.
+            def requires_raw_output(self) -> bool:
+                """Whether this schema emits raw JSON without fence markers.
 
                 Returns:
-                    True if the provider enforces valid JSON output.
+                    True because structured output is returned as raw JSON.
                 """
-                return False  # Set to True only if your provider guarantees valid JSON
+                return True
     ''')
 
   (package_dir / "schema.py").write_text(schema_content, encoding="utf-8")

--- a/tests/provider_plugin_test.py
+++ b/tests/provider_plugin_test.py
@@ -19,6 +19,7 @@ few public methods. The too-few-public-methods warnings are expected.
 """
 
 from importlib import metadata
+import importlib.util
 import os
 from pathlib import Path
 import subprocess
@@ -35,6 +36,15 @@ import pytest
 import langextract as lx
 from langextract.core import base_model
 from langextract.core import types
+
+
+def _load_module_from_path(name: str, path: Path):
+  spec = importlib.util.spec_from_file_location(name, path)
+  if spec is None or spec.loader is None:
+    raise ImportError(f"Could not load {path}")
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
 
 
 def _create_mock_entry_points(entry_points_list):
@@ -56,6 +66,27 @@ def _create_mock_entry_points(entry_points_list):
       return []
 
   return MockEntryPoints()
+
+
+class ProviderPluginGeneratorTest(absltest.TestCase):
+
+  def test_generated_schema_can_be_created_from_examples(self):
+    generator = _load_module_from_path(
+        "create_provider_plugin",
+        Path(__file__).parents[1] / "scripts" / "create_provider_plugin.py",
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+      base_dir = Path(tmpdir) / "langextract-myprovider"
+      (base_dir / "langextract_myprovider").mkdir(parents=True)
+      generator.create_schema(base_dir, "MyProvider", "myprovider")
+
+      generated = _load_module_from_path(
+          "generated_schema", base_dir / "langextract_myprovider" / "schema.py"
+      )
+      schema = generated.MyProviderSchema.from_examples([])
+
+    self.assertTrue(schema.requires_raw_output)
 
 
 class PluginSmokeTest(absltest.TestCase):


### PR DESCRIPTION
# Description

Fixes #505
Related to #99

Type: Bug fix

## Summary

The provider plugin generator added in #144 still emits the old
`supports_strict_mode` property. When `BaseSchema` moved to the
`requires_raw_output` contract in #239, the generator template was not updated.
As a result, schemas created with `--with-schema` remain abstract and
`from_examples()` raises a `TypeError`.

This change:

- replaces the stale property with the required `requires_raw_output`
  implementation
- returns `True` because the generated provider configures structured output as
  raw JSON
- adds a regression test that generates and imports the schema, then
  instantiates it through `from_examples()`

The patch is limited to the generator template and its provider-plugin
regression coverage. It restores the documented workflow without changing
runtime APIs.

# How Has This Been Tested?

```bash
pytest -q -m "not live_api and not requires_pip and not integration"
pyink scripts/create_provider_plugin.py tests/provider_plugin_test.py --check --diff --config pyproject.toml
isort scripts/create_provider_plugin.py tests/provider_plugin_test.py --check-only --diff
pylint --rcfile=tests/.pylintrc tests/provider_plugin_test.py
```

The local suite passed with 707 tests and 47 subtests. CI also passes
formatting, Python 3.10 through 3.12, and the plugin and Ollama integration
suites.

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page and am covered by the CLA check.
- [ ] I have discussed the fix with code owners in the linked issue.
- [x] No documentation change is needed because the provider guide already documents `requires_raw_output`.
- [x] I added a regression test that exercises the generated schema.
- [x] I followed Google's Python style guidance and ran `pylint` over the affected test file.
