### PR TITLE
Fix stale OpenAI schema support reference

### DIFF
--- a/skills/langextract-usage/references/providers.md
+++ b/skills/langextract-usage/references/providers.md
@@ -29,15 +29,16 @@ result = lx.extract(
 
 Env: `OPENAI_API_KEY` (falls back to `LANGEXTRACT_API_KEY`).
 
-The OpenAI provider uses JSON mode (`response_format={"type":"json_object"}`)
-and reports `requires_fence_output=False`. Leave `fence_output` unset —
-`extract()` and the factory/provider layer auto-determine fence behavior
-from the provider's schema. The OpenAI provider parallelizes batched
-prompts with a `ThreadPoolExecutor` when `max_workers > 1`.
+The OpenAI provider exposes `OpenAISchema` for structured outputs. By default,
+`extract()` derives schema constraints from the examples and sends them through
+OpenAI's JSON Schema response format. Explicit `output_schema` constraints are
+also supported when the selected model supports structured outputs.
 
-The OpenAI provider does not expose a schema class, so
-`use_schema_constraints` is a no-op here. You can omit it (as shown above)
-or leave it at its default.
+Leave `fence_output` and `use_schema_constraints` unset so `extract()` and the
+factory/provider layer configure them automatically. Without an active schema,
+the provider falls back to JSON mode (`response_format={"type":"json_object"}`).
+The OpenAI provider parallelizes batched prompts with a `ThreadPoolExecutor`
+when `max_workers > 1`.
 
 **Auto-routing scope:** the built-in OpenAI provider only auto-matches
 GPT-style `model_id`s (`^gpt-4`, `^gpt4\.`, `^gpt-5`, `^gpt5\.`), and the


### PR DESCRIPTION
# Description

Fixes #59

Type: Documentation

## Summary

The OpenAI section in the bundled provider reference predates structured-output
support added in #468 and user-provided schemas added in #483. It still says
that OpenAI has no schema class and that `use_schema_constraints` does nothing.

This update:

- documents that the provider exposes `OpenAISchema` and derives constraints
  from examples
- notes that `output_schema` is supported when the selected model supports
  structured outputs
- recommends leaving `fence_output` and `use_schema_constraints` unset so the
  provider can configure them automatically
- keeps the existing JSON-mode fallback and batch-parallelism guidance

Only `skills/langextract-usage/references/providers.md` changes. No runtime
behavior or public API is modified.

# How Has This Been Tested?

The corrected statements were checked against
`OpenAILanguageModel.get_schema_class()`, `OpenAISchema.from_examples()`,
`OpenAISchema.from_schema_dict()`, and the factory defaults.

```bash
git diff --check
awk 'length($0) > 80 {print FNR ":" length($0) ":" $0}' skills/langextract-usage/references/providers.md
```

All required CI checks pass, including formatting, Python 3.10 through 3.12,
and the plugin and Ollama integration suites.

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page and am covered by the CLA check.
- [x] The approach requested in #59 was implemented and accepted in #468; this change completes its documentation requirement.
- [x] I made the needed documentation correction.
- [x] Existing tests cover the documented behavior; this change does not modify code.
- [x] I followed the repository style guidance. `pylint` is not applicable to this Markdown-only change, and the formatting check passes.
