### PR TITLE
fix(gemini): surface refused batch responses

### DIFF
--- a/langextract/providers/gemini_batch.py
+++ b/langextract/providers/gemini_batch.py
@@ -556,6 +556,33 @@ def _extract_text(resp: _TextResponse | dict[str, Any] | None) -> str | None:
   return text if isinstance(text, str) else None
 
 
+def _response_error(resp: dict[str, Any]) -> str | None:
+  """Return a diagnostic when Gemini returned no usable candidate text."""
+  feedback = resp.get("prompt_feedback")
+  if isinstance(feedback, dict):
+    block_reason = feedback.get("block_reason") or feedback.get("blockReason")
+    if block_reason:
+      block_message = feedback.get("block_reason_message") or feedback.get(
+          "blockReasonMessage"
+      )
+      detail = f": {block_message}" if block_message else ""
+      return f"prompt blocked ({block_reason}){detail}"
+
+  candidates = resp.get("candidates")
+  if not isinstance(candidates, list) or not candidates:
+    return None
+  candidate = candidates[0]
+  if not isinstance(candidate, dict):
+    return None
+  reason = candidate.get("finish_reason") or candidate.get("finishReason")
+  message = candidate.get("finish_message") or candidate.get("finishMessage")
+  reason_name = str(reason).rsplit(".", maxsplit=1)[-1]
+  if reason and reason_name != "STOP":
+    detail = f", message={message}" if message else ""
+    return f"finish reason={reason}{detail}"
+  return None
+
+
 def _poll_completion(
     client: genai.Client, job: genai.types.BatchJob, cfg: BatchConfig
 ) -> genai.types.BatchJob:
@@ -619,7 +646,14 @@ def _parse_batch_line(
       raise exceptions.InferenceRuntimeError(f"Batch item error: {error}")
 
   resp = obj.get("response", {})
-  text = _extract_text(resp) or ""
+  text = _extract_text(resp)
+  if text is None and isinstance(resp, dict) and not cfg.ignore_item_errors:
+    response_error = _response_error(resp)
+    if response_error:
+      raise exceptions.InferenceRuntimeError(
+          f"Batch item response error: {response_error}"
+      )
+  text = text or ""
 
   key = obj.get("key", "")
   try:

--- a/tests/test_gemini_batch_api.py
+++ b/tests/test_gemini_batch_api.py
@@ -566,6 +566,77 @@ class TestGeminiBatchAPI(absltest.TestCase):
     with self.assertRaisesRegex(Exception, "Batch item error"):
       list(model.infer(["test"]))
 
+  def test_batch_item_response_refusal_raises(self):
+    """A refusal without text is not treated as a successful empty result."""
+    cfg = gb.BatchConfig()
+    with self.assertRaisesRegex(Exception, "finish reason=SAFETY"):
+      gb._parse_batch_line(
+          json.dumps({
+              "key": "idx-0",
+              "response": {"candidates": [{"finish_reason": "SAFETY"}]},
+          }),
+          {},
+          cfg,
+      )
+
+  def test_batch_item_empty_response_remains_empty(self):
+    """A response without an error diagnostic remains an empty extraction."""
+    outputs = {}
+    gb._parse_batch_line(
+        json.dumps({"key": "idx-0", "response": {"candidates": []}}),
+        outputs,
+        gb.BatchConfig(),
+    )
+    self.assertEqual(outputs, {0: ""})
+
+  def test_batch_item_response_refusal_can_be_ignored(self):
+    """The existing ignore-item-errors option suppresses response errors."""
+    outputs = {}
+    gb._parse_batch_line(
+        json.dumps({
+            "key": "idx-0",
+            "response": {"candidates": [{"finish_reason": "SAFETY"}]},
+        }),
+        outputs,
+        gb.BatchConfig(ignore_item_errors=True),
+    )
+    self.assertEqual(outputs, {0: ""})
+
+  def test_batch_item_prompt_feedback_block_raises(self):
+    """A prompt block reason is surfaced with its optional message."""
+    with self.assertRaisesRegex(Exception, r"prompt blocked \(SAFETY\)"):
+      gb._parse_batch_line(
+          json.dumps({
+              "key": "idx-0",
+              "response": {
+                  "prompt_feedback": {
+                      "blockReason": "SAFETY",
+                      "blockReasonMessage": "blocked content",
+                  }
+              },
+          }),
+          {},
+          gb.BatchConfig(),
+      )
+
+  def test_batch_item_text_wins_over_finish_reason(self):
+    """A candidate with text is not rejected based on its finish reason."""
+    outputs = {}
+    gb._parse_batch_line(
+        json.dumps({
+            "key": "idx-0",
+            "response": {
+                "candidates": [{
+                    "content": {"parts": [{"text": "partial"}]},
+                    "finishReason": "SAFETY",
+                }]
+            },
+        }),
+        outputs,
+        gb.BatchConfig(),
+    )
+    self.assertEqual(outputs, {0: "partial"})
+
 
 class BatchConfigValidationTest(parameterized.TestCase):
   """Test BatchConfig validation logic."""


### PR DESCRIPTION
# Description

Gemini batch responses that are safety-blocked or refused without candidate text were silently stored as successful empty extractions. This loses the provider diagnostic and makes a failed item indistinguishable from a valid empty result.

The fix inspects Gemini batch response feedback and non-STOP candidate finish reasons only when no text is available, raises `InferenceRuntimeError` with the available diagnostic, preserves the existing `ignore_item_errors` opt-out, and keeps undiagnosed empty responses as empty extractions for compatibility. It accepts both snake_case and camelCase JSON field names used by SDK/serialized response shapes.

Fixes #527

# How Has This Been Tested?

- `uv run --extra dev --extra test pytest tests/test_gemini_batch_api.py -q` — 31 passed, 1 dependency deprecation warning.
- `uv run --extra dev --extra test pyink --check langextract/providers/gemini_batch.py tests/test_gemini_batch_api.py --config pyproject.toml` — passed.
- `git diff --check` — passed.
- Deterministic tests cover finish-reason refusal, prompt feedback blocks, empty responses, ignored refusals, camelCase fields, and preserving text when a finish reason is present.
- No live Gemini or Vertex credentials were used; tests use the documented JSON response shape.

# Checklist

- [x] Bug fix
- [x] Regression tests added
- [x] Focused tests and formatter checks passed
- [x] No infrastructure or dependency changes
- [ ] Full live API tests (not applicable; no credentials used)
