### PR TITLE
Add built-in Anthropic (Claude 5) and xAI (Grok 4.6) providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 - [Installation](#installation)
 - [API Key Setup for Cloud Models](#api-key-setup-for-cloud-models)
 - [Adding Custom Model Providers](#adding-custom-model-providers)
+- [Using Claude (Anthropic) Models](#using-claude-anthropic-models)
+- [Using Grok (xAI) Models](#using-grok-xai-models)
 - [Using OpenAI Models](#using-openai-models)
 - [Using Local LLMs with Ollama](#using-local-llms-with-ollama)
 - [More Examples](#more-examples)
@@ -229,10 +231,11 @@ docker run --rm -e LANGEXTRACT_API_KEY="your-api-key" langextract python your_sc
 
 ## API Key Setup for Cloud Models
 
-When using LangExtract with cloud-hosted models (like Gemini or OpenAI), you'll need to
-set up an API key. On-device models don't require an API key. For developers
-using local LLMs, LangExtract offers built-in support for Ollama and can be
-extended to other third-party APIs by updating the inference endpoints.
+When using LangExtract with cloud-hosted models (like Gemini, Claude, Grok, or
+OpenAI), you'll need to set up an API key. On-device models don't require an
+API key. For developers using local LLMs, LangExtract offers built-in support
+for Ollama and can be extended to other third-party APIs by updating the
+inference endpoints.
 
 ### API Key Sources
 
@@ -240,6 +243,8 @@ Get API keys from:
 
 *   [AI Studio](https://aistudio.google.com/app/apikey) for Gemini models
 *   [Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/sdks/overview) for enterprise use
+*   [Anthropic Console](https://console.anthropic.com/settings/keys) for Claude models (`ANTHROPIC_API_KEY`)
+*   [xAI Console](https://console.x.ai) for Grok models (`XAI_API_KEY`)
 *   [OpenAI Platform](https://platform.openai.com/api-keys) for OpenAI models
 
 ### Setting up API key in your environment
@@ -323,6 +328,51 @@ See the detailed guide in [Provider System Documentation](langextract/providers/
 - Publish an entry point for discovery
 - Optionally provide a schema with `get_schema_class()` for structured output
 - Integrate with the factory via `create_model(...)`
+
+## Using Claude (Anthropic) Models
+
+LangExtract routes `claude-*` model IDs to the Anthropic Messages API
+(requires `pip install anthropic`). Current-generation defaults:
+
+| Role | Model ID |
+|---|---|
+| Default (speed + intelligence) | `claude-sonnet-5` |
+| Flagship agentic / extraction | `claude-opus-5` |
+| Frontier | `claude-fable-5` |
+| Fast / cheap | `claude-haiku-4-5` |
+
+```python
+import langextract as lx
+
+# ANTHROPIC_API_KEY in the environment is picked up automatically.
+result = lx.extract(
+    text_or_documents=input_text,
+    prompt_description=prompt,
+    examples=examples,
+    model_id="claude-sonnet-5",
+)
+```
+
+## Using Grok (xAI) Models
+
+LangExtract routes `grok-*` model IDs to xAI's OpenAI-compatible API
+(requires `pip install langextract[openai]`). The current default is
+**Grok 4.6**.
+
+```python
+import langextract as lx
+
+# XAI_API_KEY in the environment is picked up automatically.
+result = lx.extract(
+    text_or_documents=input_text,
+    prompt_description=prompt,
+    examples=examples,
+    model_id="grok-4.6",
+)
+```
+
+The xAI base URL defaults to `https://api.x.ai/v1` (override with `XAI_BASE_URL`
+or `provider_kwargs={"base_url": "..."}`).
 
 ## Using OpenAI Models
 

--- a/langextract/factory.py
+++ b/langextract/factory.py
@@ -66,16 +66,23 @@ def _kwargs_with_environment_defaults(
     Updated kwargs with environment defaults.
   """
   resolved = dict(kwargs)
+  model_lower = (model_id or "").lower()
 
   if "api_key" not in resolved and not resolved.get("vertexai", False):
-    model_lower = model_id.lower()
     env_vars_by_provider = {
+        "claude": ("ANTHROPIC_API_KEY", "LANGEXTRACT_API_KEY"),
+        "anthropic": ("ANTHROPIC_API_KEY", "LANGEXTRACT_API_KEY"),
+        "grok": ("XAI_API_KEY", "LANGEXTRACT_API_KEY"),
+        "xai": ("XAI_API_KEY", "LANGEXTRACT_API_KEY"),
         "gemini": ("GEMINI_API_KEY", "LANGEXTRACT_API_KEY"),
         "gpt": ("OPENAI_API_KEY", "LANGEXTRACT_API_KEY"),
     }
 
     for provider_prefix, env_vars in env_vars_by_provider.items():
-      if provider_prefix in model_lower:
+      if (
+          model_lower.startswith(provider_prefix)
+          or provider_prefix in model_lower
+      ):
         found_keys = []
         for env_var in env_vars:
           key_val = os.getenv(env_var)
@@ -99,6 +106,12 @@ def _kwargs_with_environment_defaults(
     resolved["base_url"] = os.getenv(
         "OLLAMA_BASE_URL", "http://localhost:11434"
     )
+
+  if (
+      any(token in model_lower for token in ("grok", "xai"))
+      and "base_url" not in resolved
+  ):
+    resolved["base_url"] = os.getenv("XAI_BASE_URL", "https://api.x.ai/v1")
 
   return resolved
 

--- a/langextract/providers/README.md
+++ b/langextract/providers/README.md
@@ -87,7 +87,12 @@ Ships with langextract, but requires extra installation:
 - **OpenAI** (`openai.py`): OpenAI's GPT models
   - Code included in package
   - Requires: `pip install langextract[openai]` to install OpenAI SDK
-  - Future: May be moved to external plugin package
+- **Anthropic / Claude** (`anthropic.py`): Claude 5 (`claude-sonnet-5`, `claude-opus-5`, `claude-fable-5`) and Haiku 4.5
+  - Requires: `pip install anthropic`
+  - Env: `ANTHROPIC_API_KEY`
+- **xAI / Grok** (`xai.py`): Grok 4.6 (`grok-4.6`) via `https://api.x.ai/v1`
+  - Requires: `pip install langextract[xai]` (OpenAI SDK)
+  - Env: `XAI_API_KEY`
 
 ### 3. External Plugins (Third-party)
 Separate packages that extend LangExtract with new providers:

--- a/langextract/providers/__init__.py
+++ b/langextract/providers/__init__.py
@@ -34,6 +34,9 @@ __all__ = [
     "gemini",
     "openai",
     "ollama",
+    "anthropic",
+    "xai",
+    "latest_models",
     "router",
     "registry",  # Backward compat
     "schemas",

--- a/langextract/providers/anthropic.py
+++ b/langextract/providers/anthropic.py
@@ -1,0 +1,216 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Anthropic (Claude) provider for LangExtract."""
+# pylint: disable=duplicate-code
+
+from __future__ import annotations
+
+import concurrent.futures
+import dataclasses
+import os
+from typing import Any, Iterator, Sequence
+
+from langextract.core import base_model
+from langextract.core import data
+from langextract.core import exceptions
+from langextract.core import schema
+from langextract.core import types as core_types
+from langextract.providers import latest_models
+from langextract.providers import patterns
+from langextract.providers import router
+
+
+def _response_text(response: Any) -> str:
+  """Flatten Anthropic message content into a single string."""
+  parts = getattr(response, 'content', None)
+  if isinstance(parts, str):
+    return parts
+  if not parts:
+    return ''
+  texts: list[str] = []
+  for block in parts:
+    text = getattr(block, 'text', None)
+    if text:
+      texts.append(text)
+      continue
+    if isinstance(block, dict) and block.get('text'):
+      texts.append(str(block['text']))
+  return ''.join(texts)
+
+
+@router.register(
+    *patterns.ANTHROPIC_PATTERNS,
+    priority=patterns.ANTHROPIC_PRIORITY,
+)
+@dataclasses.dataclass(init=False)
+class AnthropicLanguageModel(base_model.BaseLanguageModel):
+  """Language model inference using Anthropic's Claude Messages API."""
+
+  model_id: str = latest_models.CLAUDE_DEFAULT
+  api_key: str | None = None
+  base_url: str | None = None
+  format_type: data.FormatType = data.FormatType.JSON
+  temperature: float | None = 0.0
+  max_output_tokens: int = 8192
+  max_workers: int = 10
+  _client: Any = dataclasses.field(default=None, repr=False, compare=False)
+  _extra_kwargs: dict[str, Any] = dataclasses.field(
+      default_factory=dict, repr=False, compare=False
+  )
+
+  def __init__(
+      self,
+      model_id: str = latest_models.CLAUDE_DEFAULT,
+      api_key: str | None = None,
+      base_url: str | None = None,
+      format_type: data.FormatType = data.FormatType.JSON,
+      temperature: float | None = 0.0,
+      max_output_tokens: int = 8192,
+      max_workers: int = 10,
+      **kwargs,
+  ) -> None:
+    """Initialize the Anthropic language model.
+
+    Args:
+      model_id: Claude model ID (claude-sonnet-5, claude-opus-5, ...).
+      api_key: Anthropic API key. Falls back to ANTHROPIC_API_KEY.
+      base_url: Optional Anthropic-compatible base URL.
+      format_type: Output format (JSON or YAML).
+      temperature: Sampling temperature.
+      max_output_tokens: Maximum tokens in the completion (required by API).
+      max_workers: Maximum number of parallel API calls.
+      **kwargs: Extra Anthropic Messages parameters.
+    """
+    try:
+      # pylint: disable=import-outside-toplevel
+      import anthropic
+    except ImportError as e:
+      raise exceptions.InferenceConfigError(
+          'Anthropic provider requires anthropic package. '
+          'Install with: pip install anthropic'
+      ) from e
+
+    super().__init__(
+        constraint=schema.Constraint(constraint_type=schema.ConstraintType.NONE)
+    )
+
+    self.model_id = model_id or latest_models.CLAUDE_DEFAULT
+    self.api_key = api_key or os.environ.get('ANTHROPIC_API_KEY')
+    self.base_url = base_url or os.environ.get('ANTHROPIC_BASE_URL')
+    self.format_type = format_type
+    self.temperature = temperature
+    self.max_output_tokens = max_output_tokens
+    self.max_workers = max_workers
+    self._extra_kwargs = kwargs or {}
+
+    if not self.api_key:
+      raise exceptions.InferenceConfigError(
+          'API key not provided for Anthropic/Claude. Set ANTHROPIC_API_KEY.'
+      )
+
+    client_kwargs: dict[str, Any] = {'api_key': self.api_key}
+    if self.base_url:
+      client_kwargs['base_url'] = self.base_url
+    self._client = anthropic.Anthropic(**client_kwargs)
+
+  def _system_message(self) -> str:
+    if self.format_type == data.FormatType.JSON:
+      return 'You are a helpful assistant that responds in JSON format.'
+    if self.format_type == data.FormatType.YAML:
+      return 'You are a helpful assistant that responds in YAML format.'
+    return ''
+
+  def _process_single_prompt(
+      self, prompt: str, config: dict
+  ) -> core_types.ScoredOutput:
+    """Sends one prompt while preserving provider-specific error types."""
+    try:
+      max_tokens = int(
+          config.get('max_output_tokens', self.max_output_tokens) or 8192
+      )
+      api_params: dict[str, Any] = {
+          'model': self.model_id,
+          'max_tokens': max_tokens,
+          'messages': [{'role': 'user', 'content': prompt}],
+      }
+      system = self._system_message()
+      if system:
+        api_params['system'] = system
+      temp = config.get('temperature', self.temperature)
+      if temp is not None:
+        api_params['temperature'] = temp
+      if (v := config.get('top_p')) is not None:
+        api_params['top_p'] = v
+      if (v := config.get('stop')) is not None:
+        api_params['stop_sequences'] = v if isinstance(v, list) else [v]
+
+      response = self._client.messages.create(**api_params)
+      return core_types.ScoredOutput(score=1.0, output=_response_text(response))
+    except exceptions.InferenceConfigError:
+      raise
+    except Exception as e:
+      raise exceptions.InferenceRuntimeError(
+          f'Anthropic API error: {str(e)}', original=e
+      ) from e
+
+  def infer(
+      self, batch_prompts: Sequence[str], **kwargs
+  ) -> Iterator[Sequence[core_types.ScoredOutput]]:
+    """Runs inference on a list of prompts via Anthropic's Messages API."""
+    merged_kwargs = self.merge_kwargs(kwargs)
+    config: dict[str, Any] = {}
+    temp = merged_kwargs.get('temperature', self.temperature)
+    if temp is not None:
+      config['temperature'] = temp
+    if 'max_output_tokens' in merged_kwargs:
+      config['max_output_tokens'] = merged_kwargs['max_output_tokens']
+    if 'top_p' in merged_kwargs:
+      config['top_p'] = merged_kwargs['top_p']
+    if 'stop' in merged_kwargs:
+      config['stop'] = merged_kwargs['stop']
+
+    if len(batch_prompts) > 1 and self.max_workers > 1:
+      with concurrent.futures.ThreadPoolExecutor(
+          max_workers=min(self.max_workers, len(batch_prompts))
+      ) as executor:
+        future_to_index = {
+            executor.submit(
+                self._process_single_prompt, prompt, config.copy()
+            ): i
+            for i, prompt in enumerate(batch_prompts)
+        }
+        results: list[core_types.ScoredOutput | None] = [None] * len(
+            batch_prompts
+        )
+        for future in concurrent.futures.as_completed(future_to_index):
+          index = future_to_index[future]
+          try:
+            results[index] = future.result()
+          except exceptions.InferenceConfigError:
+            raise
+          except Exception as e:
+            raise exceptions.InferenceRuntimeError(
+                f'Parallel inference error: {str(e)}', original=e
+            ) from e
+        for result in results:
+          if result is None:
+            raise exceptions.InferenceRuntimeError(
+                'Failed to process one or more prompts'
+            )
+          yield [result]
+    else:
+      for prompt in batch_prompts:
+        result = self._process_single_prompt(prompt, config.copy())
+        yield [result]

--- a/langextract/providers/builtin_registry.py
+++ b/langextract/providers/builtin_registry.py
@@ -48,4 +48,14 @@ BUILTIN_PROVIDERS: list[ProviderConfig] = [
         'target': 'langextract.providers.openai:OpenAILanguageModel',
         'priority': patterns.OPENAI_PRIORITY,
     },
+    {
+        'patterns': patterns.ANTHROPIC_PATTERNS,
+        'target': 'langextract.providers.anthropic:AnthropicLanguageModel',
+        'priority': patterns.ANTHROPIC_PRIORITY,
+    },
+    {
+        'patterns': patterns.XAI_PATTERNS,
+        'target': 'langextract.providers.xai:XAILanguageModel',
+        'priority': patterns.XAI_PRIORITY,
+    },
 ]

--- a/langextract/providers/latest_models.py
+++ b/langextract/providers/latest_models.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pinned current-generation Claude and Grok model IDs.
+
+Update this module when Anthropic or xAI ship a new generally-available
+generation. Aliases here are the dateless API IDs (pinned snapshots, not
+evergreen pointers).
+"""
+
+# Claude 5 generation (as of 2026-08). Haiku remains on 4.5.
+CLAUDE_DEFAULT = 'claude-sonnet-5'
+CLAUDE_FLAGSHIP = 'claude-opus-5'
+CLAUDE_FRONTIER = 'claude-fable-5'
+CLAUDE_FAST = 'claude-haiku-4-5'
+CLAUDE_MODELS = (
+    CLAUDE_DEFAULT,
+    CLAUDE_FLAGSHIP,
+    CLAUDE_FRONTIER,
+    CLAUDE_FAST,
+    'claude-haiku-4-5-20251001',
+)
+
+# Grok 4.6 generation (as of 2026-08).
+GROK_DEFAULT = 'grok-4.6'
+GROK_PREVIOUS = 'grok-4.5'
+XAI_BASE_URL = 'https://api.x.ai/v1'
+GROK_MODELS = (
+    GROK_DEFAULT,
+    GROK_PREVIOUS,
+    'grok-4.3',
+    'grok-4',
+    'grok-build',
+    'grok-build-0.1',
+)

--- a/langextract/providers/patterns.py
+++ b/langextract/providers/patterns.py
@@ -31,6 +31,20 @@ OPENAI_PATTERNS = (
 )
 OPENAI_PRIORITY = 10
 
+# Anthropic / Claude provider patterns (Claude 4.x and Claude 5)
+ANTHROPIC_PATTERNS = (
+    r'^claude',
+    r'^anthropic',
+)
+ANTHROPIC_PRIORITY = 10
+
+# xAI / Grok provider patterns
+XAI_PATTERNS = (
+    r'^grok',
+    r'^xai',
+)
+XAI_PRIORITY = 10
+
 # Ollama provider patterns
 OLLAMA_PATTERNS = (
     # Standard Ollama naming patterns

--- a/langextract/providers/xai.py
+++ b/langextract/providers/xai.py
@@ -1,0 +1,56 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""xAI (Grok) provider for LangExtract.
+
+Grok is OpenAI-API-compatible at https://api.x.ai/v1. This provider auto-routes
+`grok-*` model IDs and injects XAI_API_KEY + the xAI base URL.
+"""
+
+from __future__ import annotations
+
+import os
+
+from langextract.providers import latest_models
+from langextract.providers import openai as openai_provider
+from langextract.providers import patterns
+from langextract.providers import router
+
+
+@router.register(
+    *patterns.XAI_PATTERNS,
+    priority=patterns.XAI_PRIORITY,
+)
+class XAILanguageModel(openai_provider.OpenAILanguageModel):
+  """Grok models via xAI's OpenAI-compatible Chat Completions API."""
+
+  model_id: str = latest_models.GROK_DEFAULT
+
+  def __init__(
+      self,
+      model_id: str = latest_models.GROK_DEFAULT,
+      api_key: str | None = None,
+      base_url: str | None = None,
+      **kwargs,
+  ) -> None:
+    resolved_key = api_key or os.environ.get('XAI_API_KEY')
+    resolved_url = (
+        base_url or os.environ.get('XAI_BASE_URL') or latest_models.XAI_BASE_URL
+    )
+    super().__init__(
+        model_id=model_id or latest_models.GROK_DEFAULT,
+        api_key=resolved_key,
+        base_url=resolved_url,
+        **kwargs,
+    )

--- a/skills/langextract-usage/references/providers.md
+++ b/skills/langextract-usage/references/providers.md
@@ -16,6 +16,44 @@ result = lx.extract(
 
 Env: `GEMINI_API_KEY` (falls back to `LANGEXTRACT_API_KEY`).
 
+## Claude (Anthropic)
+
+Current generation: **Claude Sonnet 5** (default), **Claude Opus 5** (flagship),
+**Claude Fable 5** (frontier), **Claude Haiku 4.5** (fast).
+
+```python
+result = lx.extract(
+    text_or_documents=text,
+    prompt_description=prompt,
+    examples=examples,
+    model_id="claude-sonnet-5",
+)
+```
+
+Env: `ANTHROPIC_API_KEY` (falls back to `LANGEXTRACT_API_KEY`).
+Install: `pip install anthropic`.
+
+`claude-*` and `anthropic*` model IDs auto-route to `AnthropicLanguageModel`.
+
+## Grok (xAI)
+
+Current generation: **Grok 4.6** (default). Previous: `grok-4.5`.
+
+```python
+result = lx.extract(
+    text_or_documents=text,
+    prompt_description=prompt,
+    examples=examples,
+    model_id="grok-4.6",
+)
+```
+
+Env: `XAI_API_KEY` (falls back to `LANGEXTRACT_API_KEY`).
+Base URL: `XAI_BASE_URL` or `https://api.x.ai/v1`.
+Install: `pip install langextract[xai]` (pulls the OpenAI SDK).
+
+`grok-*` and `xai*` model IDs auto-route to `XAILanguageModel`.
+
 ## OpenAI
 
 ```python

--- a/tests/claude_grok_provider_test.py
+++ b/tests/claude_grok_provider_test.py
@@ -1,0 +1,120 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Routing and factory tests for current Claude 5 and Grok 4.6 providers."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from absl.testing import parameterized
+
+from langextract import factory
+from langextract import providers as providers_module
+from langextract.core import exceptions
+from langextract.providers import anthropic as anthropic_provider
+from langextract.providers import latest_models
+from langextract.providers import router
+from langextract.providers import xai as xai_provider
+
+
+class ClaudeGrokProviderTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    router.clear()
+    providers_module._reset_for_testing()
+    providers_module.load_builtins_once()
+
+  def tearDown(self):
+    super().tearDown()
+    router.clear()
+    providers_module._reset_for_testing()
+
+  @parameterized.named_parameters(
+      ('sonnet5', 'claude-sonnet-5'),
+      ('opus5', 'claude-opus-5'),
+      ('fable5', 'claude-fable-5'),
+      ('haiku45', 'claude-haiku-4-5'),
+      ('haiku_dated', 'claude-haiku-4-5-20251001'),
+  )
+  def test_claude_model_ids_route_to_anthropic(self, model_id):
+    resolved = router.resolve(model_id)
+    self.assertIs(resolved, anthropic_provider.AnthropicLanguageModel)
+
+  @parameterized.named_parameters(
+      ('grok46', 'grok-4.6'),
+      ('grok45', 'grok-4.5'),
+      ('grok43', 'grok-4.3'),
+      ('grok_build', 'grok-build'),
+  )
+  def test_grok_model_ids_route_to_xai(self, model_id):
+    resolved = router.resolve(model_id)
+    self.assertIs(resolved, xai_provider.XAILanguageModel)
+
+  def test_latest_model_constants(self):
+    self.assertEqual(latest_models.CLAUDE_DEFAULT, 'claude-sonnet-5')
+    self.assertEqual(latest_models.CLAUDE_FLAGSHIP, 'claude-opus-5')
+    self.assertEqual(latest_models.GROK_DEFAULT, 'grok-4.6')
+
+  def test_factory_reads_anthropic_api_key(self):
+    with mock.patch.dict(
+        'os.environ', {'ANTHROPIC_API_KEY': 'sk-ant-test'}, clear=False
+    ):
+      kwargs = factory._kwargs_with_environment_defaults('claude-sonnet-5', {})
+    self.assertEqual(kwargs['api_key'], 'sk-ant-test')
+
+  def test_factory_reads_xai_api_key_and_base_url(self):
+    with mock.patch.dict(
+        'os.environ', {'XAI_API_KEY': 'xai-test'}, clear=False
+    ):
+      kwargs = factory._kwargs_with_environment_defaults('grok-4.6', {})
+    self.assertEqual(kwargs['api_key'], 'xai-test')
+    self.assertEqual(kwargs['base_url'], 'https://api.x.ai/v1')
+
+  def test_anthropic_requires_api_key(self):
+    with mock.patch.dict('os.environ', {}, clear=True):
+      with mock.patch.dict('sys.modules', {'anthropic': mock.MagicMock()}):
+        with self.assertRaises(exceptions.InferenceConfigError):
+          anthropic_provider.AnthropicLanguageModel(model_id='claude-sonnet-5')
+
+  def test_anthropic_infer_flattens_text_blocks(self):
+    fake_anthropic = mock.MagicMock()
+    block = mock.Mock()
+    block.text = '{"items":[]}'
+    fake_anthropic.Anthropic.return_value.messages.create.return_value.content = [
+        block
+    ]
+    with mock.patch.dict('sys.modules', {'anthropic': fake_anthropic}):
+      model = anthropic_provider.AnthropicLanguageModel(
+          model_id='claude-sonnet-5', api_key='sk-ant-test'
+      )
+      outputs = list(model.infer(['extract revenue']))
+    self.assertEqual(outputs[0][0].output, '{"items":[]}')
+    call_kwargs = (
+        fake_anthropic.Anthropic.return_value.messages.create.call_args.kwargs
+    )
+    self.assertEqual(call_kwargs['model'], 'claude-sonnet-5')
+    self.assertIn('max_tokens', call_kwargs)
+
+  def test_xai_uses_grok_default_and_xai_base_url(self):
+    fake_openai = mock.MagicMock()
+    with mock.patch.dict('sys.modules', {'openai': fake_openai}):
+      model = xai_provider.XAILanguageModel(api_key='xai-test')
+    self.assertEqual(model.model_id, 'grok-4.6')
+    self.assertEqual(model.base_url, 'https://api.x.ai/v1')
+    fake_openai.OpenAI.assert_called_once()
+    _, kwargs = fake_openai.OpenAI.call_args
+    self.assertEqual(kwargs['base_url'], 'https://api.x.ai/v1')
+    self.assertEqual(kwargs['api_key'], 'xai-test')


### PR DESCRIPTION
# Description

Add first-class built-in providers so `lx.extract(model_id="claude-sonnet-5")` and `lx.extract(model_id="grok-4.6")` auto-route, matching Gemini / OpenAI / Ollama.

- `AnthropicLanguageModel` — Anthropic Messages API (`claude-*`). Default `claude-sonnet-5`; also `claude-opus-5`, `claude-fable-5`, `claude-haiku-4-5`.
- `XAILanguageModel` — OpenAI-compatible client at `https://api.x.ai/v1` (`grok-*`). Default `grok-4.6`.
- Factory env lookup: `ANTHROPIC_API_KEY` / `XAI_API_KEY` (falls back to `LANGEXTRACT_API_KEY`).

Does **not** change `pyproject.toml` (protected infrastructure). Claude needs `pip install anthropic`; Grok reuses `langextract[openai]`.

This extends the provider-registry work discussed in the community-supported provider thread.

Related to #99
Related to #522
Related to #187

Feature

# How Has This Been Tested?

```
$ pytest tests/claude_grok_provider_test.py tests/registry_test.py tests/factory_test.py
```

51 passed. Coverage includes:

- `claude-sonnet-5` / `claude-opus-5` / `claude-fable-5` / `claude-haiku-4-5` route to `AnthropicLanguageModel`
- `grok-4.6` / `grok-4.5` route to `XAILanguageModel`
- factory env-key + xAI base URL injection
- Anthropic message content flattening (mocked SDK)

Also ran pyink on the new/changed Python files. CI: format-check and unit tests + pylint on 3.10 / 3.11 / 3.12.

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [ ] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.
