### PR TITLE
fix: route o-series and gpt-3.5 models to the OpenAI provider

### DIFF
--- a/langextract/providers/patterns.py
+++ b/langextract/providers/patterns.py
@@ -28,6 +28,8 @@ OPENAI_PATTERNS = (
     r'^gpt4\.',
     r'^gpt-5',
     r'^gpt5\.',
+    r'^gpt-3\.5',
+    r'^o[1-9]',
 )
 OPENAI_PRIORITY = 10
 

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -18,6 +18,7 @@ Note: This file tests the deprecated registry module which is now an alias
 for router. The no-name-in-module warning for providers.registry is expected.
 Test helper classes also intentionally have few public methods.
 """
+
 # pylint: disable=no-name-in-module
 
 import re
@@ -29,6 +30,9 @@ from langextract import providers as providers_module
 from langextract.core import base_model
 from langextract.core import types
 from langextract.providers import builtin_registry
+from langextract.providers import gemini
+from langextract.providers import ollama
+from langextract.providers import openai
 from langextract.providers import router
 
 
@@ -250,6 +254,45 @@ class RegistryTest(absltest.TestCase):
       with self.subTest(model_id=model_id):
         provider_class = router.resolve(model_id)
         self.assertEqual(provider_class, TestHFProvider)
+
+
+class BuiltinOpenAIRoutingTest(absltest.TestCase):
+  """Built-in OpenAI patterns cover reasoning and legacy model families.
+
+  Regression test for issue #492: o-series reasoning models and the legacy
+  gpt-3.5 family are not covered by OPENAI_PATTERNS, so resolve() raises
+  InferenceConfigError even though OpenAILanguageModel can serve them.
+  """
+
+  def setUp(self):
+    super().setUp()
+    router.clear()
+    providers_module.load_builtins_once()
+
+  def tearDown(self):
+    super().tearDown()
+    router.clear()
+
+  def test_openai_reasoning_models_route_to_openai(self):
+    for model_id in ("o1", "o1-mini", "o1-preview", "o3", "o3-mini", "o4-mini"):
+      with self.subTest(model_id=model_id):
+        self.assertIs(router.resolve(model_id), openai.OpenAILanguageModel)
+
+  def test_legacy_gpt35_models_route_to_openai(self):
+    for model_id in ("gpt-3.5", "gpt-3.5-turbo", "gpt-3.5-turbo-16k"):
+      with self.subTest(model_id=model_id):
+        self.assertIs(router.resolve(model_id), openai.OpenAILanguageModel)
+
+  def test_existing_openai_families_still_route(self):
+    for model_id in ("gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-5"):
+      with self.subTest(model_id=model_id):
+        self.assertIs(router.resolve(model_id), openai.OpenAILanguageModel)
+
+  def test_o_series_does_not_affect_other_providers(self):
+    self.assertIs(
+        router.resolve("gemini-2.0-flash"), gemini.GeminiLanguageModel
+    )
+    self.assertIs(router.resolve("llama3.2:1b"), ollama.OllamaLanguageModel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

`OPENAI_PATTERNS` only covered the gpt-4 / gpt-5 families, so valid OpenAI model IDs like `o1`, `o3-mini`, `o4-mini` and `gpt-3.5-turbo` never matched a provider and `router.resolve` fell through to `InferenceConfigError`, even though `OpenAILanguageModel` can serve them.

This extends the patterns with `^gpt-3\.5` and `^o[1-9]` (matching o1 / o3 / o3-mini / o4-mini and the legacy gpt-3.5 family). Neither pattern collides with the Gemini or Ollama patterns, so other providers are unaffected.

Fixes #492

# How Has This Been Tested?

Added `BuiltinOpenAIRoutingTest` to `tests/registry_test.py`:

- o-series IDs route to `OpenAILanguageModel` (`o1`, `o1-mini`, `o1-preview`, `o3`, `o3-mini`, `o4-mini`)
- legacy `gpt-3.5` IDs route to `OpenAILanguageModel`
- existing gpt-4 / gpt-5 IDs still route correctly
- Gemini and Ollama IDs still resolve to their own providers (no cross-provider capture)

```
pytest tests/registry_test.py
```

Also ran the full unit suite locally: 767 passed. The 10 failures observed are Windows-only (symlink/pip tests in `create_provider_plugin_test.py`), unrelated to this change.

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [ ] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes
- [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.
