### PR TITLE
fix: honor explicit temperature when config= or model= is passed to extract()

### DIFF
--- a/langextract/extraction.py
+++ b/langextract/extraction.py
@@ -108,7 +108,12 @@ def extract(
       format_type: The format type for the output (JSON or YAML).
       max_char_buffer: Max number of characters for inference.
       temperature: The sampling temperature for generation. When None (default),
-        uses the model's default temperature. Set to 0.0 for deterministic output
+        uses the model's default temperature. When 'config' is provided, an
+        explicit temperature is merged into config.provider_kwargs and takes
+        precedence over any temperature already set there; the caller's
+        ModelConfig is not mutated. When 'model' is provided the model is
+        already constructed, so temperature cannot be applied and a UserWarning
+        is emitted. Set to 0.0 for deterministic output
         or higher values for more variation.
       fence_output: Whether to expect/generate fenced output (```json or
         ```yaml). When True, the model is prompted to generate fenced output and
@@ -166,9 +171,13 @@ def extract(
         mentioned in the previous chunk). Defaults to None (disabled).
       config: Model configuration to use for extraction. Takes precedence over
         model_id, api_key, and language_model_type parameters. When both model
-        and config are provided, model takes precedence.
+        and config are provided, model takes precedence. An explicit
+        'temperature' argument is merged into config.provider_kwargs and wins
+        over a temperature already present there.
       model: Pre-configured language model to use for extraction. Takes
-        precedence over all other parameters including config.
+        precedence over all other parameters including config. Because the
+        instance is already built, 'temperature' cannot be applied to it and is
+        reported via a UserWarning instead of being silently dropped.
       output_schema: Optional JSON schema for LangExtract's raw JSON output
         envelope. It replaces example-derived provider constraints, while
         examples still guide the prompt when supplied. Use `lx.schema` helpers
@@ -281,6 +290,14 @@ def extract(
           UserWarning,
           stacklevel=2,
       )
+    if temperature is not None:
+      warnings.warn(
+          "'temperature' is ignored when 'model' is provided. Set the "
+          "temperature on the model instance before passing it to extract(), "
+          "or pass 'config' instead so that 'temperature' can be forwarded.",
+          UserWarning,
+          stacklevel=2,
+      )
   elif config:
     if use_schema_constraints and output_schema is None:
       warnings.warn(
@@ -288,6 +305,18 @@ def extract(
           "Or pass output_schema=... for an explicit schema.",
           UserWarning,
           stacklevel=2,
+      )
+
+    if temperature is not None:
+      # An explicit 'temperature' kwarg wins over a temperature carried in
+      # config.provider_kwargs. Replace rather than mutate so the caller's
+      # ModelConfig is left untouched and stays reusable.
+      config = dataclasses.replace(
+          config,
+          provider_kwargs={
+              **(config.provider_kwargs or {}),
+              "temperature": temperature,
+          },
       )
 
     language_model = factory.create_model(

--- a/tests/extract_precedence_test.py
+++ b/tests/extract_precedence_test.py
@@ -152,6 +152,111 @@ class ExtractParameterPrecedenceTest(absltest.TestCase):
 
   @mock.patch("langextract.annotation.Annotator")
   @mock.patch("langextract.extraction.factory.create_model")
+  def test_temperature_merges_into_config_provider_kwargs(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    """Test that an explicit temperature reaches the config's provider_kwargs."""
+    config = factory.ModelConfig(
+        model_id="config-model", provider_kwargs={"api_key": "config-key"}
+    )
+    mock_model = mock.MagicMock()
+    mock_model.requires_fence_output = True
+    mock_create_model.return_value = mock_model
+    mock_annotator_cls.return_value.annotate_text.return_value = "ok"
+
+    lx.extract(
+        text_or_documents="text",
+        prompt_description=self.description,
+        examples=self.examples,
+        config=config,
+        temperature=0.0,
+        use_schema_constraints=False,
+    )
+
+    called_config = mock_create_model.call_args[1]["config"]
+    self.assertEqual(
+        called_config.provider_kwargs,
+        {"api_key": "config-key", "temperature": 0.0},
+    )
+    self.assertEqual(called_config.model_id, "config-model")
+    # The caller's config must not be mutated.
+    self.assertEqual(config.provider_kwargs, {"api_key": "config-key"})
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.extraction.factory.create_model")
+  def test_explicit_temperature_overrides_config_provider_kwargs(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    """Test that an explicit temperature wins over one set in provider_kwargs."""
+    config = factory.ModelConfig(
+        model_id="config-model", provider_kwargs={"temperature": 0.9}
+    )
+    mock_model = mock.MagicMock()
+    mock_model.requires_fence_output = True
+    mock_create_model.return_value = mock_model
+    mock_annotator_cls.return_value.annotate_text.return_value = "ok"
+
+    lx.extract(
+        text_or_documents="text",
+        prompt_description=self.description,
+        examples=self.examples,
+        config=config,
+        temperature=0.0,
+        use_schema_constraints=False,
+    )
+
+    called_config = mock_create_model.call_args[1]["config"]
+    self.assertEqual(called_config.provider_kwargs["temperature"], 0.0)
+    self.assertEqual(config.provider_kwargs["temperature"], 0.9)
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.extraction.factory.create_model")
+  def test_config_temperature_preserved_without_explicit_temperature(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    """Test that config's temperature survives when extract() gets none."""
+    config = factory.ModelConfig(
+        model_id="config-model", provider_kwargs={"temperature": 0.9}
+    )
+    mock_model = mock.MagicMock()
+    mock_model.requires_fence_output = True
+    mock_create_model.return_value = mock_model
+    mock_annotator_cls.return_value.annotate_text.return_value = "ok"
+
+    lx.extract(
+        text_or_documents="text",
+        prompt_description=self.description,
+        examples=self.examples,
+        config=config,
+        use_schema_constraints=False,
+    )
+
+    called_config = mock_create_model.call_args[1]["config"]
+    self.assertEqual(called_config.provider_kwargs["temperature"], 0.9)
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.extraction.factory.create_model")
+  def test_temperature_with_model_emits_warning(
+      self, mock_create_model, mock_annotator_cls
+  ):
+    """Test that temperature is reported, not dropped, when model is given."""
+    provided_model = mock.MagicMock()
+    mock_annotator_cls.return_value.annotate_text.return_value = "ok"
+
+    with self.assertWarnsRegex(UserWarning, "'temperature' is ignored"):
+      lx.extract(
+          text_or_documents="text",
+          prompt_description=self.description,
+          examples=self.examples,
+          model=provided_model,
+          temperature=0.0,
+          use_schema_constraints=False,
+      )
+
+    mock_create_model.assert_not_called()
+
+  @mock.patch("langextract.annotation.Annotator")
+  @mock.patch("langextract.extraction.factory.create_model")
   def test_language_model_type_only_emits_warning_and_works(
       self, mock_create_model, mock_annotator_cls
   ):


### PR DESCRIPTION
# Description

`extract()` accepts a top-level `temperature` argument documented as "Set to 0.0
for deterministic output", but the value is only merged into provider kwargs in
the `model_id` branch of `extraction.py`. When a caller passes a pre-built
`config=` (`factory.ModelConfig`) or `model=` (a language model instance), the
argument is silently ignored: the request carries no `temperature` parameter at
all (the OpenAI provider omits it when the value is `None`), so generation runs
at the server default temperature.

We found this with a batch-invariant vLLM deployment: raw API probes at
temperature 0 were byte-identical across runs, while extractions through
langextract differed run to run. A wire capture showed the request parameters
were `{"model", "n", "response_format"}` with no temperature despite
`temperature=0.0` being passed.

This PR:

- `config=` branch: merges an explicit `temperature` into the config via
  `dataclasses.replace`, so the caller's `ModelConfig` is never mutated. An
  explicit kwarg wins over a config-supplied value; with no explicit kwarg the
  config value is untouched.
- `model=` branch: emits a `UserWarning` instead of silently ignoring the
  argument (a constructed model has no provider-agnostic temperature setter, and
  silently mutating caller-configured state seemed worse). This mirrors the
  existing `use_schema_constraints` warning in the same branch.
- Updates the `temperature`, `config`, and `model` docstrings with the
  precedence rule.

Fixes #529

Choose one: Bug fix

# How Has This Been Tested?

Added `tests/extract_precedence_test.py` with four tests covering the
precedence rules: explicit kwarg wins over a config-supplied value, a
config-supplied value survives when no kwarg is passed, the caller's
`ModelConfig` is not mutated, and the `model=` branch warns. Ran the new file
and the full suite:

```
$ pytest tests/extract_precedence_test.py -v
$ pytest tests
```

All pass. The original symptom was also re-verified end to end against our
batch-invariant vLLM deployment: with the patch, extractions at
`temperature=0.0` are byte-identical across runs, matching the raw API probes.

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [ ] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [x] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.
