### PR TITLE
Forward Gemini generation settings

### DIFF
--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -145,7 +145,9 @@ def extract(
         'accept_match_lesser' (bool, True).
       language_model_params: Additional provider-specific constructor kwargs,
         such as Gemini retry settings ('max_retries', 'retry_delay',
-        'max_retry_delay') or 'http_options'.
+        'max_retry_delay'), generation settings ('max_output_tokens', 'top_p',
+        'top_k'), or 'http_options'. For Gemini output truncated at the model's
+        token limit, increase 'max_output_tokens'.
       debug: Whether to enable debug logging. When True, enables detailed logging
         of function calls, arguments, return values, and timing for the langextract
         namespace. Note: Debug logging remains enabled for the process once activated.

--- a/langextract/providers/README.md
+++ b/langextract/providers/README.md
@@ -197,16 +197,19 @@ result = lx.extract(
     max_char_buffer=3000,       # Document chunking
 )
 
-# 2. Provider-specific parameters passed via **kwargs:
+# 2. Provider-specific constructor parameters via language_model_params:
 result = lx.extract(
     text_or_documents="Your document",
     model_id="gemini-3.5-flash",
     prompt_description="Extract entities",
     examples=[...],
-    # These go directly to the Gemini provider:
-    temperature=0.7,          # Sampling temperature
-    api_key="your-key",      # Override environment variable
-    max_output_tokens=1000,  # Token limit
+    temperature=0.7,     # Common sampling parameter
+    api_key="your-key",  # Override environment variable
+    language_model_params={
+        "max_output_tokens": 1000,
+        "top_p": 0.95,
+        "top_k": 40,
+    },
 )
 ```
 

--- a/langextract/providers/gemini.py
+++ b/langextract/providers/gemini.py
@@ -96,7 +96,14 @@ def _has_sdk_retry_options(http_options: Any) -> bool:
   return attempts is None or attempts > 1
 
 
+_GENERATION_CONFIG_KEYS: Final[tuple[str, ...]] = (
+    'max_output_tokens',
+    'top_p',
+    'top_k',
+)
+
 _API_CONFIG_KEYS: Final[set[str]] = {
+    *_GENERATION_CONFIG_KEYS,
     'response_mime_type',
     'response_schema',
     'response_json_schema',
@@ -205,8 +212,9 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
         Subsequent delays increase exponentially.
       max_retry_delay: Maximum delay in seconds between retries.
       **kwargs: Additional Gemini API parameters. Only allowlisted keys are
-        forwarded to the API (response_schema, response_mime_type, tools,
-        safety_settings, stop_sequences, candidate_count, system_instruction).
+        forwarded to the API, including generation settings
+        (max_output_tokens, top_p, top_k), response schemas, tools, safety
+        settings, stop sequences, candidate count, and system instructions.
         See https://ai.google.dev/api/generate-content for details.
     """
     try:
@@ -365,6 +373,13 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
           for key, value in self.gemini_schema.to_provider_config().items():
             call_config.setdefault(key, value)
 
+        # Generation-setting None markers suppress constructor fallbacks above
+        # but must not reach the SDK.
+        call_config = {
+            key: value
+            for key, value in call_config.items()
+            if value is not None
+        }
         response = self._client.models.generate_content(
             model=self.model_id, contents=prompt, config=call_config
         )
@@ -407,11 +422,12 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
     config = {
         'temperature': merged_kwargs.get('temperature', self.temperature),
     }
-    for key in ('max_output_tokens', 'top_p', 'top_k'):
+    # Preserve None here as an explicit marker that clears a constructor value.
+    for key in _GENERATION_CONFIG_KEYS:
       if key in merged_kwargs:
         config[key] = merged_kwargs[key]
 
-    handled_keys = {'temperature', 'max_output_tokens', 'top_p', 'top_k'}
+    handled_keys = {'temperature', *_GENERATION_CONFIG_KEYS}
     for key, value in merged_kwargs.items():
       if (
           key not in handled_keys
@@ -431,9 +447,11 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
               if self.gemini_schema
               else None
           )
-          # Remove schema fields from config for batch API - they're handled
-          # via schema_config
-          batch_config = dict(config)
+          # None markers implement clearing but must not reach the batch SDK.
+          batch_config = {
+              key: value for key, value in config.items() if value is not None
+          }
+          # Schema fields use the separate schema_config argument.
           batch_config.pop('response_mime_type', None)
           batch_config.pop('response_schema', None)
           batch_config.pop('response_json_schema', None)

--- a/tests/extract_schema_integration_test.py
+++ b/tests/extract_schema_integration_test.py
@@ -18,6 +18,7 @@ from unittest import mock
 import warnings
 
 from absl.testing import absltest
+from google import genai
 
 from langextract import factory
 import langextract as lx
@@ -78,6 +79,39 @@ class ExtractSchemaIntegrationTest(absltest.TestCase):
 
           # Result should be an AnnotatedDocument
           self.assertIsInstance(result, data.AnnotatedDocument)
+
+  def test_extract_forwards_gemini_generation_params(self):
+    """Gemini generation settings reach the SDK through extract()."""
+    generation_params = {
+        "max_output_tokens": 8192,
+        "top_p": 0.95,
+        "top_k": 40,
+    }
+
+    with mock.patch.object(genai, "Client", autospec=True) as client_class:
+      client = client_class.return_value
+      client.models.generate_content.return_value = mock.Mock(
+          text='{"extractions": []}'
+      )
+
+      result = lx.extract(
+          text_or_documents=self.test_text,
+          prompt_description="Extract conditions",
+          examples=self.examples,
+          model_id="gemini-3.5-flash",
+          api_key="test-key",
+          language_model_params=generation_params,
+          max_workers=1,
+          batch_length=1,
+          show_progress=False,
+      )
+
+    self.assertIsInstance(result, data.AnnotatedDocument)
+    client.models.generate_content.assert_called_once()
+    config = client.models.generate_content.call_args.kwargs["config"]
+    for key, value in generation_params.items():
+      self.assertIn(key, config)
+      self.assertEqual(value, config[key])
 
   @mock.patch.dict("os.environ", {"OLLAMA_BASE_URL": "http://localhost:11434"})
   def test_extract_with_ollama_uses_json_mode(self):

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -637,6 +637,96 @@ class TestGeminiLanguageModel(absltest.TestCase):
           config[key],
           f"Config value for {key} should match what was provided",
       )
+    for key in ["max_output_tokens", "top_p", "top_k"]:
+      self.assertNotIn(key, config)
+
+  @mock.patch("google.genai.Client", autospec=True)
+  def test_gemini_runtime_generation_params_override_constructor(
+      self, mock_client_class
+  ):
+    """Runtime generation settings override constructor defaults."""
+    mock_client = mock_client_class.return_value
+
+    mock_response = mock.Mock()
+    mock_response.text = '{"result": "test"}'
+    mock_client.models.generate_content.return_value = mock_response
+
+    model = gemini.GeminiLanguageModel(
+        model_id="gemini-3.5-flash",
+        api_key="test-key",
+        max_output_tokens=8192,
+        top_p=0.95,
+        top_k=40,
+    )
+    runtime_params = {
+        "max_output_tokens": 4096,
+        "top_p": 0.8,
+        "top_k": 20,
+    }
+
+    list(model.infer(["Test prompt"], **runtime_params))
+
+    mock_client.models.generate_content.assert_called_once()
+    config = mock_client.models.generate_content.call_args.kwargs["config"]
+    for key, value in runtime_params.items():
+      self.assertIn(key, config)
+      self.assertEqual(value, config[key])
+
+  @mock.patch("google.genai.Client", autospec=True)
+  def test_gemini_runtime_none_clears_constructor_generation_params(
+      self, mock_client_class
+  ):
+    """Runtime None uses provider defaults instead of constructor settings."""
+    mock_client = mock_client_class.return_value
+    mock_client.models.generate_content.return_value = mock.Mock(
+        text='{"result": "test"}'
+    )
+    model = gemini.GeminiLanguageModel(
+        model_id="gemini-3.5-flash",
+        api_key="test-key",
+        max_output_tokens=8192,
+        top_p=0.95,
+        top_k=40,
+    )
+
+    list(
+        model.infer(
+            ["Test prompt"],
+            temperature=None,
+            max_output_tokens=None,
+            top_p=None,
+            top_k=None,
+        )
+    )
+
+    config = mock_client.models.generate_content.call_args.kwargs["config"]
+    for key in ["temperature", "max_output_tokens", "top_p", "top_k"]:
+      self.assertNotIn(key, config)
+
+  @mock.patch("google.genai.Client", autospec=True)
+  def test_gemini_runtime_none_clears_only_selected_generation_param(
+      self, mock_client_class
+  ):
+    """Runtime None clears one constructor setting without clearing siblings."""
+    mock_client = mock_client_class.return_value
+    mock_client.models.generate_content.return_value = mock.Mock(
+        text='{"result": "test"}'
+    )
+    model = gemini.GeminiLanguageModel(
+        model_id="gemini-3.5-flash",
+        api_key="test-key",
+        max_output_tokens=8192,
+        top_p=0.95,
+        top_k=40,
+    )
+
+    list(model.infer(["Test prompt"], max_output_tokens=None, top_p=0.8))
+
+    config = mock_client.models.generate_content.call_args.kwargs["config"]
+    self.assertNotIn("max_output_tokens", config)
+    self.assertEqual(0.0, config["temperature"])
+    self.assertEqual(0.8, config["top_p"])
+    self.assertEqual(40, config["top_k"])
 
   @mock.patch("google.genai.Client")
   def test_gemini_runtime_kwargs_filtered(self, mock_client_class):

--- a/tests/test_gemini_batch_api.py
+++ b/tests/test_gemini_batch_api.py
@@ -179,8 +179,60 @@ class TestGeminiBatchAPI(absltest.TestCase):
     mock_client.batches.create.assert_not_called()
 
   @mock.patch.object(genai, "Client", autospec=True)
-  def test_batch_with_schema(self, mock_client_cls):
-    """Test that batch API properly includes schema when configured."""
+  def test_batch_forwards_constructor_generation_params(self, mock_client_cls):
+    """Batch requests forward constructor generation settings."""
+    mock_client = mock_client_cls.return_value
+    mock_client.vertexai = True
+
+    output_blob = mock.create_autospec(gb.storage.Blob, instance=True)
+    output_blob.name = f"output{gb._EXT_JSONL}"
+    output_blob.open.return_value.__enter__.return_value = io.StringIO(
+        _create_batch_response(0, {"name": "test"})
+    )
+    self.mock_bucket.list_blobs.return_value = [output_blob]
+
+    mock_client.batches.create.return_value = create_mock_batch_job()
+    mock_client.batches.get.return_value = create_mock_batch_job()
+
+    model = gemini.GeminiLanguageModel(
+        model_id="gemini-3.5-flash",
+        vertexai=True,
+        project="p",
+        location="l",
+        max_output_tokens=8192,
+        top_p=0.95,
+        top_k=40,
+        batch={
+            "enabled": True,
+            "threshold": 1,
+            "enable_caching": False,
+            "retention_days": None,
+        },
+    )
+
+    with mock.patch.object(gb, "_submit_file", autospec=True) as mock_submit:
+      mock_submit.return_value = create_mock_batch_job()
+
+      outs = list(model.infer(["test prompt"]))
+
+    self.assertLen(outs, 1)
+    self.assertEqual(outs[0][0].output, '{"name":"test"}')
+    request = mock_submit.call_args.args[2][0]
+    self.assertDictEqual(
+        {
+            "maxOutputTokens": 8192,
+            "temperature": 0.0,
+            "topK": 40,
+            "topP": 0.95,
+        },
+        request["generationConfig"],
+    )
+
+  @mock.patch.object(genai, "Client", autospec=True)
+  def test_batch_schema_runtime_generation_params_override_constructor(
+      self, mock_client_cls
+  ):
+    """Batch schema requests prefer runtime generation settings."""
     mock_client = mock_client_cls.return_value
     mock_client.vertexai = True
 
@@ -207,6 +259,9 @@ class TestGeminiBatchAPI(absltest.TestCase):
         project="p",
         location="l",
         gemini_schema=gemini_schema,
+        max_output_tokens=8192,
+        top_p=0.95,
+        top_k=40,
         batch={
             "enabled": True,
             "threshold": 1,
@@ -219,7 +274,14 @@ class TestGeminiBatchAPI(absltest.TestCase):
     with mock.patch.object(gb, "_submit_file", autospec=True) as mock_submit:
       mock_submit.return_value = create_mock_batch_job()
 
-      outs = list(model.infer(["test prompt"]))
+      outs = list(
+          model.infer(
+              ["test prompt"],
+              max_output_tokens=4096,
+              top_p=0.8,
+              top_k=20,
+          )
+      )
 
       self.assertLen(outs, 1)
       self.assertEqual(outs[0][0].output, '{"name":"test"}')
@@ -233,9 +295,12 @@ class TestGeminiBatchAPI(absltest.TestCase):
                   {"role": "user", "parts": [{"text": "test prompt"}]}
               ],
               "generationConfig": {
+                  "maxOutputTokens": 4096,
                   "responseMimeType": "application/json",
                   "responseSchema": gemini_schema.schema_dict,
                   "temperature": 0.0,
+                  "topK": 20,
+                  "topP": 0.8,
               },
           }],
           mock.ANY,  # Display name contains timestamp/random.
@@ -245,6 +310,78 @@ class TestGeminiBatchAPI(absltest.TestCase):
       )
 
     self.assertEqual(model.gemini_schema.schema_dict, gemini_schema.schema_dict)
+
+  @mock.patch.object(genai, "Client", autospec=True)
+  def test_batch_runtime_none_clears_constructor_generation_params(
+      self, mock_client_cls
+  ):
+    """Batch runtime None omits constructor generation settings."""
+    mock_client_cls.return_value.vertexai = True
+    model = gemini.GeminiLanguageModel(
+        model_id="gemini-3.5-flash",
+        vertexai=True,
+        project="p",
+        location="l",
+        max_output_tokens=8192,
+        top_p=0.95,
+        top_k=40,
+        batch={
+            "enabled": True,
+            "threshold": 1,
+            "enable_caching": False,
+            "retention_days": None,
+        },
+    )
+
+    with mock.patch.object(
+        gb, "infer_batch", autospec=True, return_value=['{"result": "test"}']
+    ) as mock_infer_batch:
+      list(
+          model.infer(
+              ["test prompt"],
+              temperature=None,
+              max_output_tokens=None,
+              top_p=None,
+              top_k=None,
+          )
+      )
+
+    gen_config = mock_infer_batch.call_args.kwargs["gen_config"]
+    for key in ["temperature", "max_output_tokens", "top_p", "top_k"]:
+      self.assertNotIn(key, gen_config)
+
+  @mock.patch.object(genai, "Client", autospec=True)
+  def test_batch_runtime_none_clears_only_selected_generation_param(
+      self, mock_client_cls
+  ):
+    """Batch runtime None clears one setting without clearing siblings."""
+    mock_client_cls.return_value.vertexai = True
+    model = gemini.GeminiLanguageModel(
+        model_id="gemini-3.5-flash",
+        vertexai=True,
+        project="p",
+        location="l",
+        max_output_tokens=8192,
+        top_p=0.95,
+        top_k=40,
+        batch={
+            "enabled": True,
+            "threshold": 1,
+            "enable_caching": False,
+            "retention_days": None,
+        },
+    )
+
+    with mock.patch.object(
+        gb, "infer_batch", autospec=True, return_value=['{"result": "test"}']
+    ) as mock_infer_batch:
+      list(model.infer(["test prompt"], max_output_tokens=None, top_p=0.8))
+
+    gen_config = mock_infer_batch.call_args.kwargs["gen_config"]
+    self.assertNotIn("max_output_tokens", gen_config)
+    self.assertEqual(0.0, gen_config["temperature"])
+    self.assertEqual(0.8, gen_config["top_p"])
+    self.assertEqual(40, gen_config["top_k"])
 
   @mock.patch.object(genai, "Client", autospec=True)
   def test_batch_error_handling(self, mock_client_cls):
@@ -710,6 +847,11 @@ class GCSBatchCachingTest(absltest.TestCase):
 
 class BatchOutputSchemaRequestTest(absltest.TestCase):
   """Tests for lowering provider schema config into batch REST requests."""
+
+  def test_build_request_omits_generation_config_without_values(self):
+    request = gb._build_request("prompt", None, {})
+
+    self.assertNotIn("generationConfig", request)
 
   def test_build_request_lowers_json_schema_config(self):
     schema_config = {

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -102,7 +102,8 @@ live_api = pytest.mark.live_api
 GEMINI_MODEL_PARAMS = {
     "temperature": 0.0,
     "top_p": 0.0,
-    "max_output_tokens": 256,
+    # Leave enough room for model reasoning before the structured response.
+    "max_output_tokens": 4096,
 }
 
 OPENAI_MODEL_PARAMS = {


### PR DESCRIPTION
## Summary

- Forward Gemini `max_output_tokens`, `top_p`, and `top_k` from `language_model_params` for realtime and batch requests.
- Preserve runtime override and explicit clearing behavior, with updated documentation and regression coverage.

Addresses the output-limit configuration request in #358. Retry recovery and relevance-aware chunking remain out of scope.

## Tests

- `.venv/bin/python -m pytest tests/ -ra -m "not live_api" --ignore=tests/test_ollama_integration.py`
- `.venv/bin/python -m tox -e format,lint-src,lint-tests`
- `.venv/bin/python -m tox -e live-api`
- Fresh Python 3.13 editable install, `pip check`, and `lx.extract()` smoke test

The local Ollama integration is excluded because its configured service returns the same HTTP 500 on `main`.
