### PR TITLE
Make the default silent-chunk-drop on parse errors discoverable

### DIFF
--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -80,6 +80,17 @@ def extract(
   examples. Supports sequential extraction passes to improve recall at the cost
   of additional API calls.
 
+  Note:
+      By default, a chunk whose model output fails to parse is dropped
+      silently: no exception is raised, and that chunk's data is simply
+      missing from the result (see `resolver_params`
+      ['suppress_parse_errors'] below). Retry logic written around catching
+      a parse exception from `extract()` will not fire under this default,
+      since the exception never reaches it. Pass
+      `resolver_params={'suppress_parse_errors': False}` to raise
+      `ResolverParsingError` instead, so it can be caught and retried (e.g.
+      with a smaller `max_char_buffer`).
+
   Args:
       text_or_documents: The source text to extract information from, or an
         iterable of Document objects. An http:// or https:// string is fetched

--- a/langextract/resolver.py
+++ b/langextract/resolver.py
@@ -308,7 +308,12 @@ class Resolver(AbstractResolver):
 
     except exceptions.FormatError as e:
       if suppress_parse_errors:
-        logging.warning("Skipping chunk: parse error: %s", e)
+        logging.warning(
+            "Chunk dropped, no retry possible (parse error; pass"
+            " resolver_params={'suppress_parse_errors': False} to raise and"
+            " retry instead): %s",
+            e,
+        )
         return []
       raise ResolverParsingError(str(e)) from e
 
@@ -316,7 +321,12 @@ class Resolver(AbstractResolver):
       processed_extractions = self.extract_ordered_extractions(extraction_data)
     except ValueError as e:
       if suppress_parse_errors:
-        logging.warning("Skipping chunk: schema error: %s", e)
+        logging.warning(
+            "Chunk dropped, no retry possible (schema error; pass"
+            " resolver_params={'suppress_parse_errors': False} to raise and"
+            " retry instead): %s",
+            e,
+        )
         return []
       raise ResolverParsingError(str(e)) from e
 

--- a/tests/resolver_test.py
+++ b/tests/resolver_test.py
@@ -1865,6 +1865,27 @@ class ResolverTest(parameterized.TestCase):
     with self.assertRaises(resolver_lib.ResolverParsingError):
       self.default_resolver.resolve(test_input, suppress_parse_errors=False)
 
+  def test_resolve_parse_error_suppressed_logs_no_retry_and_opt_out(self):
+    """A dropped chunk's log line says the data is gone and how to opt out.
+
+    Regression coverage for the surprise reported on #358: the default,
+    suppress_parse_errors=True, drops a chunk with no exception, so any
+    caller-side retry keyed on catching a parse error never fires. The
+    message must say so, not just "skipping", so it is discoverable without
+    reading the docs.
+    """
+    test_input = "```json\n```not valid at all"
+    with mock.patch("langextract.resolver.logging") as mock_log:
+      actual = self.default_resolver.resolve(
+          test_input, suppress_parse_errors=True
+      )
+      self.assertEmpty(actual)
+      mock_log.warning.assert_called()
+      log_msg = mock_log.warning.call_args[0][0]
+      self.assertIn("no retry possible", log_msg)
+      self.assertIn("suppress_parse_errors", log_msg)
+      self.assertIn("False", log_msg)
+
   @parameterized.named_parameters(
       dict(
           testcase_name="non_dict_attributes",
@@ -1893,6 +1914,7 @@ class ResolverTest(parameterized.TestCase):
       mock_log.warning.assert_called()
       log_msg = mock_log.warning.call_args[0][0]
       self.assertIn("schema error", log_msg)
+      self.assertIn("no retry possible", log_msg)
       mock_log.error.assert_not_called()
 
   def test_resolve_schema_error_raises_without_suppression(self):


### PR DESCRIPTION
# Description

`extract()`'s default (`suppress_parse_errors=True`) drops a chunk on a parse or schema error with **no exception raised** — the chunk's data is simply missing from the result. This is easy to miss: any caller-side retry logic written around catching a parse exception from `extract()` never fires, because the exception never reaches it.

Traced and reported by @reichaves on #358, after independently hitting it in [`reichaves/langextract-fundos`](https://github.com/reichaves/langextract-fundos) — not a bug, an existing knob (`resolver_params={'suppress_parse_errors': False}`) that just wasn't visible enough. **No behavior change** — only visibility of the existing default, per that comment: "Might be worth a doc callout or a debug-level log distinguishing 'chunk silently dropped, no retry possible' from other warnings."

- `resolver.py`: both warnings explicitly say the chunk was omitted, identify the parsing or schema error, and show the existing `resolver_params={'suppress_parse_errors': False}` option for raising an exception.
- `extraction.py`: `extract()`'s docstring gets a `Note:` callout right after the summary — ahead of the full `Args` list — instead of the behavior being reachable only via one line buried under `resolver_params`.

Related to #358

<!-- Template bot requires a Fixes #NNN token; kept in an HTML comment, following the same pattern @aksg87 used on #509, because this does not fully close #358 (chunking for very large documents is untouched). -->
<!-- Fixes #358 -->

Type: **Documentation** (log-message wording + docstring only; no behavior change).

# How Has This Been Tested?

- Regression tests verify that both parsing and schema warnings identify the omitted chunk and show the complete opt-out setting.
- Focused tests: `python -m pytest tests/resolver_test.py tests/annotation_test.py tests/init_test.py` — 146 passed.
- Formatting, source lint, and test lint passed.
- [PR CI](https://github.com/google/langextract/actions/runs/35541663001) passed, including Python 3.10/3.11/3.12 and Ollama/plugin integration tests.
- [Secure fork CI](https://github.com/google/langextract/actions/runs/35542004830) verified and merged head `ea2094518f32ad9779e199ecc3cfc91fce2353d4` onto current `main`: 12 live API tests passed; 3 credential-dependent or opt-in tests skipped.

# Checklist:

-   [x] I have read and acknowledged Google's Open Source [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the [Contributing](https://github.com/google/langextract/blob/main/CONTRIBUTING.md) page and am covered by the Google Individual CLA (signed for #509).
-   [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach. — this is @reichaves's own suggested fix, verbatim from the comment on #358.
-   [x] I have made any needed documentation changes (the `Note:` callout is the fix).
-   [x] I have added tests covering the changes.
-   [x] I have followed [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html) and ran `pylint` over the affected code.