### PR TITLE
fix(gemini): raise on refusal/safety-blocked responses instead of reporting success

### DIFF
--- a/langextract/providers/gemini.py
+++ b/langextract/providers/gemini.py
@@ -348,6 +348,34 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
 
     return bool(_RETRYABLE_MESSAGE_RE.search(str(error)))
 
+  @staticmethod
+  def _describe_missing_gemini_text(response: Any) -> str:
+    """Builds a diagnostic message for a Gemini response with no text.
+
+    `response.text` returns None (not an exception) when the prompt was
+    blocked before generation, when the candidate stopped for a non-STOP
+    reason (safety, recitation, etc.) with no content, or when the response
+    contains only non-text parts (e.g. a function call). Without this,
+    callers previously got ScoredOutput(score=1.0, output=None) reported as
+    a successful empty extraction, silently discarding the actual reason.
+    """
+    prompt_feedback = getattr(response, 'prompt_feedback', None)
+    block_reason = getattr(prompt_feedback, 'block_reason', None)
+    if block_reason:
+      block_message = getattr(prompt_feedback, 'block_reason_message', None)
+      detail = f': {block_message}' if block_message else ''
+      return f'Gemini blocked the prompt ({block_reason}){detail}'
+
+    candidates = getattr(response, 'candidates', None)
+    if candidates:
+      finish_reason = getattr(candidates[0], 'finish_reason', None)
+      if finish_reason and finish_reason != 'STOP':
+        return (
+            f'Gemini response contained no text (finish_reason={finish_reason})'
+        )
+
+    return 'Gemini response contained no text content.'
+
   def _process_single_prompt(
       self, prompt: str, config: dict
   ) -> core_types.ScoredOutput:
@@ -368,8 +396,15 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
         response = self._client.models.generate_content(
             model=self.model_id, contents=prompt, config=call_config
         )
-        return core_types.ScoredOutput(score=1.0, output=response.text)
+        output_text = response.text
+        if output_text is None:
+          raise exceptions.InferenceRuntimeError(
+              self._describe_missing_gemini_text(response)
+          )
+        return core_types.ScoredOutput(score=1.0, output=output_text)
 
+      except exceptions.InferenceRuntimeError:
+        raise
       except Exception as e:
         if attempt < self.max_retries and self._is_retryable_error(e):
           # Cap after jitter so the named maximum applies to the real sleep.

--- a/tests/provider_schema_test.py
+++ b/tests/provider_schema_test.py
@@ -740,5 +740,91 @@ class ApplyOutputSchemaTest(absltest.TestCase):
         model.apply_output_schema(self.output_schema)
 
 
+class GeminiRefusalHandlingTest(absltest.TestCase):
+  """Tests Gemini safety-block and empty-response handling.
+
+  response.text returns None (not an exception) when a prompt is blocked
+  before generation or a candidate stops for a non-STOP reason with no
+  content -- mirrors the OpenAI refusal-handling gap fixed for #491, but
+  for the Gemini realtime path, which was left unaddressed.
+  """
+
+  def setUp(self):
+    super().setUp()
+
+    patcher = mock.patch("google.genai.Client", autospec=True)
+    self.addCleanup(patcher.stop)
+
+    mock_client_cls = patcher.start()
+    self.mock_client = mock_client_cls.return_value
+
+    self.model = gemini.GeminiLanguageModel(
+        model_id="gemini-3.5-flash",
+        api_key="test_key",
+    )
+
+  def test_process_single_prompt_returns_text(self):
+    response = mock.Mock(text="Hello")
+    self.mock_client.models.generate_content.return_value = response
+
+    result = self.model._process_single_prompt("prompt", {})
+
+    self.assertEqual(result.output, "Hello")
+    self.assertEqual(result.score, 1.0)
+
+  def test_process_single_prompt_raises_on_blocked_prompt(self):
+    prompt_feedback = mock.Mock(
+        block_reason="SAFETY", block_reason_message="blocked content"
+    )
+    response = mock.Mock(
+        text=None, prompt_feedback=prompt_feedback, candidates=[]
+    )
+    self.mock_client.models.generate_content.return_value = response
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        "Gemini blocked the prompt \\(SAFETY\\): blocked content",
+    ):
+      self.model._process_single_prompt("prompt", {})
+
+  def test_process_single_prompt_raises_on_non_stop_finish_reason(self):
+    candidate = mock.Mock(finish_reason="SAFETY")
+    response = mock.Mock(
+        text=None, prompt_feedback=None, candidates=[candidate]
+    )
+    self.mock_client.models.generate_content.return_value = response
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        "no text \\(finish_reason=SAFETY\\)",
+    ):
+      self.model._process_single_prompt("prompt", {})
+
+  def test_process_single_prompt_raises_when_no_diagnostic_available(self):
+    response = mock.Mock(text=None, prompt_feedback=None, candidates=[])
+
+    self.mock_client.models.generate_content.return_value = response
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        "contained no text content",
+    ):
+      self.model._process_single_prompt("prompt", {})
+
+  def test_process_single_prompt_does_not_retry_on_refusal(self):
+    prompt_feedback = mock.Mock(
+        block_reason="SAFETY", block_reason_message=None
+    )
+    response = mock.Mock(
+        text=None, prompt_feedback=prompt_feedback, candidates=[]
+    )
+    self.mock_client.models.generate_content.return_value = response
+
+    with self.assertRaises(exceptions.InferenceRuntimeError):
+      self.model._process_single_prompt("prompt", {})
+
+    self.mock_client.models.generate_content.assert_called_once()
+
+
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Fixes #508.

# Description

`GeminiLanguageModel._process_single_prompt` returned `ScoredOutput(score=1.0, output=response.text)` unconditionally. `google.genai`'s `response.text` returns `None` (not an exception) when:

- the prompt was blocked before generation (`prompt_feedback.block_reason` set, no candidates),
- a candidate stopped for a non-`STOP` `finish_reason` (`SAFETY`, `RECITATION`, `PROHIBITED_CONTENT`, etc.) with no content, or
- the response contains only non-text parts.

Every one of these was silently reported as a **successful empty extraction**, discarding the actual block/refusal reason.

This is the same class of bug already fixed for the OpenAI realtime provider in #491 / PR #496. That issue explicitly noted:

> The Gemini realtime path has the same *class* of gap on a safety-blocked `response.text` (version-dependent); worth folding the same guard in there too.

PR #496 only touched `openai.py`, leaving the Gemini side unaddressed. I verified the `None`-on-block/refusal behavior directly against the installed `google-genai` 2.11.0 SDK source (`GenerateContentResponse._get_text`) rather than assuming it from the docstring.

## Fix

After reading `response.text`, check for `None` and raise `InferenceRuntimeError` with the best available diagnostic:

- `prompt_feedback.block_reason` (+ `block_reason_message` if present) for prompt-level blocks,
- `candidates[0].finish_reason` for candidate-level non-`STOP` stops,
- a generic message otherwise.

Also re-raises `InferenceRuntimeError` before the generic retry handler, so a safety-blocked prompt isn't retried with identical content (mirrors the intent of the OpenAI fix).

# How Has This Been Tested?

Added `GeminiRefusalHandlingTest` to `tests/provider_schema_test.py` with 5 tests: successful text passthrough, prompt-level block, candidate-level non-`STOP` finish reason, no-diagnostic-available fallback, and a check that a refusal is not retried. The 4 error-path tests were confirmed to **fail** against the pre-fix code (`git stash` isolating just `gemini.py`).

```bash
.venv/bin/python -m pytest tests/provider_schema_test.py -q
# 32 passed (27 baseline + 5 new), same 1 pre-existing unrelated failure as clean main

.venv/bin/python -m pytest tests -k gemini -q
# 137 passed, 7 skipped (live API creds unavailable), 0 failed

.venv/bin/python -m pytest tests -q -m "not live_api"
# 673 passed (668 baseline + 5 new), same 39 pre-existing unrelated failures
# (OpenAI kwargs passthrough) as clean upstream/main -- no regressions

.venv/bin/python -m tox -e format      # clean
.venv/bin/python -m tox -e lint-src    # clean
.venv/bin/python -m tox -e lint-tests  # 10.00/10
```

# Checklist

- [x] I have read the contribution guidelines.
- [x] I have added or updated tests where appropriate.
- [x] I have verified that all tests pass locally.
- [x] My changes are limited to the scope of this fix.