### PR TITLE
Fix: OpenAI o-series and gpt-3.5 model IDs route to no provider

### DIFF
--- a/langextract/providers/patterns.py
+++ b/langextract/providers/patterns.py
@@ -28,6 +28,8 @@ OPENAI_PATTERNS = (
     r'^gpt4\.',
     r'^gpt-5',
     r'^gpt5\.',
+    r'^gpt-3\.5',
+    r'^o[1-9]',
 )
 OPENAI_PRIORITY = 10
 

--- a/tests/patterns_test.py
+++ b/tests/patterns_test.py
@@ -1,0 +1,62 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the built-in provider routing patterns in patterns.py."""
+
+from absl.testing import absltest
+
+from langextract import providers as providers_module
+from langextract.providers import openai as openai_provider
+from langextract.providers import router
+
+
+class OpenAIPatternsTest(absltest.TestCase):
+  """Regression test for issue #492: o-series and gpt-3.5 model IDs
+  previously matched no provider pattern and raised InferenceConfigError."""
+
+  def setUp(self):
+    super().setUp()
+    router.clear()
+    providers_module._builtins_loaded = False  # pylint: disable=protected-access
+    providers_module.load_builtins_once()
+
+  def tearDown(self):
+    super().tearDown()
+    router.clear()
+    providers_module._builtins_loaded = False  # pylint: disable=protected-access
+
+  def test_reasoning_and_legacy_openai_models_resolve_to_openai_provider(self):
+    model_ids = [
+        "o1",
+        "o1-mini",
+        "o3",
+        "o3-mini",
+        "o4-mini",
+        "gpt-3.5-turbo",
+    ]
+    for model_id in model_ids:
+      with self.subTest(model_id=model_id):
+        resolved = router.resolve(model_id)
+        self.assertEqual(resolved, openai_provider.OpenAILanguageModel)
+
+  def test_ollama_gpt_oss_pattern_is_unaffected(self):
+    # Guards against the new `^o[1-9]` OpenAI pattern accidentally
+    # colliding with Ollama's `^gpt-oss` pattern (it shouldn't - different
+    # literal prefixes - but this pins the expected behavior explicitly).
+    resolved = router.resolve("gpt-oss:20b")
+    self.assertNotEqual(resolved, openai_provider.OpenAILanguageModel)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
# Description

Fixes #492

Bug fix

`OPENAI_PATTERNS` in `langextract/providers/patterns.py` only matched `gpt-4`/`gpt4.`/`gpt-5`/`gpt5.` prefixes. Any OpenAI o-series reasoning model id (`o1`, `o3`, `o3-mini`, `o4-mini`, ...) or a legacy `gpt-3.5-turbo`-style id matched no provider pattern at all, so `factory.create_model()` raised `InferenceConfigError: no provider found` instead of routing to the OpenAI provider. Adds the two missing patterns (`^gpt-3\.5`, `^o[1-9]`).

# How Has This Been Tested?

Added `tests/patterns_test.py` with two tests:
- `test_reasoning_and_legacy_openai_models_resolve_to_openai_provider` -- verifies o-series (`o1`, `o1-mini`, `o3`, `o3-mini`, `o4-mini`) and `gpt-3.5-turbo` all resolve to the OpenAI provider via the router, as subtests.
- `test_ollama_gpt_oss_pattern_is_unaffected` -- guards against the new `o[1-9]` pattern accidentally shadowing Ollama's existing `gpt-oss` model support.

```
$ python -m pytest tests/
61 passed, 3 skipped (pre-existing, unrelated -- missing API keys / no local Ollama)
```

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [x] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes
- [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.
