### PR TITLE
Raise on model responses without text

### DIFF
--- a/langextract/providers/README.md
+++ b/langextract/providers/README.md
@@ -378,6 +378,14 @@ class MyProviderLanguageModel(base_model.BaseLanguageModel):
             yield [types.ScoredOutput(score=1.0, output=result)]
 ```
 
+The built-in providers keep SDK response types inside the provider. A local
+helper such as `_response_to_scored_output()` translates usable text into
+`ScoredOutput` and raises a provider-tagged `InferenceRuntimeError` for blocked,
+refused, truncated, or otherwise unusable responses. `infer()` remains the
+public plugin contract; the helper is a convention, not a required base method.
+Providers using this pattern should re-raise `InferenceRuntimeError` before any
+retry or blanket exception handler so the diagnostic is preserved.
+
 **Pattern Registration Explained:**
 - The `@router.register` decorator patterns (e.g., `r'^mymodel'`, `r'^custom'`) define which model IDs your provider supports
 - When users call `lx.extract(model_id="mymodel-3b")`, the router matches against these patterns

--- a/langextract/providers/gemini.py
+++ b/langextract/providers/gemini.py
@@ -27,6 +27,7 @@ import time
 from typing import Any, Final, Iterator, Sequence
 
 from absl import logging
+from google.genai import types as genai_types
 
 from langextract.core import base_model
 from langextract.core import data
@@ -94,6 +95,68 @@ def _has_sdk_retry_options(http_options: Any) -> bool:
     attempts = getattr(retry_options, 'attempts', None)
   # attempts=None means SDK default (which is >1); 0 or 1 means no retries.
   return attempts is None or attempts > 1
+
+
+_MAX_TOKENS_HINT: Final[str] = (
+    ' The output token budget was exhausted before any text was emitted;'
+    ' consider raising max_output_tokens (thinking models may consume the'
+    ' budget on reasoning before any text is produced).'
+)
+
+
+def _no_text_diagnostic(
+    response: genai_types.GenerateContentResponse, text: str | None
+) -> str | None:
+  """Diagnose missing output that the SDK reports without raising.
+
+  Returning missing text as success can silently drop a blocked chunk.
+
+  Returns:
+    A provider diagnostic, or None for text and empty completions without a
+    block or abnormal finish reason, which retain existing resolver handling.
+  """
+  if text:
+    return None
+
+  prompt_feedback = response.prompt_feedback
+  block_reason = prompt_feedback.block_reason if prompt_feedback else None
+  candidate = response.candidates[0] if response.candidates else None
+  finish_reason = candidate.finish_reason if candidate else None
+  if block_reason == genai_types.BlockedReason.BLOCKED_REASON_UNSPECIFIED:
+    block_reason = None
+  if finish_reason == genai_types.FinishReason.FINISH_REASON_UNSPECIFIED:
+    finish_reason = None
+
+  if (
+      text == ''
+      and block_reason is None
+      and finish_reason in (None, genai_types.FinishReason.STOP)
+  ):
+    return None
+
+  if block_reason:
+    block_message = prompt_feedback.block_reason_message
+    detail = f': {block_message}' if block_message else ''
+    return (
+        'Gemini blocked the prompt'
+        f' (block_reason={block_reason.value}{detail}).'
+    )
+  if finish_reason and finish_reason != genai_types.FinishReason.STOP:
+    hint = (
+        _MAX_TOKENS_HINT
+        if finish_reason == genai_types.FinishReason.MAX_TOKENS
+        else ''
+    )
+    return (
+        f'Gemini returned no text (finish_reason={finish_reason.value}).{hint}'
+    )
+  if candidate and candidate.content and candidate.content.parts:
+    return (
+        'Gemini returned only non-text parts (e.g. a function call or'
+        ' thought-only output) where text output was expected.'
+    )
+  detail = f' (finish_reason={finish_reason.value})' if finish_reason else ''
+  return f'Gemini returned no text content{detail}.'
 
 
 _GENERATION_CONFIG_KEYS: Final[tuple[str, ...]] = (
@@ -383,8 +446,10 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
         response = self._client.models.generate_content(
             model=self.model_id, contents=prompt, config=call_config
         )
-        return core_types.ScoredOutput(score=1.0, output=response.text)
+        return self._response_to_scored_output(response)
 
+      except exceptions.InferenceRuntimeError:
+        raise
       except Exception as e:
         if attempt < self.max_retries and self._is_retryable_error(e):
           # Cap after jitter so the named maximum applies to the real sleep.
@@ -402,8 +467,23 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
           delay = min(delay * 2, self.max_retry_delay)
           continue
         raise exceptions.InferenceRuntimeError(
-            f'Gemini API error: {e}', original=e
+            f'Gemini API error: {e}', original=e, provider='Gemini'
         ) from e
+
+  @staticmethod
+  def _response_to_scored_output(
+      response: genai_types.GenerateContentResponse,
+  ) -> core_types.ScoredOutput:
+    """Translate one Gemini SDK response into LangExtract output.
+
+    Raises:
+      InferenceRuntimeError: If the response has no usable text.
+    """
+    output_text = response.text
+    diagnostic = _no_text_diagnostic(response, output_text)
+    if diagnostic is not None:
+      raise exceptions.InferenceRuntimeError(diagnostic, provider='Gemini')
+    return core_types.ScoredOutput(score=1.0, output=output_text)
 
   def infer(
       self, batch_prompts: Sequence[str], **kwargs
@@ -509,6 +589,8 @@ class GeminiLanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
           index = future_to_index[future]
           try:
             results[index] = future.result()
+          except exceptions.InferenceRuntimeError:
+            raise
           except Exception as e:
             raise exceptions.InferenceRuntimeError(
                 f'Parallel inference error: {str(e)}', original=e

--- a/langextract/providers/openai.py
+++ b/langextract/providers/openai.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import concurrent.futures
 import dataclasses
 import logging
-from typing import Any, Iterator, Sequence
+from typing import Any, Iterator, Sequence, TYPE_CHECKING
 import warnings
 
 from langextract.core import base_model
@@ -32,6 +32,9 @@ from langextract.providers import openai_batch
 from langextract.providers import patterns
 from langextract.providers import router
 from langextract.providers import schemas
+
+if TYPE_CHECKING:
+  from openai.types import chat
 
 
 @router.register(
@@ -248,17 +251,59 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
     try:
       api_params = self._build_chat_completions_params(prompt, config)
       response = self._client.chat.completions.create(**api_params)
-
-      output_text = response.choices[0].message.content
-
-      return core_types.ScoredOutput(score=1.0, output=output_text)
+      return self._response_to_scored_output(response)
 
     except exceptions.InferenceConfigError:
       raise
+    except exceptions.InferenceRuntimeError:
+      raise
     except Exception as e:
       raise exceptions.InferenceRuntimeError(
-          f'OpenAI API error: {str(e)}', original=e
+          f'OpenAI API error: {str(e)}', original=e, provider='OpenAI'
       ) from e
+
+  @staticmethod
+  def _response_to_scored_output(
+      response: chat.ChatCompletion,
+  ) -> core_types.ScoredOutput:
+    """Translate one OpenAI SDK response into LangExtract output.
+
+    Raises:
+      InferenceRuntimeError: If the response has no usable content.
+    """
+    if not response.choices:
+      raise exceptions.InferenceRuntimeError(
+          'OpenAI response contained no choices.', provider='OpenAI'
+      )
+
+    choice = response.choices[0]
+    output_text = choice.message.content
+    finish_reason = choice.finish_reason
+
+    # Refusals may accompany content, so do not tie them to empty output.
+    refusal = choice.message.refusal
+    if refusal:
+      raise exceptions.InferenceRuntimeError(
+          f'OpenAI refused the request: {refusal}', provider='OpenAI'
+      )
+
+    if output_text is None or (
+        not output_text and finish_reason not in (None, 'stop')
+    ):
+      detail = f' (finish_reason={finish_reason})' if finish_reason else ''
+      hint = (
+          ' The output token budget was exhausted before any text was'
+          ' emitted; consider raising max_output_tokens (reasoning models'
+          ' may consume the budget before any text is produced).'
+          if finish_reason == 'length'
+          else ''
+      )
+      raise exceptions.InferenceRuntimeError(
+          f'OpenAI response contained no message content{detail}.{hint}',
+          provider='OpenAI',
+      )
+
+    return core_types.ScoredOutput(score=1.0, output=output_text)
 
   def infer_batch(
       self, prompts: Sequence[str], batch_size: int = 32
@@ -371,6 +416,8 @@ class OpenAILanguageModel(base_model.BaseLanguageModel):  # pylint: disable=too-
           try:
             results[index] = future.result()
           except exceptions.InferenceConfigError:
+            raise
+          except exceptions.InferenceRuntimeError:
             raise
           except Exception as e:
             raise exceptions.InferenceRuntimeError(

--- a/tests/gemini_retry_test.py
+++ b/tests/gemini_retry_test.py
@@ -23,6 +23,8 @@ from google import genai
 from google.genai import errors as genai_errors
 import httpx
 
+import langextract as lx
+from langextract.core import data
 from langextract.core import exceptions
 from langextract.providers import gemini
 
@@ -512,6 +514,311 @@ class TestGeminiHttpOptionsRetryGuard(_MockClientTest):
     http_options = mock.MagicMock(spec=['retry_options'], retry_options=None)
     model = _build_model(http_options=http_options, max_retries=3)
     self.assertEqual(model.max_retries, 3)
+
+
+def _make_no_text_response(
+    *,
+    text=None,
+    block_reason=None,
+    block_reason_message=None,
+    finish_reason=None,
+    parts=None,
+):
+  """Build a response whose `.text` reports no usable output."""
+  response = mock.create_autospec(
+      genai.types.GenerateContentResponse, instance=True
+  )
+  response.text = text
+  if block_reason is not None:
+    response.prompt_feedback = (
+        genai.types.GenerateContentResponsePromptFeedback(
+            block_reason=block_reason, block_reason_message=block_reason_message
+        )
+    )
+  else:
+    response.prompt_feedback = None
+  if finish_reason is not None or parts is not None:
+    response.candidates = [
+        genai.types.Candidate(
+            finish_reason=finish_reason,
+            content=genai.types.Content(parts=parts),
+        )
+    ]
+  else:
+    response.candidates = []
+  return response
+
+
+class TestGeminiNoTextResponse(_MockClientTest):
+  """Responses without text must raise, not report empty success (#508)."""
+
+  def setUp(self):
+    super().setUp()
+    self.model = _build_model()
+
+  @parameterized.named_parameters(
+      ('text', '{"ok": 1}'),
+      ('empty_text', ''),
+  )
+  def test_text_is_read_once(self, text):
+    self.mock_client.models.generate_content.return_value = (
+        genai.types.GenerateContentResponse()
+    )
+    mock_text = self.enter_context(
+        mock.patch.object(
+            genai.types.GenerateContentResponse,
+            'text',
+            new_callable=mock.PropertyMock,
+            return_value=text,
+        )
+    )
+
+    result = self.model._process_single_prompt('prompt', {})
+
+    self.assertEqual(result.output, text)
+    self.assertEqual(result.score, 1.0)
+    mock_text.assert_called_once()
+
+  @parameterized.named_parameters(
+      dict(testcase_name='none_text', text=None),
+      dict(testcase_name='empty_text', text=''),
+  )
+  def test_blocked_prompt_raises_with_block_reason(self, text):
+    self.mock_client.models.generate_content.return_value = (
+        _make_no_text_response(
+            text=text,
+            block_reason=genai.types.BlockedReason.SAFETY,
+            block_reason_message='unsafe request',
+        )
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        r'blocked the prompt \(block_reason=SAFETY: unsafe request\)',
+    ) as cm:
+      self.model._process_single_prompt('prompt', {})
+
+    self.assertEqual(cm.exception.provider, 'Gemini')
+
+  @parameterized.named_parameters(
+      dict(testcase_name='none_text', text=None),
+      dict(testcase_name='empty_text', text=''),
+  )
+  def test_non_stop_finish_reason_raises(self, text):
+    self.mock_client.models.generate_content.return_value = (
+        _make_no_text_response(
+            text=text, finish_reason=genai.types.FinishReason.SAFETY
+        )
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        r'no text \(finish_reason=SAFETY\)',
+    ):
+      self.model._process_single_prompt('prompt', {})
+
+  @parameterized.named_parameters(
+      dict(testcase_name='none_text', text=None),
+      dict(testcase_name='empty_text', text=''),
+  )
+  def test_exhausted_token_budget_raises_with_hint(self, text):
+    self.mock_client.models.generate_content.return_value = (
+        _make_no_text_response(
+            text=text, finish_reason=genai.types.FinishReason.MAX_TOKENS
+        )
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        r'finish_reason=MAX_TOKENS.*max_output_tokens',
+    ):
+      self.model._process_single_prompt('prompt', {})
+
+  def test_empty_text_with_normal_stop_passes_through(self):
+    self.mock_client.models.generate_content.return_value = (
+        genai.types.GenerateContentResponse(
+            candidates=[
+                genai.types.Candidate(
+                    finish_reason=genai.types.FinishReason.STOP,
+                    content=genai.types.Content(
+                        parts=[genai.types.Part(text='')]
+                    ),
+                )
+            ]
+        )
+    )
+
+    result = self.model._process_single_prompt('prompt', {})
+
+    self.assertEqual(result.output, '')
+
+  def test_extract_accepts_empty_text_with_normal_stop(self):
+    self.mock_client.models.generate_content.return_value = (
+        genai.types.GenerateContentResponse(
+            candidates=[
+                genai.types.Candidate(
+                    finish_reason=genai.types.FinishReason.STOP,
+                    content=genai.types.Content(
+                        parts=[genai.types.Part(text='')]
+                    ),
+                )
+            ]
+        )
+    )
+    examples = [
+        data.ExampleData(
+            text='Alice lives in Paris.',
+            extractions=[
+                data.Extraction(
+                    extraction_class='person', extraction_text='Alice'
+                )
+            ],
+        )
+    ]
+
+    result = lx.extract(
+        text_or_documents='Bob lives in London.',
+        prompt_description='Extract person names.',
+        examples=examples,
+        model=self.model,
+        use_schema_constraints=False,
+        show_progress=False,
+    )
+
+    self.assertEmpty(result.extractions)
+
+  def test_non_text_parts_raise(self):
+    self.mock_client.models.generate_content.return_value = (
+        _make_no_text_response(
+            parts=[genai.types.Part(function_call={'name': 'extract'})]
+        )
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError, 'only non-text parts'
+    ):
+      self.model._process_single_prompt('prompt', {})
+
+  def test_no_diagnostic_raises_generic_message(self):
+    self.mock_client.models.generate_content.return_value = (
+        _make_no_text_response()
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError, 'no text content'
+    ):
+      self.model._process_single_prompt('prompt', {})
+
+  def test_blocked_prompt_without_message_preserves_error_without_retry(self):
+    self.mock_client.models.generate_content.return_value = (
+        _make_no_text_response(block_reason=genai.types.BlockedReason.SAFETY)
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        r'^Gemini blocked the prompt \(block_reason=SAFETY\)\.$',
+    ):
+      self.model._process_single_prompt('prompt', {})
+
+    self.mock_client.models.generate_content.assert_called_once()
+
+  def test_unspecified_block_reason_is_not_reported_as_blocked(self):
+    self.mock_client.models.generate_content.return_value = (
+        _make_no_text_response(
+            text='',
+            block_reason=genai.types.BlockedReason.BLOCKED_REASON_UNSPECIFIED,
+            finish_reason=genai.types.FinishReason.STOP,
+        )
+    )
+
+    result = self.model._process_single_prompt('prompt', {})
+
+    self.assertEqual(result.output, '')
+
+  def test_unspecified_finish_reason_allows_empty_text(self):
+    self.mock_client.models.generate_content.return_value = (
+        _make_no_text_response(
+            text='',
+            finish_reason=(genai.types.FinishReason.FINISH_REASON_UNSPECIFIED),
+        )
+    )
+
+    result = self.model._process_single_prompt('prompt', {})
+
+    self.assertEqual(result.output, '')
+
+  def test_none_text_with_stop_finish_reason_names_the_reason(self):
+    self.mock_client.models.generate_content.return_value = (
+        _make_no_text_response(finish_reason=genai.types.FinishReason.STOP)
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        r'no text content \(finish_reason=STOP\)',
+    ):
+      self.model._process_single_prompt('prompt', {})
+
+  def test_parallel_infer_preserves_no_text_error(self):
+    self.mock_client.models.generate_content.return_value = (
+        _make_no_text_response(block_reason=genai.types.BlockedReason.SAFETY)
+    )
+    model = _build_model(max_workers=2)
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError, r'^Gemini blocked the prompt'
+    ) as cm:
+      list(model.infer(['prompt one', 'prompt two']))
+
+    self.assertEqual(cm.exception.provider, 'Gemini')
+
+  @parameterized.named_parameters(
+      dict(testcase_name='sequential', max_workers=1),
+      dict(testcase_name='parallel', max_workers=2),
+  )
+  def test_extract_propagates_thought_only_response(self, max_workers):
+    self.mock_client.models.generate_content.return_value = (
+        genai.types.GenerateContentResponse(
+            candidates=[
+                genai.types.Candidate(
+                    finish_reason=genai.types.FinishReason.MAX_TOKENS,
+                    content=genai.types.Content(
+                        parts=[genai.types.Part(text='Thinking', thought=True)]
+                    ),
+                )
+            ]
+        )
+    )
+    examples = [
+        data.ExampleData(
+            text='Alice lives in Paris.',
+            extractions=[
+                data.Extraction(
+                    extraction_class='person', extraction_text='Alice'
+                )
+            ],
+        )
+    ]
+    model = _build_model(max_workers=max_workers)
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError, r'^Gemini.*MAX_TOKENS'
+    ) as cm:
+      lx.extract(
+          text_or_documents='Alice lives in Paris. Bob lives in London.',
+          prompt_description='Extract person names.',
+          examples=examples,
+          model=model,
+          use_schema_constraints=False,
+          max_char_buffer=24,
+          batch_length=2,
+          max_workers=max_workers,
+          show_progress=False,
+      )
+
+    self.assertEqual(cm.exception.provider, 'Gemini')
+    self.assertEqual(
+        self.mock_client.models.generate_content.call_count, max_workers
+    )
 
 
 if __name__ == '__main__':

--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -870,7 +870,12 @@ class TestOpenAILanguageModelInference(parameterized.TestCase):
 
     mock_response = mock.Mock()
     mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"name": "John", "age": 30}'))
+        mock.Mock(
+            message=mock.Mock(
+                content='{"name": "John", "age": 30}', refusal=None
+            ),
+            finish_reason="stop",
+        )
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
@@ -941,7 +946,10 @@ class TestOpenAILanguageModel(absltest.TestCase):
 
     mock_response = mock.Mock()
     mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+        mock.Mock(
+            message=mock.Mock(content='{"result": "test"}', refusal=None),
+            finish_reason="stop",
+        )
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
@@ -967,7 +975,10 @@ class TestOpenAILanguageModel(absltest.TestCase):
 
     mock_response = mock.Mock()
     mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+        mock.Mock(
+            message=mock.Mock(content='{"result": "test"}', refusal=None),
+            finish_reason="stop",
+        )
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
@@ -990,7 +1001,10 @@ class TestOpenAILanguageModel(absltest.TestCase):
 
     mock_response = mock.Mock()
     mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+        mock.Mock(
+            message=mock.Mock(content='{"result": "test"}', refusal=None),
+            finish_reason="stop",
+        )
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
@@ -1014,7 +1028,10 @@ class TestOpenAILanguageModel(absltest.TestCase):
 
     mock_response = mock.Mock()
     mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+        mock.Mock(
+            message=mock.Mock(content='{"result": "test"}', refusal=None),
+            finish_reason="stop",
+        )
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
@@ -1036,7 +1053,10 @@ class TestOpenAILanguageModel(absltest.TestCase):
 
     mock_response = mock.Mock()
     mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+        mock.Mock(
+            message=mock.Mock(content='{"result": "test"}', refusal=None),
+            finish_reason="stop",
+        )
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
@@ -1059,7 +1079,10 @@ class TestOpenAILanguageModel(absltest.TestCase):
 
     mock_response = mock.Mock()
     mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+        mock.Mock(
+            message=mock.Mock(content='{"result": "test"}', refusal=None),
+            finish_reason="stop",
+        )
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
@@ -1082,7 +1105,10 @@ class TestOpenAILanguageModel(absltest.TestCase):
 
     mock_response = mock.Mock()
     mock_response.choices = [
-        mock.Mock(message=mock.Mock(content="test output"))
+        mock.Mock(
+            message=mock.Mock(content="test output", refusal=None),
+            finish_reason="stop",
+        )
     ]
     mock_client.chat.completions.create.return_value = mock_response
 
@@ -1108,7 +1134,10 @@ class TestOpenAILanguageModel(absltest.TestCase):
 
     mock_response = mock.Mock()
     mock_response.choices = [
-        mock.Mock(message=mock.Mock(content='{"result": "test"}'))
+        mock.Mock(
+            message=mock.Mock(content='{"result": "test"}', refusal=None),
+            finish_reason="stop",
+        )
     ]
     mock_client.chat.completions.create.return_value = mock_response
 

--- a/tests/provider_schema_test.py
+++ b/tests/provider_schema_test.py
@@ -17,6 +17,10 @@
 from unittest import mock
 
 from absl.testing import absltest
+from absl.testing import parameterized
+import openai as openai_sdk
+from openai.resources import chat as chat_resources
+from openai.types import chat
 
 from langextract import exceptions
 from langextract import factory
@@ -661,7 +665,10 @@ class ApplyOutputSchemaTest(absltest.TestCase):
       mock_client_cls.return_value = mock_client
       mock_response = mock.Mock()
       mock_response.choices = [
-          mock.Mock(message=mock.Mock(content='{"extractions": []}'))
+          mock.Mock(
+              message=mock.Mock(content='{"extractions": []}', refusal=None),
+              finish_reason="stop",
+          )
       ]
       mock_client.chat.completions.create.return_value = mock_response
 
@@ -738,6 +745,236 @@ class ApplyOutputSchemaTest(absltest.TestCase):
           exceptions.InferenceConfigError, "already has a schema"
       ):
         model.apply_output_schema(self.output_schema)
+
+
+class OpenAINoContentResponseTest(parameterized.TestCase):
+  """Responses without content must raise, not report empty success (#491)."""
+
+  def setUp(self):
+    super().setUp()
+    mock_client_cls = self.enter_context(
+        mock.patch.object(openai_sdk, "OpenAI", autospec=True)
+    )
+    mock_client = mock_client_cls.return_value
+    mock_client.chat = chat_resources.Chat(mock_client)
+    self.mock_create = self.enter_context(
+        mock.patch.object(chat_resources.Completions, "create", autospec=True)
+    )
+    self.model = openai.OpenAILanguageModel(
+        model_id="gpt-4o", api_key="test_key"
+    )
+
+  def test_content_returns_scored_output(self):
+    self.mock_create.return_value.choices = [
+        mock.Mock(
+            message=mock.Mock(content='{"ok": 1}', refusal=None),
+            finish_reason="stop",
+        )
+    ]
+
+    result = self.model._process_single_prompt("prompt", {})
+
+    self.assertEqual(result.output, '{"ok": 1}')
+    self.assertEqual(result.score, 1.0)
+
+  def test_refusal_raises_with_refusal_message(self):
+    self.mock_create.return_value.choices = [
+        mock.Mock(
+            message=mock.Mock(content=None, refusal="I can't help with that."),
+            finish_reason="stop",
+        )
+    ]
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        "OpenAI refused the request: I can't help with that.",
+    ) as cm:
+      self.model._process_single_prompt("prompt", {})
+
+    self.assertEqual(cm.exception.provider, "OpenAI")
+
+  def test_refusal_with_content_still_raises(self):
+    self.mock_create.return_value.choices = [
+        mock.Mock(
+            message=mock.Mock(content="partial", refusal="Request refused"),
+            finish_reason="stop",
+        )
+    ]
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        "OpenAI refused the request: Request refused",
+    ):
+      self.model._process_single_prompt("prompt", {})
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="none_content_filter",
+          content=None,
+          finish_reason="content_filter",
+      ),
+      dict(
+          testcase_name="empty_content_filter",
+          content="",
+          finish_reason="content_filter",
+      ),
+      dict(
+          testcase_name="none_tool_call",
+          content=None,
+          finish_reason="tool_calls",
+      ),
+      dict(
+          testcase_name="empty_tool_call",
+          content="",
+          finish_reason="tool_calls",
+      ),
+      dict(
+          testcase_name="none_unknown_finish_reason",
+          content=None,
+          finish_reason="future_reason",
+      ),
+      dict(
+          testcase_name="empty_unknown_finish_reason",
+          content="",
+          finish_reason="future_reason",
+      ),
+  )
+  def test_missing_content_raises_with_finish_reason(
+      self, content, finish_reason
+  ):
+    self.mock_create.return_value.choices = [
+        mock.Mock(
+            message=mock.Mock(content=content, refusal=None),
+            finish_reason=finish_reason,
+        )
+    ]
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        rf"no message content \(finish_reason={finish_reason}\)",
+    ):
+      self.model._process_single_prompt("prompt", {})
+
+  @parameterized.named_parameters(
+      dict(testcase_name="none_content", content=None),
+      dict(testcase_name="empty_content", content=""),
+  )
+  def test_exhausted_budget_raises_with_hint(self, content):
+    self.mock_create.return_value.choices = [
+        mock.Mock(
+            message=mock.Mock(content=content, refusal=None),
+            finish_reason="length",
+        )
+    ]
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        r"finish_reason=length.*max_output_tokens",
+    ):
+      self.model._process_single_prompt("prompt", {})
+
+  def test_empty_content_with_normal_stop_passes_through(self):
+    self.mock_create.return_value.choices = [
+        mock.Mock(
+            message=mock.Mock(content="", refusal=None),
+            finish_reason="stop",
+        )
+    ]
+
+    result = self.model._process_single_prompt("prompt", {})
+
+    self.assertEqual(result.output, "")
+
+  def test_no_choices_raises(self):
+    self.mock_create.return_value.choices = []
+
+    with self.assertRaisesRegex(exceptions.InferenceRuntimeError, "no choices"):
+      self.model._process_single_prompt("prompt", {})
+
+  def test_no_content_error_is_not_rewrapped(self):
+    self.mock_create.return_value.choices = [
+        mock.Mock(
+            message=mock.Mock(content=None, refusal=None),
+            finish_reason=None,
+        )
+    ]
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError, r"^OpenAI response contained"
+    ):
+      self.model._process_single_prompt("prompt", {})
+
+  def test_parallel_infer_preserves_no_content_error(self):
+    self.mock_create.return_value.choices = [
+        mock.Mock(
+            message=mock.Mock(content=None, refusal=None),
+            finish_reason="content_filter",
+        )
+    ]
+    model = openai.OpenAILanguageModel(
+        model_id="gpt-4o", api_key="test_key", max_workers=2
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        r"^OpenAI response contained no message content",
+    ) as cm:
+      list(model.infer(["prompt one", "prompt two"]))
+
+    self.assertEqual(cm.exception.provider, "OpenAI")
+
+  @parameterized.named_parameters(
+      dict(testcase_name="sequential", max_workers=1),
+      dict(testcase_name="parallel", max_workers=2),
+  )
+  def test_extract_propagates_refusal(self, max_workers):
+    self.mock_create.return_value = chat.ChatCompletion(
+        id="test-completion",
+        created=0,
+        model="gpt-4o",
+        object="chat.completion",
+        choices=[
+            chat.chat_completion.Choice(
+                index=0,
+                finish_reason="stop",
+                message=chat.ChatCompletionMessage(
+                    role="assistant", content=None, refusal="Request refused"
+                ),
+            )
+        ],
+    )
+    examples = [
+        data.ExampleData(
+            text="Alice lives in Paris.",
+            extractions=[
+                data.Extraction(
+                    extraction_class="person", extraction_text="Alice"
+                )
+            ],
+        )
+    ]
+    model = openai.OpenAILanguageModel(
+        model_id="gpt-4o", api_key="test_key", max_workers=max_workers
+    )
+
+    with self.assertRaisesRegex(
+        exceptions.InferenceRuntimeError,
+        r"^OpenAI refused the request: Request refused",
+    ) as cm:
+      lx.extract(
+          text_or_documents="Alice lives in Paris. Bob lives in London.",
+          prompt_description="Extract person names.",
+          examples=examples,
+          model=model,
+          use_schema_constraints=False,
+          max_char_buffer=24,
+          batch_length=2,
+          max_workers=max_workers,
+          show_progress=False,
+      )
+
+    self.assertEqual(cm.exception.provider, "OpenAI")
+    self.assertEqual(self.mock_create.call_count, max_workers)
 
 
 if __name__ == "__main__":

--- a/tests/test_kwargs_passthrough.py
+++ b/tests/test_kwargs_passthrough.py
@@ -33,7 +33,11 @@ def _configure_openai_mock(mock_openai_class, content='{"result": "test"}'):
   mock_client = mock.Mock()
   mock_openai_class.return_value = mock_client
   mock_response = mock.Mock()
-  mock_response.choices = [mock.Mock(message=mock.Mock(content=content))]
+  mock_response.choices = [
+      mock.Mock(
+          message=mock.Mock(content=content, refusal=None), finish_reason='stop'
+      )
+  ]
   mock_client.chat.completions.create.return_value = mock_response
   return mock_client
 


### PR DESCRIPTION
## Summary

Fixes #491. Fixes #508.

Gemini and OpenAI realtime inference now raise `InferenceRuntimeError` when blocking, refusal, or an exhausted output budget produces no text. Provider-local adapters use typed SDK responses and preserve diagnostics through retries and parallel inference.

Empty-string completions that stop normally retain existing resolver handling. Batch changes are out of scope; Gemini batch is tracked by #527.

Builds on #496, #507 and #516; thanks to @malai001, @mittalpk and @uuzzrm.

## Tests

- `tox -p auto -e py310,py311,py313,format,lint-src,lint-tests`: 828 unit tests pass per Python version; formatting and lint pass.
- `pytest tests/gemini_retry_test.py tests/provider_schema_test.py tests/test_kwargs_passthrough.py tests/inference_test.py -q`: 214 tests pass with minimum SDK versions.
- Live API and integration checks run in PR CI.
