### PR TITLE
Route OpenAI reasoning and GPT-3.5 model IDs

### DIFF
--- a/langextract/providers/patterns.py
+++ b/langextract/providers/patterns.py
@@ -24,10 +24,12 @@ GEMINI_PRIORITY = 10
 
 # OpenAI provider patterns
 OPENAI_PATTERNS = (
+    r'^gpt-3\.5',
     r'^gpt-4',
     r'^gpt4\.',
     r'^gpt-5',
     r'^gpt5\.',
+    r'^o[1-9]',
 )
 OPENAI_PRIORITY = 10
 

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -29,6 +29,7 @@ from langextract import providers as providers_module
 from langextract.core import base_model
 from langextract.core import types
 from langextract.providers import builtin_registry
+from langextract.providers import patterns
 from langextract.providers import router
 
 
@@ -87,6 +88,14 @@ class RegistryTest(absltest.TestCase):
 
     self.assertEqual(router.resolve("gemini-pro"), FakeProvider)
     self.assertEqual(router.resolve("palm-2"), FakeProvider)
+
+  def test_openai_patterns_include_reasoning_and_gpt_3_5_models(self):
+    """OpenAI reasoning and GPT-3.5 model IDs resolve automatically."""
+    router.register(*patterns.OPENAI_PATTERNS)(FakeProvider)
+
+    for model_id in ("o1", "o3-mini", "o4-mini", "gpt-3.5-turbo"):
+      with self.subTest(model_id=model_id):
+        self.assertEqual(router.resolve(model_id), FakeProvider)
 
   def test_priority_resolution(self):
     """Test that higher priority wins on conflicts."""


### PR DESCRIPTION
# Description

Add the missing OpenAI routing patterns for GPT-3.5 and the o-series reasoning models. Without these patterns, valid model IDs such as `o3-mini` fall through provider resolution before the OpenAI provider can be initialized.

The registry test uses the centralized pattern tuple and verifies representative IDs from both families.

Fixes #492

Bug fix

# How Has This Been Tested?

```text
$ python3 <stdlib pattern contract>
stdlib pattern contract: PASS

$ python3 -m py_compile langextract/providers/patterns.py tests/registry_test.py
```

The full project test suite was not run locally because this focused routing change can be checked with the standard library, while importing the complete package would require installing the project's Google SDK, pandas, NumPy, and other base dependencies. GitHub CI is expected to run the repository test matrix.

# Checklist

- [x] I have read and acknowledged Google's Open Source Code of Conduct.
- [x] I have read the Contributing page.
- [ ] Google CLA status must be confirmed by the repository check.
- [ ] Code-owner agreement is not recorded in issue #492; the implementation follows the issue's proposed two-pattern change.
- [x] No documentation change is needed for this routing-table fix.
- [x] I added a regression test.
- [ ] Full pylint was not run locally; affected files follow the existing 80-column, 2-space style.

AI-assisted tooling was used for repository inspection, test design, and drafting. The code change and validation scope are described above.