### PR TITLE
feat(gemini): allow thinking_config for Gemini 3

### DIFF
--- a/langextract/providers/gemini.py
+++ b/langextract/providers/gemini.py
@@ -112,6 +112,7 @@ _API_CONFIG_KEYS: Final[set[str]] = {
     'tools',
     'stop_sequences',
     'candidate_count',
+    'thinking_config',
 }
 
 

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -607,6 +607,7 @@ class TestGeminiLanguageModel(absltest.TestCase):
         tools=["tool1", "tool2"],
         stop_sequences=["\n\n"],
         system_instruction="Be helpful",
+        thinking_config={"thinking_level": "minimal"},
         # Unknown parameters to test filtering
         unknown_param="should_be_ignored",
         another_unknown="also_ignored",
@@ -616,6 +617,7 @@ class TestGeminiLanguageModel(absltest.TestCase):
         "tools": ["tool1", "tool2"],
         "stop_sequences": ["\n\n"],
         "system_instruction": "Be helpful",
+        "thinking_config": {"thinking_level": "minimal"},
     }
     self.assertEqual(
         expected_extra_kwargs,
@@ -630,7 +632,12 @@ class TestGeminiLanguageModel(absltest.TestCase):
     call_args = mock_client.models.generate_content.call_args
     config = call_args.kwargs["config"]
 
-    for key in ["tools", "stop_sequences", "system_instruction"]:
+    for key in [
+        "tools",
+        "stop_sequences",
+        "system_instruction",
+        "thinking_config",
+    ]:
       self.assertIn(key, config, f"Expected {key} to be in API config")
       self.assertEqual(
           expected_extra_kwargs[key],


### PR DESCRIPTION
# Description

Fixes #319

Type: Bug fix

## Summary

Gemini 3 exposes `thinking_config` for controlling reasoning effort, but the Gemini provider's API configuration allowlist discarded it before requests were sent. This change allows the parameter through to the Google GenAI request config and adds regression coverage for the allowlist and forwarded value.

The change is backward compatible: existing parameters and unknown-parameter filtering are unchanged.

## How Has This Been Tested?

```bash
python -m pytest -q tests/inference_test.py -k gemini_allowlist_filtering
python -m pytest -q tests/inference_test.py -k "gemini and not live_api"
```

Results: 1 passed, 40 deselected; 8 passed, 33 deselected.

The repository's formatting/static checks were not fully runnable in this environment: `pyink` is not installed, and the installed Pylint/astroid combination fails while parsing the repository's Python 3.12 `type` alias syntax. `isort` was run on the affected files.

## Checklist

- [x] I have read the contributing guidance and Google Open Source Code of Conduct.
- [x] I added regression coverage for the change.
- [x] No documentation change is needed.
- [x] The change is limited to the linked issue.