### PR TITLE
Surface blocked Gemini batch items instead of returning empty output

### DIFF
--- a/langextract/providers/gemini_batch.py
+++ b/langextract/providers/gemini_batch.py
@@ -556,6 +556,44 @@ def _extract_text(resp: _TextResponse | dict[str, Any] | None) -> str | None:
   return text if isinstance(text, str) else None
 
 
+def _no_text_block_diagnostic(resp: Any) -> str | None:
+  """Return a block diagnostic when a textless response was refused.
+
+  A safety-blocked or refused batch item has no extractable text, so it is
+  indistinguishable from a genuinely empty generation by ``_extract_text``
+  alone. Vertex batch output uses REST-style (camelCase) keys, while inline
+  responses may arrive snake_case; accept both.
+
+  Args:
+    resp: The parsed ``response`` object from a batch output JSONL line.
+
+  Returns:
+    A human-readable reason when the response itself signals a block/refusal,
+    or None when it simply lacks text without a diagnostic.
+  """
+  if not isinstance(resp, dict):
+    return None
+
+  prompt_feedback = resp.get("promptFeedback") or resp.get("prompt_feedback")
+  if isinstance(prompt_feedback, dict):
+    block_reason = prompt_feedback.get("blockReason") or prompt_feedback.get(
+        "block_reason"
+    )
+    if block_reason:
+      return f"block_reason={block_reason}"
+
+  candidates = resp.get("candidates")
+  if isinstance(candidates, list) and candidates:
+    candidate = candidates[0]
+    if isinstance(candidate, dict):
+      finish_reason = candidate.get("finishReason") or candidate.get(
+          "finish_reason"
+      )
+      if finish_reason and finish_reason != "STOP":
+        return f"finish_reason={finish_reason}"
+  return None
+
+
 def _poll_completion(
     client: genai.Client, job: genai.types.BatchJob, cfg: BatchConfig
 ) -> genai.types.BatchJob:
@@ -620,6 +658,16 @@ def _parse_batch_line(
 
   resp = obj.get("response", {})
   text = _extract_text(resp) or ""
+
+  if not text and not cfg.ignore_item_errors:
+    # A safety-blocked or refused item has no text but still reports a block
+    # reason in the response. Surface that instead of silently treating the
+    # item as a successful empty extraction.
+    diagnostic = _no_text_block_diagnostic(resp)
+    if diagnostic:
+      raise exceptions.InferenceRuntimeError(
+          f"Batch item blocked or refused: {diagnostic}"
+      )
 
   key = obj.get("key", "")
   try:

--- a/langextract/providers/gemini_batch.py
+++ b/langextract/providers/gemini_batch.py
@@ -556,6 +556,13 @@ def _extract_text(resp: _TextResponse | dict[str, Any] | None) -> str | None:
   return text if isinstance(text, str) else None
 
 
+_UNSPECIFIED_REASONS = frozenset((
+    "FINISH_REASON_UNSPECIFIED",
+    "BLOCKED_REASON_UNSPECIFIED",
+    "BLOCK_REASON_UNSPECIFIED",
+))
+
+
 def _no_text_block_diagnostic(resp: Any) -> str | None:
   """Return a block diagnostic when a textless response was refused.
 
@@ -579,7 +586,8 @@ def _no_text_block_diagnostic(resp: Any) -> str | None:
     block_reason = prompt_feedback.get("blockReason") or prompt_feedback.get(
         "block_reason"
     )
-    if block_reason:
+    # The zero enum value means the service reported no reason, not a block.
+    if block_reason and block_reason not in _UNSPECIFIED_REASONS:
       return f"block_reason={block_reason}"
 
   candidates = resp.get("candidates")
@@ -589,8 +597,9 @@ def _no_text_block_diagnostic(resp: Any) -> str | None:
       finish_reason = candidate.get("finishReason") or candidate.get(
           "finish_reason"
       )
-      if finish_reason and finish_reason != "STOP":
-        return f"finish_reason={finish_reason}"
+      if finish_reason and finish_reason not in _UNSPECIFIED_REASONS:
+        if finish_reason != "STOP":
+          return f"finish_reason={finish_reason}"
   return None
 
 
@@ -666,7 +675,7 @@ def _parse_batch_line(
     diagnostic = _no_text_block_diagnostic(resp)
     if diagnostic:
       raise exceptions.InferenceRuntimeError(
-          f"Batch item blocked or refused: {diagnostic}"
+          f"Batch item blocked or refused: {diagnostic}", provider="Gemini"
       )
 
   key = obj.get("key", "")

--- a/tests/test_gemini_batch_api.py
+++ b/tests/test_gemini_batch_api.py
@@ -665,6 +665,21 @@ class BatchParseBlockedItemTest(absltest.TestCase):
     }
     self.assertEqual(self._parse(response, self.cfg), {0: ""})
 
+  def test_unspecified_reasons_are_not_treated_as_blocked(self):
+    # The zero enum value means the service set no reason; it is not a block.
+    responses = (
+        {
+            "candidates": [{
+                "finishReason": "FINISH_REASON_UNSPECIFIED",
+                "content": {"role": "model", "parts": []},
+            }]
+        },
+        {"promptFeedback": {"blockReason": "BLOCKED_REASON_UNSPECIFIED"}},
+        {"promptFeedback": {"blockReason": "BLOCK_REASON_UNSPECIFIED"}},
+    )
+    for response in responses:
+      self.assertEqual(self._parse(response, self.cfg), {0: ""})
+
 
 class BatchConfigValidationTest(parameterized.TestCase):
   """Test BatchConfig validation logic."""

--- a/tests/test_gemini_batch_api.py
+++ b/tests/test_gemini_batch_api.py
@@ -25,6 +25,7 @@ from absl.testing import parameterized
 from google import genai
 from google.api_core import exceptions
 
+from langextract.core import exceptions as core_exceptions
 from langextract.providers import gemini
 from langextract.providers import gemini_batch as gb
 from langextract.providers import schemas
@@ -565,6 +566,104 @@ class TestGeminiBatchAPI(absltest.TestCase):
 
     with self.assertRaisesRegex(Exception, "Batch item error"):
       list(model.infer(["test"]))
+
+  @mock.patch.object(genai, "Client", autospec=True)
+  def test_blocked_batch_item_raises(self, mock_client_cls):
+    """A safety-blocked item must raise, not report empty success."""
+    mock_client = mock_client_cls.return_value
+    mock_client.vertexai = True
+
+    output_blob = mock.create_autospec(gb.storage.Blob, instance=True)
+    output_blob.name = f"output{gb._EXT_JSONL}"
+    output_blob.open.return_value.__enter__.return_value = io.StringIO(
+        json.dumps({
+            "key": f"{gb._KEY_IDX}0",
+            "response": {"promptFeedback": {"blockReason": "SAFETY"}},
+        })
+    )
+    self.mock_bucket.list_blobs.return_value = [output_blob]
+
+    job = create_mock_batch_job()
+    mock_client.batches.create.return_value = job
+    mock_client.batches.get.return_value = job
+
+    model = gemini.GeminiLanguageModel(
+        model_id="gemini-3.5-flash",
+        vertexai=True,
+        project="p",
+        location="l",
+        batch={
+            "enabled": True,
+            "threshold": 1,
+            "enable_caching": False,
+            "retention_days": None,
+        },
+    )
+
+    with self.assertRaisesRegex(
+        core_exceptions.InferenceRuntimeError,
+        "Batch item blocked or refused",
+    ):
+      list(model.infer(["test"]))
+
+
+class BatchParseBlockedItemTest(absltest.TestCase):
+  """Blocked/refused batch items raise instead of becoming empty successes.
+
+  Regression test for issue #527. A safety-blocked or refused item has no
+  text content but still reports a block/finish reason in the response; it
+  used to be written into outputs as '' (an empty success).
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.cfg = gb.BatchConfig(
+        enabled=True, enable_caching=False, retention_days=None
+    )
+    self.ignore_cfg = gb.BatchConfig(
+        enabled=True,
+        enable_caching=False,
+        retention_days=None,
+        ignore_item_errors=True,
+    )
+
+  def _parse(self, response, cfg):
+    outputs = {}
+    line = json.dumps({"key": f"{gb._KEY_IDX}0", "response": response})
+    gb._parse_batch_line(line, outputs, cfg)
+    return outputs
+
+  def test_blocked_candidate_raises(self):
+    response = {
+        "candidates": [{
+            "finishReason": "SAFETY",
+            "content": {"role": "model", "parts": []},
+        }]
+    }
+    with self.assertRaisesRegex(
+        core_exceptions.InferenceRuntimeError, "finish_reason=SAFETY"
+    ):
+      self._parse(response, self.cfg)
+
+  def test_blocked_prompt_raises(self):
+    response = {"promptFeedback": {"blockReason": "SAFETY"}}
+    with self.assertRaisesRegex(
+        core_exceptions.InferenceRuntimeError, "block_reason=SAFETY"
+    ):
+      self._parse(response, self.cfg)
+
+  def test_blocked_item_ignored_when_configured(self):
+    response = {"promptFeedback": {"blockReason": "SAFETY"}}
+    self.assertEqual(self._parse(response, self.ignore_cfg), {0: ""})
+
+  def test_genuinely_empty_response_without_diagnostic_stays_empty(self):
+    response = {
+        "candidates": [{
+            "finishReason": "STOP",
+            "content": {"role": "model", "parts": []},
+        }]
+    }
+    self.assertEqual(self._parse(response, self.cfg), {0: ""})
 
 
 class BatchConfigValidationTest(parameterized.TestCase):


### PR DESCRIPTION
# Description

Bug fix. Fixes #527.

- Report blocked or failed textless Gemini batch items instead of empty success.
- Recognize Vertex's top-level status error messages.
- Preserve explicit ignore mode and recheck ambiguous empty cache entries in
  strict mode.
- Cover response diagnostics, output ordering, and cache behavior.

Strict mode rechecks empty cached results because older cache entries cannot
distinguish a genuine empty completion from an ignored failure. Nonempty cache
hits and explicit ignore mode are unchanged.

# How Has This Been Tested?

- Regression tests fail on unpatched main and pass with the fix.
- `python -m pytest tests/test_gemini_batch_api.py -q`
- `python -m tox -e format,lint-src,lint-tests`
- `python -m tox -p 3 -e py310,py311,py312 --parallel-no-spinner`
- Built and installed wheel/source distributions in fresh environments.

Python 3.10, 3.11, and 3.12: 867 tests passed on each version.
Batch suite: 55 passed. Formatting and both lint checks passed.

Live Vertex/GCS validation passed with gemini-2.5-flash: two grounded documents,
schema-constrained responses, output-key preservation, and cache-only replay
with new submission forbidden. Blocked-response cases use deterministic tests.
The default gemini-3.5-flash was unavailable at the tested regional endpoint;
repository defaults were not changed.

# Checklist

- [x] Added regression tests and preserved existing behavior outside the fix.
- [x] Documented the strict-mode cache tradeoff.
- [x] Passed formatting and source/test lint checks.
