### PR TITLE
Fix UnicodeEncodeError in create_provider_plugin.py on Windows

### DIFF
--- a/scripts/create_provider_plugin.py
+++ b/scripts/create_provider_plugin.py
@@ -46,6 +46,13 @@ import sys
 import tempfile
 import textwrap
 
+# Windows consoles default stdout/stderr to the legacy code page (e.g.
+# cp1252), which cannot encode the Unicode checkmarks this script prints.
+# Reconfigure to UTF-8 so `print("✓ ...")` doesn't raise UnicodeEncodeError.
+for _stream in (sys.stdout, sys.stderr):
+  if hasattr(_stream, "reconfigure"):
+    _stream.reconfigure(encoding="utf-8")
+
 _PACKAGE_NAME_RE = re.compile(r"[a-z][a-z0-9_]*")
 
 # Values pip's own option parser treats as true for boolean env vars.
@@ -716,6 +723,12 @@ def create_test_script(
   import os
   import re
   import sys
+
+  # Windows consoles default stdout/stderr to the legacy code page (e.g.
+  # cp1252), which cannot encode the Unicode checkmarks this script prints.
+  for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+      _stream.reconfigure(encoding="utf-8")
 
   # Test the INSTALLED plugin, never the adjacent source tree: drop this
   # script's directory from the import path so an uninstalled plugin

--- a/tests/create_provider_plugin_test.py
+++ b/tests/create_provider_plugin_test.py
@@ -165,6 +165,7 @@ class _CreateProviderPluginTestBase(parameterized.TestCase):
         [sys.executable, str(pathlib.Path(base_dir) / "test_plugin.py")],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
         cwd=cwd or self._make_tempdir(),
         env=self._subprocess_env(extra_path),


### PR DESCRIPTION
# Description

Windows consoles default stdout/stderr to a legacy code page (e.g. cp1252) that cannot encode the Unicode checkmarks (✓/✅) printed by `scripts/create_provider_plugin.py` and the `test_plugin.py` it generates. Both crash with `UnicodeEncodeError`. Reconfigure stdout/stderr to UTF-8 in both places.

Also fixes the test harness's `subprocess.run` call, which decoded the generated script's UTF-8 output using the locale-dependent default encoding, producing mojibake instead of matching the expected checkmark output on Windows.

This is a leftover console-output path of the same Windows cp1252 vs UTF-8 class already validated and fixed for file I/O / HTML export. #158 has community support (6 👍) and established that Windows users hit this encoding class in the getting-started path. #518 documents the remaining generator-script crash.

Fixes #158
Related to #518
Related to #108
Related to #166

Bug fix

# How Has This Been Tested?

On Windows (Python 3.14):

```
$ pip install -e ".[dev,test,openai]"
$ pytest tests/create_provider_plugin_test.py
```

77 passed, 1 skipped (symlink test, unsupported on this filesystem). 15 of those tests were failing before this fix.

```
$ pytest tests/ -m "not live_api and not vertex_ai and not requires_pip"
```

783 passed, 1 skipped.

CI on this PR: format-check, test (3.10 / 3.11 / 3.12), plugin-integration-test, and ollama-integration-test are green.

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [x] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.
