### PR TITLE
fix: raise on Gemini responses with no text content

### DIFF
--- a/langextract/providers/gemini.py
+++ b/langextract/providers/gemini.py
@@ -368,8 +368,25 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
         response = self._client.models.generate_content(
             model=self.model_id, contents=prompt, config=call_config
         )
+
+        if response.text is None:
+          block_reason = None
+          prompt_feedback = getattr(response, 'prompt_feedback', None)
+          if prompt_feedback is not None:
+            block_reason = getattr(prompt_feedback, 'block_reason', None)
+          finish_reason = None
+          candidates = getattr(response, 'candidates', None)
+          if candidates:
+            finish_reason = getattr(candidates[0], 'finish_reason', None)
+          raise exceptions.InferenceRuntimeError(
+              'Gemini response contains no text content '
+              f'(block_reason={block_reason}, finish_reason={finish_reason})'
+          )
+
         return core_types.ScoredOutput(score=1.0, output=response.text)
 
+      except exceptions.InferenceRuntimeError:
+        raise
       except Exception as e:
         if attempt < self.max_retries and self._is_retryable_error(e):
           # Cap after jitter so the named maximum applies to the real sleep.

--- a/tests/gemini_retry_test.py
+++ b/tests/gemini_retry_test.py
@@ -514,5 +514,83 @@ class TestGeminiHttpOptionsRetryGuard(_MockClientTest):
     self.assertEqual(model.max_retries, 3)
 
 
+class TestGeminiNoTextResponseHandling(_MockClientTest):
+  """Responses without text content must raise, not return empty success.
+
+  Regression test for issue #508: a safety-blocked prompt or a candidate
+  that stopped without producing text used to be reported as a successful
+  empty extraction (ScoredOutput(score=1.0, output=None)).
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.model = _build_model()
+
+  def _make_no_text_response(self, candidates=None, block_reason=None):
+    """Build a GenerateContentResponse whose text property is None."""
+    response = mock.create_autospec(
+        genai.types.GenerateContentResponse, instance=True
+    )
+    response.text = None
+    response.candidates = [] if candidates is None else candidates
+    response.prompt_feedback = (
+        None if block_reason is None else mock.Mock(block_reason=block_reason)
+    )
+    return response
+
+  def test_text_response_returns_scored_output(self):
+    self.mock_client.models.generate_content.return_value = _make_response(
+        '{"ok": 1}'
+    )
+
+    result = self.model._process_single_prompt('prompt', {'temperature': 0.0})
+
+    self.assertEqual(result.output, '{"ok": 1}')
+    self.assertEqual(result.score, 1.0)
+
+  def test_blocked_prompt_raises_with_block_reason(self):
+    self.mock_client.models.generate_content.return_value = (
+        self._make_no_text_response(candidates=[], block_reason='SAFETY')
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError, 'block_reason=SAFETY'
+    ):
+      self.model._process_single_prompt('prompt', {'temperature': 0.0})
+
+    self.mock_client.models.generate_content.assert_called_once()
+
+  def test_empty_candidate_raises_with_finish_reason(self):
+    candidate = mock.Mock(finish_reason='SAFETY')
+    self.mock_client.models.generate_content.return_value = (
+        self._make_no_text_response(candidates=[candidate])
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError, 'finish_reason=SAFETY'
+    ):
+      self.model._process_single_prompt('prompt', {'temperature': 0.0})
+
+  def test_no_text_response_is_not_retried(self):
+    self.mock_client.models.generate_content.return_value = (
+        self._make_no_text_response()
+    )
+
+    with self.assertRaises(exceptions.InferenceRuntimeError):
+      self.model._process_single_prompt('prompt', {'temperature': 0.0})
+
+    self.assertEqual(self.mock_client.models.generate_content.call_count, 1)
+
+  def test_error_propagates_unwrapped(self):
+    self.mock_client.models.generate_content.return_value = (
+        self._make_no_text_response(candidates=[], block_reason='OTHER')
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError, '^Gemini response contains no text'
+    ):
+      self.model._process_single_prompt('prompt', {'temperature': 0.0})
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# Description

The Gemini realtime path returned a "successful" empty extraction when a prompt was blocked or a candidate stopped without producing text: `GenerateContentResponse.text` is `None` for safety-blocked prompts, candidates with a non-`STOP` finish reason, and non-text-only responses, and `_process_single_prompt` happily returned `ScoredOutput(score=1.0, output=None)`. The caller gets no signal that anything was blocked, and the actual reason (`prompt_feedback.block_reason` / `candidates[0].finish_reason`) is silently discarded.

This mirrors the guard already applied to the OpenAI provider (#496): when `response.text` is `None`, `_process_single_prompt` now raises `InferenceRuntimeError` with the available block/finish reason, and the error propagates unwrapped (not retried, not wrapped in "Gemini API error").

Fixes #508

# How Has This Been Tested?

Added `TestGeminiNoTextResponseHandling` to `tests/gemini_retry_test.py` covering:

- a normal text response still returns `ScoredOutput`
- a blocked prompt (`prompt_feedback.block_reason`) raises with the block reason
- an empty candidate (`finish_reason`) raises with the finish reason
- a no-text response is never retried
- the `InferenceRuntimeError` propagates unwrapped

```
pytest tests/gemini_retry_test.py
```

Also ran the full unit suite locally: 767 passed. The 10 failures observed are Windows-only (symlink/pip tests in `create_provider_plugin_test.py`), unrelated to this change.

# Checklist:

- [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
- [ ] I have read the [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md) page, and I either signed the Google [Individual CLA](https://cla.developers.google.com/about/google-individual) or am covered by my company's [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach.
- [x] I have made any needed documentation changes, or noted in the linked issue(s) that documentation elsewhere needs updating.
- [x] I have added tests, or I have ensured existing tests cover the changes
- [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.
